### PR TITLE
Lab1 Fix bugs

### DIFF
--- a/lab1/lab_1.ipynb
+++ b/lab1/lab_1.ipynb
@@ -514,7 +514,7 @@
          "outputs": [],
          "source": [
             "for e in df.itertuples():\n",
-            "    assert 0 < e.GrLivArea < 4000\n",
+            "    assert 0 < e.GrLivArea <= 4000\n",
             "\n",
             "print(\"Solution is correct!\")"
          ]
@@ -743,7 +743,7 @@
          },
          "outputs": [],
          "source": [
-            "pd.Series(np.log(df[\"SalePrice\"])).hist()\n",
+            "pd.Series(df[\"SalePrice\"]).hist()\n",
             "plt.title(\"Log sale price\")\n",
             "plt.show()"
          ]
@@ -2569,7 +2569,7 @@
             "tags": []
          },
          "source": [
-            "Jak widać, będziemy tu mieli do czynienia z problemem klasyfikacji niezbalansowanej. Na szczęście funkcja kosztu w regresji logistycznej pozwala na dodanie **wag klas (class weights)**, aby przypisać większą wagę interesującej nas klasie pozytywnej. Scikit-learn dla wartości `class_weights=\"balanced\"` obliczy wagi odwrotnie proporcjonalne do częstości danej klasy w zbiorze."
+            "Jak widać, będziemy tu mieli do czynienia z problemem klasyfikacji niezbalansowanej. Na szczęście funkcja kosztu w regresji logistycznej pozwala na dodanie **wag klas (class weights)**, aby przypisać większą wagę interesującej nas klasie pozytywnej. Scikit-learn dla wartości `class_weight=\"balanced\"` obliczy wagi odwrotnie proporcjonalne do częstości danej klasy w zbiorze."
          ],
          "outputs": []
       },
@@ -2816,12 +2816,12 @@
          "source": [
             "*Trening, tuning i analiza modeli*\n",
             "\n",
-            "1. Wytrenuj podstawowy model regresji logistycznej z użyciem `LogisticRegression`. Użyj wag klas (`class_weights=\"balanced\"`). Przetestuj model, wypisując pecyzję, czułość oraz miarę F1 w procentach. **Uwaga:** Scikit-learn domyślnie stosuje tutaj regularyzację L2, więc przekaż `penalty=\"None\"`.\n",
+            "1. Wytrenuj podstawowy model regresji logistycznej z użyciem `LogisticRegression`. Użyj wag klas (`class_weight=\"balanced\"`). Przetestuj model, wypisując pecyzję, czułość oraz miarę F1 w procentach. **Uwaga:** Scikit-learn domyślnie stosuje tutaj regularyzację L2, więc przekaż `penalty=\"None\"`.\n",
             "2. Dokonaj tuningu modelu z regularyzacją L2 za pomocą `LogisticRegressionCV`:\n",
             "    - sprawdź 100 wartości, wystarczy podać liczbę do `Cs`,\n",
             "    - użyj 5-krotnej walidacji krzyżowej,\n",
             "    - wybierz najlepszy model według metryki F1 (parametr `scoring`),\n",
-            "    - pamiętaj o `class_weights=\"balanced\"` i `random_state=0`,\n",
+            "    - pamiętaj o `class_weight=\"balanced\"` i `random_state=0`,\n",
             "    - użyj `n_jobs=-1` dla przyspieszenia obliczeń (`-1` znaczy, że użyjemy wszystkich rdzeni do obliczeń),\n",
             "    - przetestuj model, wypisując precyzję, czułość i miarę F1 w procentach.\n",
             "    - **uwaga:** Scikit-learn stosuje tutaj konwencję, gdzie parametr `C` to odwrotność siły regularyzacji - im mniejszy, tym silniejsza regularyzacja.\n",


### PR DESCRIPTION
# Introduced changes:

## Task 1:
### From:
```python
assert 0 < e.GrLivArea < 4000
```
### To:
```python
assert 0 < e.GrLivArea <= 4000
```
### Motivation:
The description states, “remove real estate with GrLivArea over 4000 square feet,” which means properties with GrLivArea less than or equal to 4000 should be retained.

## Task 2:
### From:
```python
pd.Series(np.log(df["SalePrice"])).hist()
```
### To:
```python
pd.Series(df["SalePrice"]).hist()
```
### Motivation:
The `df["SalePrice"]` column should already be transformed in this cell, making the `np.log(...)` transformation redundant and incorrect.

## Task 8, 10:
### From:
```python
class_weights="balanced"
```
### To:
```python
class_weight="balanced"
```
### Motivation:
The correct parameter name is `class_weight` according to the [scikit-learn documentation](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html).
