### PR TITLE
Lab5: zły padding w oryginalnym pliku

### DIFF
--- a/lab5/Lab5.ipynb
+++ b/lab5/Lab5.ipynb
@@ -1555,7 +1555,7 @@
     "def preprocess_function(examples):\n",
     "    result = tokenizer(examples[\"text\"], truncation=True, max_length=256)\n",
     "    targets = tokenizer(\n",
-    "        examples[\"labels\"], truncation=True, max_length=32, padding=True\n",
+    "        examples[\"labels\"], truncation=True, max_length=32, padding=\"max_length\"\n",
     "    )\n",
     "    input_ids = [\n",
     "        [(l if l != tokenizer.pad_token_id else -100) for l in e]\n",


### PR DESCRIPTION
`padding=True` działa dla poquadu, ale wszystko zależy od długości tekstów w danym batchu. 

Przy dużej ilości szczęścia (a tak właśnie jest w przypadku poquadu) nic się nie dzieje. 
W przypadku mniejszej ilości szczęścia (np. w przypadku squadu) zdarzają się batche, gdzie longest != max_length, co kończy się tym, że model nie jest w stanie tworzyć tensorów do treningu.

fyi @apohllo 