### PR TITLE
Fix buga z ostatniego PR, Literówki w lab1 - zadanie 6,9,10

### DIFF
--- a/lab1/lab_1.ipynb
+++ b/lab1/lab_1.ipynb
@@ -2155,7 +2155,7 @@
             "\n",
             "Wypisz znalezione optymalne wartości siły regularyzacji `.alpha_` dla obu modeli, zaokrąglone do 4 miejsca po przecinku dla czytelności.\n",
             "\n",
-            "Wartości błędu przypisz do zmiennych: `reg_train_rmse`, `reg_test_rmse`, `lass_train_rmse`, `lasso_test_rmse`.\n",
+            "Wartości błędu przypisz do zmiennych: `ridge_train_rmse`, `ridge_test_rmse`, `lasso_train_rmse`, `lasso_test_rmse`.\n",
             "Wartości $\\alpha$ przypisz do zmiennych `reg_ridge_alpha` oraz `reg_lasso_alpha`.\n",
             "\n",
             "---\n",

--- a/lab1/lab_1.ipynb
+++ b/lab1/lab_1.ipynb
@@ -11,8 +11,7 @@
          },
          "source": [
             "# Regresja liniowa i logistyczna"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -50,8 +49,7 @@
             "Na pierwszych zajęciach możesz korzystać ze środowiska Google Colab i zdalnego środowiska obliczeniowego. Jeżeli interesuje Cię skonfigurowanie Pythona  na własnym komputerze, to niezbędne informacje są podane w sekcji \"Konfiguracja własnego komputera\".\n",
             "\n",
             "**Uwaga:** niektóre zadania zamiast kodu wymagają podania pisemnej odpowiedzi w miejscu oznaczonym `// skomentuj tutaj`."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -68,8 +66,7 @@
             "* [seaborn](https://seaborn.pydata.org/) - kompleksowe narzędzie do wizualizacji danych jako takich. Pozwala na stworzenie bardzo szerokiej gamy wykresów w zależności od potrzeb.\n",
             "\n",
             "Zostały tutaj pominięte pewne standardowe biblioteki jak np. `os` czy `matplotlib`."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -82,8 +79,7 @@
             "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/apohllo/sztuczna-inteligencja/blob/master/lab1/lab_1.ipynb)\n",
             "\n",
             "Jeżeli pracujesz na Google Colab, zacznij od przeniesienia dwóch plików CSV, które zostały dołączone do laboratorium ([ames_data.csv](ames_data.csv) oraz [bank_marketing_data.csv](bank_marketing_data.csv)), do folderu `/content`. Nie musisz ich umieszczać w `/content/sample_data` - ważne, aby znalazły się w `/content`. Jeżeli pracujesz lokalnie, to wystarczy, że pliki te będą obok tego notebooka.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -92,8 +88,7 @@
             "## Konfiguracja własnego komputera\n",
             "\n",
             "Jeżeli korzystasz z własnego komputera, to musisz zainstalować trochę więcej bibliotek (Google Colab ma je już zainstalowane). Najlepiej używać Pythona 3.9 lub nowszej wersji. Laboratorium było testowane z wersją 3.9."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -112,8 +107,7 @@
             "   * `poetry install --no-root`\n",
             "3. Po konfiguracji możemy uruchamiać Jupyter Lab poleceniem:\n",
             "   * `poetry run jupyter lab`\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -122,8 +116,7 @@
             "### Anaconda\n",
             "\n",
             "Jeżeli korzystasz z Anacondy (możesz uruchomić w terminalu):"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -146,8 +139,7 @@
             "### venv\n",
             "\n",
             "Jeżeli używasz zwykłego venv'a (**zdecydowanie niezalecane, szczególnie na Windowsie**):"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -168,8 +160,7 @@
          "metadata": {},
          "source": [
             "W przypadku własnego komputera, jeżeli instalowałeś z terminala, pamiętaj, aby zarejestrować aktualne środowisko wirtualne jako kernel (środowisko uruchomieniowe) dla Jupyter Notebooka. Wybierz go jako używany kernel w menu na górze notebooka (nazwa jak w komendzie poniżej)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -190,8 +181,7 @@
          "metadata": {},
          "source": [
             "## Zbiór danych do regresji"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -204,8 +194,7 @@
             "- California housing - zbyt prosty (tylko kilka zmiennych numerycznych), użyty np. w książce \"Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow\" A. Geron ([opis](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html))\n",
             "\n",
             "Autor zbioru to Dean De Cock, a zbiór został opisany oryginalnie w [tym artykule](https://jse.amstat.org/v19n3/decock.pdf). "
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -228,8 +217,7 @@
          "metadata": {},
          "source": [
             "### Ładowanie danych tabelarycznych"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -239,8 +227,7 @@
             "Pliki [ames_data.csv](ames_data.csv) oraz [bank_marketing_data.csv](bank_marketing_data.csv) to dwa zbiory danych, niezależne od siebie. Pierwszy jest wykorzystywany w pierwszej części laboratorium (regresji liniowej), natomiast drugi przyda się przy regresji logistycznej (klasyfikacji). Jego celem jest przewidywanie wartości domu.\n",
             "\n",
             "Wczytajmy dane `ames_data.csv` do zmiennej `df` (takiej nazwy często się używa, żeby oznaczyć obiekt `DataFrame` - zaawansowanej tablicy, dostarczonej nam przez bibliotekę `pandas`)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -264,8 +251,7 @@
          "metadata": {},
          "source": [
             "Zobaczmy jakie dane znajdują się w naszej tabeli. Wykorzystajmy do tego metodę `info()`."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -286,16 +272,14 @@
          "metadata": {},
          "source": [
             "Mamy naprawdę dużo cech! Ich szczegółowy opis znajdziesz w dołączonym do laboratorium pliku [ames_description.txt](ames_description.txt)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
          "metadata": {},
          "source": [
             "### Wstępna analiza danych"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -304,8 +288,7 @@
             "Zawsze, zanim zaczniesz robić jakąkolwiek predykcję czy analizę danych, dobrze jest zapoznać się z nimi, z ich kodowaniem i znaczeniem. Kolejnym istotnym aspektem jest typ danych. Nie każdy klasyfikator nadaje się do każdego typu.\n",
             "\n",
             "Wyświetlmy teraz kilka przykładowych rekordów z początku pliku, korzystając z metody `head()`."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -326,8 +309,7 @@
          "metadata": {},
          "source": [
             "Jeżeli potrzebujesz szybko stwierdzić, ile dane zawierają rekordów i kolumn, pomocna jest opcja `shape`:"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -354,16 +336,14 @@
          },
          "source": [
             "## Eksploracja danych, czyszczenie danych i inżynieria cech"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
          "metadata": {},
          "source": [
             "### Usunięcie niepotrzebnych kolumn"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -376,8 +356,7 @@
             "Formalnie czynimy założenie, że rekordy w naszych danych (próbki / wiersze, poszczególne domy w przypadku tego zbioru) są **niezależne i równomiernie rozłożone** (ang. **independent and identically distributed - i.i.d.**). Innymi słowy, kolejność w danych nie ma znaczenia, bo zbieraliśmy dane taką samą metodą i w identycznych warunkach. Jest to bardzo typowe w ML.\n",
             "\n",
             "**PID** jest po prostu numerem identyfikacyjnym danej nieruchomości w systemie informatycznym, a więc też możemy to usunąć."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -398,16 +377,14 @@
          "metadata": {},
          "source": [
             "### Usunięcie słabo reprezentowanych dzielnic"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
          "metadata": {},
          "source": [
             "Dzielnice *GrnHill* oraz *Landmrk* obejmują w sumie zaledwie 3 domy."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -428,16 +405,14 @@
          "metadata": {},
          "source": [
             "### Usunięcie obserwacji odstających (outliers)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
          "metadata": {},
          "source": [
             "Usuniemy budynki, które mają powyżej 4000 stóp kwadratowych (ok. 370 metrów kwadratowych) powierzchni. Możemy zobaczyć je na wykresie poniżej. "
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -464,8 +439,7 @@
             "Jak widać na wykresie, jest dosłownie kilka domów o tej powierzhcni. Takie skrajne przypadki raczej nas nie interesują - a na pewno stanowią problem dla tak prostego modelu jak regresja liniowa. Nie chcemy też, żeby nasz model uczył się takich anomalii, więc lepiej je usunąć.\n",
             "\n",
             "Tutaj robimy to ręcznie, ale istnieją też algorytmy do detekcji i usuwania obserwacji odstających."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -480,8 +454,7 @@
          },
          "source": [
             "### Zadanie 1 (0.25 punktu)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -498,8 +471,7 @@
             "Usuń rekordy nieruchomości o powierzchni (**GrLivArea**) ponad (ostra nierówność) 4 tys. stóp kwadratowych.\n",
             "\n",
             "Podpowiedź: w Pandas korzysta się z `.loc[]` do filtrowania wierszy i kolumn. Pierwszy indeks oznacza, które wiersze zostawić, a drugi indeks, które kolumny wybrać. Jeżeli chcemy zostawić wszystko (np. nie usuwać żadnych kolumn), to zadziała standardowy Pythonowy `:`, jak przy indeksowaniu list."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -554,8 +526,7 @@
          },
          "source": [
             "Zobaczmy jak teraz wygląda ten sam wykres."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -591,8 +562,7 @@
          },
          "source": [
             "### Transformacja logarytmiczna zmiennej zależnej"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -605,8 +575,7 @@
          },
          "source": [
             "Zawsze warto też przyjrzeć się rozkładowi zmiennej docelowej, żeby poznać jej typ i skalę. Jak widać poniżej, rozkład jest dość skośny, co ma sens - mało jest bardzo drogich domów."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -661,8 +630,7 @@
             "Rozkład normalny jest zwykle korzystniejszy dla tworzenia modeli, bo daje sensowną \"wartość środkową\" do przewidywania, a także penalizuje tak samo błędy niezależnie od ich znaku (zaniżona i zawyżona predykcja). Dokonamy dlatego **transformacji logarytmicznej (log transform)**, czyli zlogarytmujemy zmienną docelową (zależną). Dla stabilności numerycznej używa się zwykle `np.log1p`, a nie `np.log` (tutaj [wyjaśnienie](https://stackoverflow.com/questions/49538185/purpose-of-numpy-log1p)).\n",
             "\n",
             "Dodatkowa korzyść z takiej transformacji jest taka, że regresja liniowa przewiduje dowolne wartości rzeczywiste. Po przekształceniu logarytmicznym jest to całkowicie ok, natomiast w oryginalnej przestrzeni trzeba by wymusić przewidywanie tylko wartości pozytywnych (negatywne ceny są bez sensu). Da się to zrobić, ale zwiększa to koszt obliczeniowy. Operowanie na tzw. log-price jest bardzo częste w finansach."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -677,8 +645,7 @@
          },
          "source": [
             "### Zadanie 2 (0.25 punktu) "
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -693,8 +660,7 @@
          },
          "source": [
             "Przekształć zmienną **SalePrice** za pomocą funkcji logarytmicznej `np.log1p`."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -748,8 +714,7 @@
          },
          "source": [
             "Sprawdźmy teraz jak rozkład **SalePrice** wygląda po transformacji:"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -783,8 +748,7 @@
          },
          "source": [
             "### Uzupełnianie wartości brakujących"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -797,8 +761,7 @@
          },
          "source": [
             "Sprawdźmy też wartości brakujące. Są zmienne, które mają poniżej 10% wartości - takie zmienne dla modeli regresji liniowej są po prostu bezużyteczne, ponieważ brakujących wartości nie można wprost zamodelować. Znacząca liczba cech ma jednak co najmniej 10% braków. Z nich będziemy jednak starali się zrobić użytek."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -839,8 +802,7 @@
             "Można więc zastosować odpowiednią wiedzę i przyjąć wartości domyślne. Przykładowo, brak informacji o powierzchni piwnicy możemy uznać po prostu za brak piwnicy i wpisać tam odpowiednią wartość. W przypadku niektórych zmiennych może doprowadzić to do stworzenia nowej wartości, która implicite będzie reprezentować wartość brakującą.\n",
             "\n",
             "Znaczna część poniższej analizy została zainspirowana [tym notebookiem na Kaggle](https://www.kaggle.com/code/juliencs/a-study-on-regression-applied-to-the-ames-dataset)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -982,8 +944,7 @@
          },
          "source": [
             "W przypadku wykonywania tego typu zmian - o ile istnieje taka możliwość - warto rozważyć różne interpretacje brakujących wartości. Może okazać się, że przyjęte przez nas założenia są błędne i prowadzą do pogorszenia działania modelu. Dlatego warto porównać jakoś predykcji z danymi uzupełnionymi oraz z danymi, w których kolumna z brakującymi wartościami jest po prostu usuwana."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -998,8 +959,7 @@
          },
          "source": [
             "### Zadanie 3 (0.5 punktu)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1021,8 +981,7 @@
             "\n",
             "W praktyce niestety zwykle nie jest tak łatwo, że mamy dokumentację i ten krok zajmuje kilka godzin (lub dni) konsultacji z różnymi osobami w firmie :) \n",
             "Czasami w ogóle nie da się ustalić jaka wartość byłaby sensowna, ponieważ nie mamy żadnego dostępu do osób odpowiedzialnych za przygotowanie wykorzystywanego zbioru danych."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1079,8 +1038,7 @@
          },
          "source": [
             "### Dane kategoryczne"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1093,8 +1051,7 @@
             "Szczególnym przypadkiem są zmienne binarne (*boolean*). Jest to u nas kolumna **CentralAir** (Central Air Conditioning). Z opisu w pliku [ames_description.txt](ames_description.txt) wiemy, że przyjmuje ona dokładnie dwie wartości kategoryczne: *No* oraz *Yes*. W takiej sytuacji wolno zakodować te wartości numerycznie jako 0 i 1. Stwierdzasz tym samym, że klimatyzacja albo jest, albo jej nie ma.\n",
             "\n",
             "Sytuacją podobną, chociaż mniej oczywistą, może być zmienna **Street**, opisująca typ drogi wiodącej do nieruchomości. Jeśli znowu spojrzymy do opisu danych, to można zauważyć, że ta zmienna może przyjmować tylko dwie różne wartości - *Grvl* i *Pave*. I tu też możemy sobie pozwolić na zakodowanie tych wartości jako 0 i 1. Stwierdzamy wtedy, że droga jest *utwardzona* (Pave) dla wartości 1. Oczywiście równie dobrze można by zakodować to odwrotnie i stwierdzić, że droga jest *nieutwardzona* (Grvl) gdy wartość wynosi 1."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1103,8 +1060,7 @@
             "W Pandas typy numeryczne są oparte o NumPy (np. `np.int64`), a zmienne kategoryczne, napisy itp. są typu `object` (typ `Categorical` istnieje od pewnego czasu, ale nie jest jeszcze zbyt dobrze wspierany).\n",
             "\n",
             "Zmienne **MSSubClass** oraz **MoSold** są kategoryczne (tak wynika z informacji zawartej w pliku [ames_description.txt](ames_description.txt)), a są w naszych danych wprost liczbami. Przekształćmy je zatem do poprawnego typu."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1122,7 +1078,8 @@
          },
          "outputs": [],
          "source": [
-            "pd.set_option(\"future.no_silent_downcasting\", True)",
+            "# wyłączenie przestarzałych zachowań\n",
+            "pd.set_option(\"future.no_silent_downcasting\", True)\n",
             "df = df.replace(\n",
             "    {\n",
             "        \"MSSubClass\": {\n",
@@ -1158,31 +1115,6 @@
             "            12: \"Dec\",\n",
             "        },\n",
             "    }\n",
-            ")",
-            "\n",
-            "df = df.astype(\n",
-            "    {\n",
-            "        \"Alley\": np.int64,\n",
-            "        \"BsmtCond\": np.int64,\n",
-            "        \"BsmtExposure\": np.int64,\n",
-            "        \"BsmtFinType1\": np.int64,\n",
-            "        \"BsmtFinType2\": np.int64,\n",
-            "        \"BsmtQual\": np.int64,\n",
-            "        \"ExterCond\": np.int64,\n",
-            "        \"ExterQual\": np.int64,\n",
-            "        \"FireplaceQu\": np.int64,\n",
-            "        \"Functional\": np.int64,\n",
-            "        \"GarageCond\": np.int64,\n",
-            "        \"GarageQual\": np.int64,\n",
-            "        \"HeatingQC\": np.int64,\n",
-            "        \"KitchenQual\": np.int64,\n",
-            "        \"LandSlope\": np.int64,\n",
-            "        \"LotShape\": np.int64,\n",
-            "        \"PavedDrive\": np.int64,\n",
-            "        \"PoolQC\": np.int64,\n",
-            "        \"Street\": np.int64,\n",
-            "        \"Utilities\": np.int64,\n",
-            "    }\n",
             ")"
          ]
       },
@@ -1207,8 +1139,7 @@
             "* *Ex* (Excellent)\n",
             "\n",
             "Do następujących wartości możemy dopasować pewną skalę punktową, bo są one naturalnie uporządkowane."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1279,6 +1210,45 @@
       },
       {
          "cell_type": "markdown",
+         "metadata": {},
+         "source": [
+            "Jako że wymusiliśmy wyłączenie zachowania, które zostanie usunięte w przyszłej wersji Pandas, to musimy ręczne ustawić typy kolumn."
+         ]
+      },
+      {
+         "cell_type": "code",
+         "execution_count": null,
+         "metadata": {},
+         "outputs": [],
+         "source": [
+            "df = df.astype(\n",
+            "    {\n",
+            "        \"Alley\": np.int64,\n",
+            "        \"BsmtCond\": np.int64,\n",
+            "        \"BsmtExposure\": np.int64,\n",
+            "        \"BsmtFinType1\": np.int64,\n",
+            "        \"BsmtFinType2\": np.int64,\n",
+            "        \"BsmtQual\": np.int64,\n",
+            "        \"ExterCond\": np.int64,\n",
+            "        \"ExterQual\": np.int64,\n",
+            "        \"FireplaceQu\": np.int64,\n",
+            "        \"Functional\": np.int64,\n",
+            "        \"GarageCond\": np.int64,\n",
+            "        \"GarageQual\": np.int64,\n",
+            "        \"HeatingQC\": np.int64,\n",
+            "        \"KitchenQual\": np.int64,\n",
+            "        \"LandSlope\": np.int64,\n",
+            "        \"LotShape\": np.int64,\n",
+            "        \"PavedDrive\": np.int64,\n",
+            "        \"PoolQC\": np.int64,\n",
+            "        \"Street\": np.int64,\n",
+            "        \"Utilities\": np.int64,\n",
+            "    }\n",
+            ")"
+         ]
+      },
+      {
+         "cell_type": "markdown",
          "metadata": {
             "editable": true,
             "slideshow": {
@@ -1288,8 +1258,7 @@
          },
          "source": [
             "## Przygotowanie danych do uczenia\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1322,8 +1291,7 @@
             "---\n",
             "\n",
             "**Uwaga**: w eksperymentach ustalamy na sztywno wartość parametru `random_state`. [Doczytaj](https://scikit-learn.org/stable/glossary.html#term-random_state), dlaczego wykorzystywany jest ten parametr i co się dzieje, gdy jest on równy stałej wartości jak zero."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1363,8 +1331,7 @@
             "- zmienne kategoryczne nieuporządkowane trzeba przetworzyć tak, aby nasz algorym był w stanie je obsłużyć, czyli je zakodować za pomocą **one-hot encoding**,\n",
             "- zmienne numeryczne dalej mogą mieć wartości brakujące, więc trzeba je uzupełnić, inaczej **imputować (impute)**,\n",
             "- zmienne numeryczne trzeba przeskalować do zakresu wartości $[0, 1]$ czyli je **znormalizować (normalization)** przez zastosowanie **min-max scaling**.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1388,8 +1355,7 @@
             "#### Dla zainteresowanych\n",
             "\n",
             "Jeżeli mamy dużo możliwych wartości, czyli zmienną o dużej **kardynalności (cardinality)**, to kolumn powstanie bardzo dużo. Do tego są **rzadkie (sparse)**, więc tracimy dużo pamięci na przechowywanie zer. Istnieją inne kodowania, które zajmują mniej miejsca, a implementuje je biblioteka [Category Encoders](https://contrib.scikit-learn.org/category_encoders/).\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1417,8 +1383,7 @@
             "#### Dla zainteresowanych\n",
             "\n",
             "Popularne algorytmy imputacji danych często są oparte [o algorytm najbliższych sąsiadów, czyli najbardziej podobne punkty](https://scikit-learn.org/stable/modules/impute.html#nearest-neighbors-imputation). Innym podejściem, iteracyjnie imputującym wartości, jest [algorytm MICE](https://www.numpyninja.com/post/mice-algorithm-to-impute-missing-values-in-a-dataset).\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1441,8 +1406,7 @@
             "#### Dla zainteresowanych\n",
             "\n",
             "Porównanie różnych metod skalowania [możesz znaleźć tutaj](https://scikit-learn.org/stable/auto_examples/preprocessing/plot_all_scaling.html). Ciekawą metodą jest np. RobustScaler, który jest podobny do StandardScaler, ale używa mediany i kwartyli zamiast średniej i odchylenia standardowego. Są to tzw. robust statistics, czyli miary odporne na występowanie wartości odstających (outliers)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1468,8 +1432,7 @@
             "**Ważne:** jako, że zaraz skorzystamy z regresji liniowej, do klasy `OneHotEncoder` trzeba przekazać `drop=\"first\"`. Stworzy to 1 zmienną mniej, niż typowy one-hot encoding, np. `pd.get_dummies()`, gwarantując brak **idealnie współliniowych zmiennych (perfectly collinear features)**, co byłby niestabilny numerycznie. Dodatkowo, jako że przekształcamy już po podziale na zbiór treningowy i testowy, to możemy spotkać na zbiorze testowym nieliczne przypadki kategorii, których nie ma w zbiorze treningowym - kodujemy je wtedy po prostu jako wektory zer za pomocą `handle_unknown=\"ignore\"`.\n",
             "\n",
             "Na przykładzie `StandardScaler` (standaryzacja) rozpatrzmy, jak działają poszczególne metody.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1500,8 +1463,7 @@
             "Wydzieliliśmy dane testowe po to, żeby sprawdzać, jak model poradzi sobie z danymi, których do tej pory nigdy nie widział, bo to właśnie takie dane będzie on dostawać w praktyce, po wdrożeniu do realnego systemu. Ta ocena obejmuje też etap preprocessingu, w tym skalowania. Więc jeśli etap preprocessingu zobaczy dane testowe, to nie będziemy w stanie uczciwie estymować jego zachowania na nowych danych.\n",
             "\n",
             "Wykorzystanie danych testowych w procesie treningu to błąd **wycieku danych (data leakage)**. Skutkuje on niepoprawnym, nadmiernie optymistycznym oszacowaniem jakości modelu.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1520,8 +1482,7 @@
             "### Metoda `.fit_transform()`\n",
             "\n",
             "Metoda, która najpierw wykonuje `.fit()`, a potem `.transform()` i zwraca wynik ostatniej. W przypadku niektórych transformacji wykorzystuje ich specyfikę i działa szybciej, niż sekwencyjne wywołanie `.fit()` oraz`.transform()`. Trzeba jednak pamiętać, że możemy tego użyć tylko na zbiorze treningowym - na zbiorze testowym wywołujemy już tylko `.transform()`.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1536,8 +1497,7 @@
          },
          "source": [
             "### Zadanie 4 (0.5 punktu)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1554,8 +1514,7 @@
             "Stwórz pipeline'y dla zmiennych kategorycznych i numerycznych. Połącz je następnie z użyciem `ColumnTransformer`. \"Wytrenuj\" go na danych treningowych, a następnie przetransformuj dane treningowe oraz testowe.\n",
             "\n",
             "**Uwaga:** przekaż do `ColumnTransformer` parametr `verbose_feature_names_out=False`, żeby nie zmieniał on nazw cech. Ułatwi nam to późniejszą analizę wyników."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1646,8 +1605,7 @@
          },
          "source": [
             "## Regresja liniowa"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1680,8 +1638,7 @@
             "L(y, \\hat{y}) = \\frac{1}{n} \\sum_{i=1}^n \\left( y - \\hat{y} \\right)^2\n",
             "$$\n",
             "gdzie $\\hat{y}$ to wartość przewidywana przez model, $y$ - prawdziwa, a $n$ to liczba punktów w zbiorze.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1714,8 +1671,7 @@
             "Minimalizując inne rodzaje błędu, otrzymujemy modele liniowe o innych parametrach, ale tej samej postaci funkcji. Typowo modele te są bardziej odporne na wartości odstające, ale bardziej kosztowne w treningu. Są to np. [quantile regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.QuantileRegressor.html) optymalizująca koszt L1 (*mean absolute error*) czy [Huber regression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.HuberRegressor.html), optymalizująca tzw. Huber loss (połączenie L1 i L2).\n",
             "\n",
             "Obliczanie regresji liniowej używa pseudoodwrotności Moore'a-Penrose'a i SVD. Objaśnia to dobrze [ten tutorial](https://sthalles.github.io/svd-for-regression/)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1753,8 +1709,7 @@
          },
          "source": [
             "Czy taki błąd to duży, czy mały? Wszystko zależy od skali wartości przewidywanych. Trzeba pamiętać, że dokonaliśmy logarytmowania zmiennej docelowej, więc trzeba to sprawdzić po transformacji odwrotnej `np.expm1`. Po tej operacji wartość błędu będzie wyrażona w dolarach."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1767,8 +1722,7 @@
          },
          "source": [
             "## Zbyt małe i nadmierne dopasowanie"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1788,8 +1742,7 @@
             "- obliczamy błąd treningowy oraz testowy,\n",
             "- jeżeli oba błędy są wysokie, to mamy zbyt małe dopasowanie (*underfitting*) i trzeba użyć pojemniejszego modelu,\n",
             "- jeżeli błąd treningowy jest dużo niższy od testowego, to mamy nadmierne dopasowanie (*overfitting*) i model trzeba regularyzować.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1812,8 +1765,7 @@
             "#### Dla zainteresowanych\n",
             "\n",
             "W praktyce detekcja nadmiernego dopasowania nie musi być wcale taka oczywista. Nasz model może przeuczać się tylko na niektórych segmentach danych, dla nietrywialnych kombinacji cech etc. Testowanie modeli ML i detekcja overfittingu jest otwartym problemem badawczym, ale powstają już pierwsze narzędzia do tego, np. [Giskard](https://github.com/Giskard-AI/giskard)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1828,8 +1780,7 @@
          },
          "source": [
             "### Zadanie 5 (1.0 punkt)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1851,8 +1802,7 @@
             "- zwrócenie RMSE dla zbioru treningowego i testowego.\n",
             "\n",
             "Skomentuj wyniki. Czy następuje przeuczenie modelu? Oceń także sam błąd, czy subiektywnie to duża wartość, biorąc pod uwagę rozkład zmiennej docelowej (wartości i wykresy w sekcji EDA)?"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -1937,8 +1887,7 @@
          "source": [
             "// skomentuj tutaj\n",
             "\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1951,8 +1900,7 @@
          },
          "source": [
             "## Regresja regularyzowana (ridge, LASSO)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1972,8 +1920,7 @@
             "Jak widać, regularyzacja dodaje do zwykłego kosztu MSE dodatkowe wyrazy, penalizujące wielkość wag $\\boldsymbol{w}$. **Siłę regularyzacji (regularization strength)**, czyli jak mocna jest taka kara, wyznacza współczynnik, oznaczany typowo $\\lambda$ albo $\\alpha$. Jest to **hiperparametr (hyperparameter)**, czyli stała modelu, którą narzucamy z góry, przed treningiem. Nie jest on uczony z danych. Jak go dobrać, omówimy poniżej.\n",
             "\n",
             "Regresja ridge (L2) zmniejsza wagi i jest różniczkowalna (szybsza i łatwiejsza w treningu). Regresja LASSO (L1) dokonuje **selekcji cech (feature selection)**, zmniejszając często wagi cech dokładnie do zera, eliminując tym samym słabe cechy. Oba naraz realizuje model ElasticNet.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -1990,8 +1937,7 @@
             "- jeżeli nie potrzebujemy bardzo precyzyjnego rozwiązania, można ustawić większe `tol` dla przyspieszenia obliczeń.\n",
             "\n",
             "Jako że nasz model jest regularyzowany i nie ma ryzyka problemów numerycznych, to teraz już obliczamy intercept."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2030,8 +1976,7 @@
          },
          "source": [
             "W przypadku regularyzacji L2 domyślna siła regularyzacji (`alpha=1.0`) znacząco poprawiła wynik, natomiast w przypadku L1 mamy bardzo silny underfitting."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2047,8 +1992,7 @@
             "\n",
             "* **pełne przeszukiwanie** (*grid search*) - definiujemy możliwe wartości dla różnych hiperparametrów, a metoda sprawdza ich wszystkie możliwe kombinacje (czyli siatkę),\n",
             "* **losowe przeszukiwanie** (*randomized search*) - definiujemy możliwe wartości jak w pełnym przeszukiwaniu, ale sprawdzamy tylko ograniczoną liczbę losowo wybranych kombinacji."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2069,8 +2013,7 @@
             "Takich metod szczególnie często używa się przy tuningu hiperparametrów dla sieci neuronowej, gdyż jej wytrenowanie jest czasochłonne, a więc nie możemy pozwolić sobie na sprawdzenie licznych kombinacji, bo zbyt dużo by nas to kosztowało.\n",
             "\n",
             "Ta metoda została zaimplementowana w wielu frameworkach, jak np. Optuna czy Hyperopt. Więcej można o nich przeczytać [tutaj](https://towardsdatascience.com/a-conceptual-explanation-of-bayesian-model-based-hyperparameter-optimization-for-machine-learning-b8172278050f)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2096,8 +2039,7 @@
             "#### Dla zainteresowanych\n",
             "\n",
             "Walidacji skrośnej można użyć także do testowania, tworząc wiele zbiorów testowych. Można połączyć obie techniki, co daje tzw. [nested cross-validation](https://vitalflux.com/python-nested-cross-validation-algorithm-selection/). Jest to bardzo kosztowna, ale jednocześnie bardzo precyzyjna technika."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2116,8 +2058,7 @@
             "`RidgeCV` domyślnie wykorzystuje efektywną implementację Leave-One-Out Cross-Validation (LOOCV). Jest to możliwe dzięki pewnym sztuczkom opartym na algebrze liniowej, wyjaśnionych [w dokumentacji w kodzie](https://github.com/scikit-learn/scikit-learn/blob/8c9c1f27b7e21201cfffb118934999025fd50cca/sklearn/linear_model/_ridge.py#L1547) (dla zainteresowanych). Co ważne, jest to operacja o wiele szybsza niż osobne grid search + ridge regression, a nawet od `RidgeCV` z mniejszą liczbą foldów.\n",
             "\n",
             "`LassoCV` oraz `ElasticNetCV` iterują od najmniejszych do największych wartości `alpha` (siły regularyzacji), używając rozwiązania dla mniejszej siły regularyzacji jako punktu początkowego dla kolejnej wartości. Odpowiada to po prostu dość inteligentnemu wyborowi punktu startowego w optymalizacji funkcji kosztu, a znacznie obniża koszt obliczeniowy."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2132,8 +2073,7 @@
          },
          "source": [
             "### Zadanie 6 (1.0 punkt)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2171,8 +2111,7 @@
             "---\n",
             "\n",
             "Przetestuj modele z użyciem `assess_regression_model()`. Skomentuj wyniki. Czy udało się wyeliminować overfitting?"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2231,8 +2170,7 @@
          "source": [
             "// skomentuj tutaj\n",
             "\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2245,8 +2183,7 @@
          },
          "source": [
             "## Regresja wielomianowa"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2270,8 +2207,7 @@
             "Kwestią sporną jest, czy jest sens przeprowadzać taką transformację dla zmiennych po one-hot encodingu. Potęgi na pewno nie mają sensu, natomiast interakcje realizują po prostu operację koniunkcji (AND), ale łatwo prowadzi to do eksplozji wymiarowości. Dla uproszczenia poniżej zastosujemy transformację dla wszystkich cech.\n",
             "\n",
             "Warto pamiętać, że jeżeli używamy modelu, który sam dodaje intercept (jak regresja liniowa), to trzeba przekazać `include_bias=False`. Żeby wymiarowość zbytnio nam nie urosła, użyjemy `interaction_only=True`."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2312,8 +2248,7 @@
          },
          "source": [
             "Co ciekawe, model bardziej zbliżył się do przeuczenia, ale błąd testowy zmalał. Jest to niezbyt częste, ale możliwe."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2328,8 +2263,7 @@
             "## Regresja logistyczna\n",
             "\n",
             "Regresja logistyczna jest modelem, który pozwala na przewidywanie wartości zmiennych dychotomicznych w oparciu o jedną lub większą liczbę cech. Funkcją bazową regresji logistycznej jest funkcja logistyczna. Bardzo ciekawe podsumowanie dotyczące matematyki stojącej za regresją logistyczną znajdziesz [tu](https://philippmuens.com/logistic-regression-from-scratch)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2346,8 +2280,7 @@
             "Zbiór posiada dwie wersje, uproszczoną oraz rozszerzoną o dodatkowe atrybuty socjoekonomiczne (np. sytuację ekonomiczną w planowanym momencie reklamy). Wykorzystamy tę drugą, bo są to bardzo wartościowe cechy. Dodatkowo każda wersja posiada pełny zbiór (ok. 45 tysięcy przykładów) oraz pomniejszony (ok. 4 tysiąca przykładów). Dzięki skalowalności regresji logistycznej możemy bez problemu wykorzystać pełny zbiór z dodatkowymi cechami.\n",
             "\n",
             "Opisy zmiennych znajdują się w pliku [bank_marketing_description.txt](bank_marketing_description.txt)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2362,8 +2295,7 @@
          },
          "source": [
             "### Zadanie 7 (1.0 punkt)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2389,8 +2321,7 @@
             "    - usuń wiersze z `education` na poziomie `illiterate`, jest ich tylko kilkanaście.\n",
             "4. Zakoduj odpowiednio zmienne `education`, `contact`, `month`, `day_of_week` i `y`. Dla ułatwienia słowniki tych zmiennych są w zmiennych poniżej.\n",
             "5. Wyodrębnij kolumnę `y` do zmiennej `y` (pamiętaj o usunięciu jej z DataFrame'a)."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2467,6 +2398,36 @@
          ]
       },
       {
+         "cell_type": "markdown",
+         "metadata": {
+            "tags": [
+               "ex"
+            ]
+         },
+         "source": [
+            "Pamiętajmy o zmianie typu kolumn, które zmieniliśmy na typ zakodowany przez `np.int64`."
+         ]
+      },
+      {
+         "cell_type": "code",
+         "execution_count": null,
+         "metadata": {
+            "tags": [
+               "ex"
+            ]
+         },
+         "outputs": [],
+         "source": [
+            "# downcast replaced columns into int64\n",
+            "df = df.astype({\n",
+            "    \"contact\": np.int64,\n",
+            "    \"month\": np.int64,\n",
+            "    \"day_of_week\": np.int64,\n",
+            "    \"y\": np.int64\n",
+            "})"
+         ]
+      },
+      {
          "cell_type": "code",
          "execution_count": null,
          "metadata": {
@@ -2507,8 +2468,7 @@
          },
          "source": [
             "### Zadanie 8 (0.5 punktu)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2526,8 +2486,7 @@
             "\n",
             "1. Sprawdź, czy są jakieś wartości brakujące za pomocą biblioteki `missingno`. Jeżeli tak, to sprawdź w dokumentacji zbioru, jaka byłaby sensowna wartość do ich uzupełnienia.\n",
             "2. Narysuj wykres (bar plot) z częstością klas. Uwzględnij częstość na wykresie ([to może się przydać](https://stackoverflow.com/a/68107610/9472066)). Pamiętaj o tytule i opisaniu osi."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2576,8 +2535,7 @@
          },
          "source": [
             "Jak widać, będziemy tu mieli do czynienia z problemem klasyfikacji niezbalansowanej. Na szczęście funkcja kosztu w regresji logistycznej pozwala na dodanie **wag klas (class weights)**, aby przypisać większą wagę interesującej nas klasie pozytywnej. Scikit-learn dla wartości `class_weights=\"balanced\"` obliczy wagi odwrotnie proporcjonalne do częstości danej klasy w zbiorze."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2592,8 +2550,7 @@
          },
          "source": [
             "### Zadanie 9 (1.0 punkt)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2611,8 +2568,7 @@
             "\n",
             "1. Dokonaj podziału zbioru na treningowy i testowy w proporcjach 75%-25%. Pamiętaj o użyciu podziału ze stratyfikacją (argument `stratify`), aby zachować proporcje klas. Ustaw `random_state=0`.\n",
             "2. Stwórz `ColumnTransformer`, przetwarzający zmienne kategoryczne za pomocą `OneHotEncoder` (teraz już nie musimy robić `drop=\"first\"`), a numeryczne za pomocą `StandardScaler`. Zaaplikuj go do odpowiednich kolumn.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2695,8 +2651,7 @@
             "Prosty przypadek - mamy zbiór danych, który pozwala na podstawie różnych parametrów medycznych wykryć rzadką chorobę, która zdarza się u 0.01% ludzi. Weźmy prosty klasyfikator, który zawsze zwraca klasę negatywną. Niby jest w oczywisty sposób kompletnie nieprzydatny, ale jednak dla losowej próbki ludzi dostanie ***celność*** równą 99.99%, bo, rzeczywiście, u większości tej choroby nie będzie.\n",
             "\n",
             "Potrzebujemy bardziej skomplikowanej metryki, której nie da się tak łatwo oszukać.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2730,8 +2685,7 @@
             "$$\n",
             "\n",
             "czyli ilość przypadków, w których poprawnie zidentykowaliśmy klasę, podzieloną przez ilość wszystkich przypadków.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2759,8 +2713,7 @@
             "Jest to ilość przypadków, w których poprawnie rozpoznaliśmy klasę pozytywną, podzielona przez ilość wszystkich przypadków, w których zwróciliśmy klasę pozytywną.\n",
             "\n",
             "Ta metryka może być bardzo pomocna, na przykład, przy klasyfikacji spamu. Gorzej będzie, jeśli wrzucimy ważnego maila do spamu, niż przegapimy jakąś reklamę. Chcemy, aby jeśli coś zostało zaklasyfikowane jako spam, rzeczywiście nim było - chcemy jak najwyższą precyzję.\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2788,8 +2741,7 @@
             "[Ten tutorial](https://mlu-explain.github.io/precision-recall/) ma świetne wizualizację, które w interaktywny sposób prezentują działanie powyższych metryk.\n",
             "\n",
             "**Uwaga**:  indeks dolny w mierze $F_1$ oznacza, że mamy do czyninia z miarą, która daje taką samą wagę precyzji i czułości, ale w ogólnym przypadku jest to parametr, za pomocą którego możemy promować miarę, która ma dla nas większe znaczenie."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2804,8 +2756,7 @@
          },
          "source": [
             "### Zadanie 10 (2.0 punkty)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2840,8 +2791,7 @@
             "    - Czy twoim zdaniem tworzenie modeli z regularyzacją ma sens w tym przypadku?\n",
             "\n",
             "Napisz co, w twojej opinii, jest ważniejsze dla naszego problemu, ***precision*** czy ***recall***? Jak moglibyśmy, nie zmieniając modelu, zmienić ich stosunek?"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -2936,8 +2886,7 @@
          "source": [
             "// skomentuj tutaj\n",
             "\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2952,8 +2901,7 @@
          },
          "source": [
             "### Zadanie 11 (2.0 punkty)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -2974,8 +2922,7 @@
             "   - Wypisz F1 treningowy oraz testowy w procentach.\n",
             "   - Wartości F1 na tych zbiorach przypisz do zmiennych `f1_train` oraz `f1_test`.\n",
             "4. Zdecyduj, czy jest sens tworzyć modele z regularyzacją. Jeżeli tak, to wytrenuj i dokonaj tuningu takich modeli. Jeżeli nie, to uzasadnij czemu."
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -3026,8 +2973,7 @@
          "source": [
             "// skomentuj tutaj\n",
             "\n"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -3042,8 +2988,7 @@
          },
          "source": [
             "## Zadanie 12 dodatkowe (3 punkty)"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "markdown",
@@ -3085,8 +3030,7 @@
             "Przetestuj założenia za pomocą testów statystycznych: Harvey Collier, Jarque-Bera, Breusch–Pagan. Współliniowość zmiennych zweryfikuj z użyciem współczynnika uwarunkowania. Zastosuj poziom istotności $\\alpha=0.05$.\n",
             "\n",
             "Czy założenia są spełnione w przypadku podstawowego modelu i/lub modeli z regularyzacją? Czy modele regularyzowane w lepszym stopniu spełniają założenia?"
-         ],
-         "outputs": []
+         ]
       },
       {
          "cell_type": "code",
@@ -3138,7 +3082,7 @@
          "name": "python",
          "nbconvert_exporter": "python",
          "pygments_lexer": "ipython3",
-         "version": "3.11.5"
+         "version": "3.11.0"
       }
    },
    "nbformat": 4,

--- a/lab1/lab_1.ipynb
+++ b/lab1/lab_1.ipynb
@@ -2604,10 +2604,10 @@
             "assert X_train.shape == (30877, 37)\n",
             "assert X_test.shape == (10293, 37)\n",
             "\n",
-            "assert X_train[:,26].min() == 0\n",
-            "assert X_train[:,26].max() == 1\n",
-            "assert -3 < X_train[:,0].min() < -2\n",
-            "assert 5 < X_train[:,0].max() < 6\n",
+            "assert X_train[:,0].min() == 0\n",
+            "assert X_train[:,0].max() == 1\n",
+            "assert -3 < X_train[:,26].min() < -2\n",
+            "assert 5 < X_train[:,26].max() < 6\n",
             "\n"
          ]
       },

--- a/lab1/lab_1.ipynb
+++ b/lab1/lab_1.ipynb
@@ -2821,7 +2821,7 @@
          "source": [
             "*Trening, tuning i analiza modeli*\n",
             "\n",
-            "1. Wytrenuj podstawowy model regresji logistycznej z użyciem `LogisticRegression`. Użyj wag klas (`class_weights=\"balanced\"`). Przetestuj model, wypisując pecyzję, czułość oraz miarę F1 w procentach. **Uwaga:** Scikit-learn domyślnie stosuje tutaj regularyzację L2, więc przekaż `penalty=\"None\"`.\n",
+            "1. Wytrenuj podstawowy model regresji logistycznej z użyciem `LogisticRegression`. Użyj wag klas (`class_weights=\"balanced\"`). Przetestuj model, wypisując precyzję, czułość oraz miarę F1 w procentach. **Uwaga:** Scikit-learn domyślnie stosuje tutaj regularyzację L2, więc przekaż `penalty=\"None\"`.\n",
             "2. Dokonaj tuningu modelu z regularyzacją L2 za pomocą `LogisticRegressionCV`:\n",
             "    - sprawdź 100 wartości, wystarczy podać liczbę do `Cs`,\n",
             "    - użyj 5-krotnej walidacji krzyżowej,\n",

--- a/lab1/lab_1.ipynb
+++ b/lab1/lab_1.ipynb
@@ -2648,10 +2648,10 @@
             "assert X_train.shape == (30877, 37)\n",
             "assert X_test.shape == (10293, 37)\n",
             "\n",
-            "assert X_train[:,0].min() == 0\n",
-            "assert X_train[:,0].max() == 1\n",
-            "assert -3 < X_train[:,26].min() < -2\n",
-            "assert 5 < X_train[:,26].max() < 6\n",
+            "assert X_train[:,26].min() == 0\n",
+            "assert X_train[:,26].max() == 1\n",
+            "assert -3 < X_train[:,0].min() < -2\n",
+            "assert 5 < X_train[:,0].max() < 6\n",
             "\n"
          ]
       },


### PR DESCRIPTION
- Nazwy zmiennych w poleceniu nie zgadzały się z nazwami w assertach w zadaniu 6
- Naprawione asserty dla wartości po przekształceniu StandardScalerem i OneHotEncoding w zadaniu 9
- Literówka w zadaniu 10
- Naprawiłem błąd wprowadzony w ostatnim PR - została tam dodana opcja która wyłącza feauture pandas który jest deprecated - przez to gdy zencodujemy kolumnę object na int64 to pandas nie dokona za nas cichego downcastingu tylko ręcznie musimy zmienić typ  kolumny - w PR w 1 sekcji owa zmiana typu była w złej komórce, a w drugim zbiorze danych brakowało tego, dodałem tą sekcję do drugiego zbioru danych