### PR TITLE
Remove unnecessary `typing`

### DIFF
--- a/lab3/lab_3.ipynb
+++ b/lab3/lab_3.ipynb
@@ -762,7 +762,6 @@
     "editable": true,
     "id": "2etpw7TNLAs0",
     "outputId": "8ac35c12-6c70-41ec-bf57-414456fc3c96",
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -856,7 +855,6 @@
     "editable": true,
     "id": "4DNsaZAnLAs0",
     "outputId": "70822008-530d-4173-deb9-8149a9fe5b41",
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -1125,7 +1123,6 @@
     },
     "id": "NbABKz5-LAs2",
     "outputId": "086dc0f3-0184-4072-9fd3-275b60dee2e4",
-    "scrolled": true,
     "tags": [
      "ex"
     ]
@@ -1165,7 +1162,6 @@
     },
     "id": "zH37zDX4LAs2",
     "outputId": "b1f93309-6f04-4ffc-b0ca-08d0a32120a0",
-    "scrolled": true,
     "tags": [
      "ex"
     ]
@@ -1800,7 +1796,6 @@
    "metadata": {
     "editable": true,
     "lines_to_next_cell": 2,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },

--- a/lab3/lab_3.ipynb
+++ b/lab3/lab_3.ipynb
@@ -1,2297 +1,2244 @@
 {
-   "cells": [
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "# Sieci neuronowe"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "## Wstęp\n",
-            "\n",
-            "Celem laboratorium jest zapoznanie się z podstawami sieci neuronowych oraz uczeniem głębokim (*deep learning*). Zapoznasz się na nim z następującymi tematami:\n",
-            "- treningiem prostych sieci neuronowych, w szczególności z:\n",
-            "  - regresją liniową w sieciach neuronowych\n",
-            "  - optymalizacją funkcji kosztu\n",
-            "  - algorytmem spadku wzdłuż gradientu\n",
-            "  - siecią typu Multilayer Perceptron (MLP)\n",
-            "- frameworkiem PyTorch, w szczególności z:\n",
-            "  - ładowaniem danych\n",
-            "  - preprocessingiem danych\n",
-            "  - pisaniem pętli treningowej i walidacyjnej\n",
-            "  - walidacją modeli\n",
-            "- architekturą i hiperaprametrami sieci MLP, w szczególności z:\n",
-            "  - warstwami gęstymi (w pełni połączonymi)\n",
-            "  - funkcjami aktywacji\n",
-            "  - regularyzacją: L2, dropout"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "## Wykorzystywane biblioteki\n",
-            "\n",
-            "Zaczniemy od pisania ręcznie prostych sieci w bibliotece Numpy, służącej do obliczeń numerycznych na CPU. Później przejdziemy do wykorzystywania frameworka PyTorch, służącego do obliczeń numerycznych na CPU, GPU oraz automatycznego różniczkowania, wykorzystywanego głównie do treningu sieci neuronowych.\n",
-            "\n",
-            "Wykorzystamy PyTorcha ze względu na popularność, łatwość instalacji i użycia, oraz dużą kontrolę nad niskopoziomowymi aspektami budowy i treningu sieci neuronowych. Framework ten został stworzony do zastosowań badawczych i naukowych, ale ze względu na wygodę użycia stał się bardzo popularny także w przemyśle. W szczególności całkowicie zdominował przetwarzanie języka naturalnego (NLP) oraz uczenie na grafach.\n",
-            "\n",
-            "Pierwszy duży framework do deep learningu, oraz obecnie najpopularniejszy, to TensorFlow, wraz z wysokopoziomową nakładką Keras. Są jednak szanse, że Google (autorzy) będzie go powoli porzucać na rzecz ich nowego frameworka JAX ([dyskusja](https://www.reddit.com/r/MachineLearning/comments/vfl57t/d_google_quietly_moving_its_products_from/), [artykuł Business Insidera](https://www.businessinsider.com/facebook-pytorch-beat-google-tensorflow-jax-meta-ai-2022-6?IR=T)), który jest bardzo świeżym, ale ciekawym narzędziem.\n",
-            "\n",
-            "Trzecia, ale znacznie mniej popularna od powyższych opcja to Apache MXNet."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "## Konfiguracja własnego komputera\n",
-            "\n",
-            "Jeżeli korzystasz z własnego komputera, to musisz zainstalować trochę więcej bibliotek (Google Colab ma je już zainstalowane).\n",
-            "\n",
-            "Jeżeli nie masz GPU lub nie chcesz z niego korzystać, to wystarczy znaleźć odpowiednią komendę CPU [na stronie PyTorcha](https://pytorch.org/get-started/locally/). Dla Anacondy odpowiednia komenda została podana poniżej, dla pip'a znajdź ją na stronie.\n",
-            "\n",
-            "Jeżeli chcesz korzystać ze wsparcia GPU (na tym laboratorium nie będzie potrzebne, na kolejnych może przyspieszyć nieco obliczenia), to musi być to odpowiednio nowa karta NVidii, mająca CUDA compatibility ([lista](https://developer.nvidia.com/cuda-gpus)). Poza PyTorchem będzie potrzebne narzędzie NVidia CUDA w wersji 11.6 lub 11.7. Instalacja na Windowsie jest bardzo prosta (wystarczy ściągnąć plik EXE i zainstalować jak każdy inny program). Instalacja na Linuxie jest trudna i można względnie łatwo zepsuć sobie system, ale jeżeli chcesz spróbować, to [ten tutorial](https://www.youtube.com/results?search_query=nvidia+cuda+install+ubuntu+20.04) jest bardzo dobry."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "Othm3C2lLAsj"
-         },
-         "source": [
-            "## Wprowadzenie\n",
-            "\n",
-            "Zanim zaczniemy naszą przygodę z sieciami neuronowymi, przyjrzyjmy się prostemu przykładowi regresji liniowej na syntetycznych danych:"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "id": "rnJsfxbnLAsj"
-         },
-         "outputs": [],
-         "source": [
-            "from typing import Tuple, Dict\n",
-            "\n",
-            "import numpy as np\n",
-            "import matplotlib.pyplot as plt"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/",
-               "height": 282
-            },
-            "id": "EaYpEXzBLAsl",
-            "outputId": "2f8d2922-72f0-4d38-8548-d1262adf522e"
-         },
-         "outputs": [],
-         "source": [
-            "np.random.seed(0)\n",
-            "\n",
-            "x = np.linspace(0, 1, 100)\n",
-            "y = x + np.random.normal(scale=0.1, size=x.shape)\n",
-            "\n",
-            "plt.scatter(x, y)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "PEM_-yKELAsl",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "W przeciwieństwie do laboratorium 1, tym razem będziemy chcieli rozwiązać ten problem własnoręcznie, bez użycia wysokopoziomowego interfejsu Scikit-learn'a. W tym celu musimy sobie przypomnieć sformułowanie naszego **problemu optymalizacyjnego (optimization problem)**.\n",
-            "\n",
-            "W przypadku prostej regresji liniowej (1 zmienna) mamy model postaci $\\hat{y} = \\alpha x + \\beta$, z dwoma parametrami, których będziemy się uczyć. Miarą niedopasowania modelu o danych parametrach jest **funkcja kosztu (cost function)**, nazywana też funkcją celu. Najczęściej używa się **błędu średniokwadratowego (mean squared error, MSE)**:\n",
-            "$$\\large\n",
-            "MSE = \\frac{1}{N} \\sum_{i}^{N} (y - \\hat{y})^2\n",
-            "$$\n",
-            "\n",
-            "Od jakich $\\alpha$ i $\\beta$ zacząć? W najprostszym wypadku wystarczy po prostu je wylosować jako niewielkie liczby zmiennoprzecinkowe."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "PEM_-yKELAsl",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 1 (0.5 punkt)\n",
-            "\n",
-            "Uzupełnij kod funkcji `mse`, obliczającej błąd średniokwadratowy. Wykorzystaj Numpy'a w celu wektoryzacji obliczeń dla wydajności."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "RaA7Q46TLAsm",
-            "outputId": "5c57fe58-1934-4d21-9a7b-d14e9a23140b",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "def mse(y: np.ndarray, y_hat: np.ndarray) -> float:\n",
-            "    # implement me!\n",
-            "    # your_code\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/",
-               "height": 282
-            },
-            "editable": true,
-            "id": "qSGfamGbLAsm",
-            "outputId": "733ce15f-ae75-466b-e7ee-eb3c9d9d534c",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "a = np.random.rand()\n",
-            "b = np.random.rand()\n",
-            "print(f\"MSE: {mse(y, a * x + b):.3f}\")\n",
-            "\n",
-            "plt.scatter(x, y)\n",
-            "plt.plot(x, a * x + b, color=\"g\", linewidth=4)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "Y--E9Mp9LAsn"
-         },
-         "source": [
-            "Losowe parametry radzą sobie nie najlepiej. Jak lepiej dopasować naszą prostą do danych? Zawsze możemy starać się wyprowadzić rozwiązanie analitycznie, i w tym wypadku nawet nam się uda. Jest to jednak szczególny i dość rzadki przypadek, a w szczególności nie będzie to możliwe w większych sieciach neuronowych.\n",
-            "\n",
-            "Potrzebna nam będzie **metoda optymalizacji (optimization method)**, dającą wartości parametrów minimalizujące dowolną różniczkowalną funkcję kosztu. Zdecydowanie najpopularniejszy jest tutaj **spadek wzdłuż gradientu (gradient descent)**.\n",
-            "\n",
-            "Metoda ta wywodzi się z prostych obserwacji, które tutaj przedstawimy. Bardziej szczegółowe rozwinięcie dla zainteresowanych: [sekcja 4.3 \"Deep Learning Book\"](https://www.deeplearningbook.org/contents/numerical.html), [ten praktyczny kurs](https://cs231n.github.io/optimization-1/), [analiza oryginalnej publikacji Cauchy'ego](https://www.math.uni-bielefeld.de/documenta/vol-ismp/40_lemarechal-claude.pdf) (oryginał w języku francuskim).\n",
-            "\n",
-            "Pochodna jest dokładnie równa granicy funkcji. Dla małego $\\epsilon$ można ją przybliżyć jako:\n",
-            "$$\\large\n",
-            "\\frac{f(x)}{dx} \\approx \\frac{f(x+\\epsilon) - f(x)}{\\epsilon}\n",
-            "$$\n",
-            "\n",
-            "Przyglądając się temu równaniu widzimy, że: \n",
-            "* dla funkcji rosnącej ($f(x+\\epsilon) > f(x)$) wyrażenie $\\frac{f(x)}{dx}$ będzie miało znak dodatni \n",
-            "* dla funkcji malejącej ($f(x+\\epsilon) < f(x)$) wyrażenie $\\frac{f(x)}{dx}$ będzie miało znak ujemny \n",
-            "\n",
-            "Widzimy więc, że potrafimy wskazać kierunek zmniejszenia wartości funkcji, patrząc na znak pochodnej. Zaobserwowano także, że amplituda wartości w $\\frac{f(x)}{dx}$ jest tym większa, im dalej jesteśmy od minimum (maximum). Pochodna wyznacza więc, w jakim kierunku funkcja najszybciej rośnie, zaś przeciwny zwrot to ten, w którym funkcja najszybciej spada.\n",
-            "\n",
-            "Stosując powyższe do optymalizacji, mamy:\n",
-            "$$\\large\n",
-            "x_{t+1} = x_{t} -  \\alpha * \\frac{f(x)}{dx}\n",
-            "$$\n",
-            "\n",
-            "$\\alpha$ to niewielka wartość (rzędu zwykle $10^{-5}$ - $10^{-2}$), wprowadzona, aby trzymać się założenia o małej zmianie parametrów ($\\epsilon$). Nazywa się ją **stałą uczącą (learning rate)** i jest zwykle najważniejszym hiperparametrem podczas nauki sieci.\n",
-            "\n",
-            "Metoda ta zakłada, że używamy całego zbioru danych do aktualizacji parametrów w każdym kroku, co nazywa się po prostu GD (od *gradient descent*) albo *full batch GD*. Wtedy każdy krok optymalizacji nazywa się **epoką (epoch)**.\n",
-            "\n",
-            "Im większa stała ucząca, tym większe nasze kroki podczas minimalizacji. Możemy więc uczyć szybciej, ale istnieje ryzyko, że będziemy \"przeskakiwać\" minima. Mniejsza stała ucząca to wolniejszy, ale dokładniejszy trening. Jednak nie zawsze ona pozwala osiągnąć lepsze wyniki, bo może okazać się, że utkniemy w minimum lokalnym. Można także zmieniać stałą uczącą podczas treningu, co nazywa się **learning rate scheduling (LR scheduling)**. Obrazowo:\n",
-            "\n",
-            "![learning_rate](http://www.bdhammel.com/assets/learning-rate/lr-types.png)"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "496qEjkVLAso"
-         },
-         "source": [
-            "![interactive LR](http://cdn-images-1.medium.com/max/640/1*eeIvlwkMNG1wSmj3FR6M2g.gif)"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "RYkyAHKzLAsp"
-         },
-         "source": [
-            "Policzmy więc pochodną dla naszej funkcji kosztu MSE. Pochodną liczymy po parametrach naszego modelu, bo to właśnie ich chcemy dopasować tak, żeby koszt był jak najmniejszy:\n",
-            "\n",
-            "$$\\large\n",
-            "MSE = \\frac{1}{N} \\sum_{i}^{N} (y_i - \\hat{y_i})^2\n",
-            "$$\n",
-            "\n",
-            "W powyższym wzorze tylko $y_i$ jest zależny od $a$ oraz $b$. Możemy wykorzystać tu regułę łańcuchową (*chain rule*) i policzyć pochodne po naszych parametrach w sposób następujący:\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} MSE}{\\text{d} a} = \\frac{1}{N} \\sum_{i}^{N} \\frac{\\text{d} (y_i - \\hat{y_i})^2}{\\text{d} \\hat{y_i}} \\frac{\\text{d} \\hat{y_i}}{\\text{d} a}\n",
-            "$$\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} MSE}{\\text{d} b} = \\frac{1}{N} \\sum_{i}^{N} \\frac{\\text{d} (y_i - \\hat{y_i})^2}{\\text{d} \\hat{y_i}} \\frac{\\text{d} \\hat{y_i}}{\\text{d} b}\n",
-            "$$\n",
-            "\n",
-            "Policzmy te pochodne po kolei:\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} (y_i - \\hat{y_i})^2}{\\text{d} \\hat{y_i}} = -2 \\cdot (y_i - \\hat{y_i})\n",
-            "$$\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} \\hat{y_i}}{\\text{d} a} = x_i\n",
-            "$$\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} \\hat{y_i}}{\\text{d} b} = 1\n",
-            "$$\n",
-            "\n",
-            "Łącząc powyższe wyniki dostaniemy:\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} MSE}{\\text{d} a} = \\frac{-2}{N} \\sum_{i}^{N} (y_i - \\hat{y_i}) \\cdot {x_i}\n",
-            "$$\n",
-            "\n",
-            "$$\\large\n",
-            "\\frac{\\text{d} MSE}{\\text{d} b} = \\frac{-2}{N} \\sum_{i}^{N} (y_i - \\hat{y_i})\n",
-            "$$\n",
-            "\n",
-            "Aktualizacja parametrów wygląda tak:\n",
-            "\n",
-            "$$\\large\n",
-            "a' = a - \\alpha * \\left( \\frac{-2}{N} \\sum_{i=1}^N (y_i - \\hat{y}_i) \\cdot x_i \\right)\n",
-            "$$\n",
-            "$$\\large\n",
-            "b' = b - \\alpha * \\left( \\frac{-2}{N} \\sum_{i=1}^N (y_i - \\hat{y}_i) \\right)\n",
-            "$$\n",
-            "\n",
-            "Liczymy więc pochodną funkcji kosztu, a potem za pomocą reguły łańcuchowej \"cofamy się\", dochodząc do tego, jak każdy z parametrów wpływa na błąd i w jaki sposób powinniśmy go zmienić. Nazywa się to **propagacją wsteczną (backpropagation)** i jest podstawowym mechanizmem umożliwiającym naukę sieci neuronowych za pomocą spadku wzdłuż gradientu. Więcej możesz o tym przeczytać [tutaj](https://cs231n.github.io/optimization-2/)."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 2 (1.0 punkt)\n",
-            "\n",
-            "Zaimplementuj funkcję realizującą jedną epokę treningową. Zauważ, że `x` oraz `y` są wektorami. Oblicz predykcję przy aktualnych parametrach oraz zaktualizuj je zgodnie z powyższymi wzorami."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "4qbdWOSULAsp",
-            "outputId": "055607ae-87aa-470a-e6da-25682c82d470",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "def optimize(\n",
-            "    x: np.ndarray, y: np.ndarray, a: float, b: float, learning_rate: float = 0.1\n",
-            "):\n",
-            "    y_hat = a * x + b\n",
-            "    errors = y - y_hat\n",
-            "    # implement me!\n",
-            "    # your_code\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "for i in range(1000):\n",
-            "    loss = mse(y, a * x + b)\n",
-            "    a, b = optimize(x, y, a, b)\n",
-            "    if i % 100 == 0:\n",
-            "        print(f\"step {i} loss: \", loss)\n",
-            "\n",
-            "print(\"final loss:\", loss)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "assert 0.0 < loss < 2.0\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/",
-               "height": 282
-            },
-            "editable": true,
-            "id": "xOgRcPC1LAsq",
-            "outputId": "85b0b3e4-aa0d-467a-d8ff-5f01be17b243",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "plt.scatter(x, y)\n",
-            "plt.plot(x, a * x + b, color=\"g\", linewidth=4)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "vOr2fWYpLAsq"
-         },
-         "source": [
-            "Udało ci się wytrenować swoją pierwszą sieć neuronową. Czemu? Otóż neuron to po prostu wektor parametrów, a zwykle robimy iloczyn skalarny tych parametrów z wejściem. Dodatkowo na wyjście nakłada się **funkcję aktywacji (activation function)**, która przekształca wyjście. Tutaj takiej nie było, a właściwie była to po prostu funkcja identyczności.\n",
-            "\n",
-            "Oczywiście w praktyce korzystamy z odpowiedniego frameworka, który w szczególności:\n",
-            "- ułatwia budowanie sieci, np. ma gotowe klasy dla warstw neuronów\n",
-            "- ma zaimplementowane funkcje kosztu oraz ich pochodne\n",
-            "- sam różniczkuje ze względu na odpowiednie parametry i aktualizuje je odpowiednio podczas treningu\n"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "NJBYJabuLAsr"
-         },
-         "source": [
-            "## Wprowadzenie do PyTorcha"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "EB-99XqhLAsr"
-         },
-         "source": [
-            "PyTorch to w gruncie rzeczy narzędzie do algebry liniowej z [automatycznym rożniczkowaniem](https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html), z możliwością przyspieszenia obliczeń z pomocą GPU. Na tych fundamentach zbudowany jest pełny framework do uczenia głębokiego. Można spotkać się ze stwierdzenie, że PyTorch to NumPy + GPU + opcjonalne różniczkowanie, co jest całkiem celne. Plus można łatwo debugować printem :)\n",
-            "\n",
-            "PyTorch używa dynamicznego grafu obliczeń, który sami definiujemy w kodzie. Takie podejście jest bardzo wygodne, elastyczne i pozwala na łatwe eksperymentowanie. Odbywa się to potencjalnie kosztem wydajności, ponieważ pozostawia kwestię optymalizacji programiście. Więcej na ten temat dla zainteresowanych na końcu laboratorium.\n",
-            "\n",
-            "Samo API PyTorcha bardzo przypomina Numpy'a, a podstawowym obiektem jest `Tensor`, klasa reprezentująca tensory dowolnego wymiaru. Dodatkowo niektóre tensory będą miały automatycznie obliczony gradient. Co ważne, tensor jest na pewnym urządzeniu, CPU lub GPU, a przenosić między nimi trzeba explicite.\n",
-            "\n",
-            "Najważniejsze moduły:\n",
-            "- `torch` - podstawowe klasy oraz funkcje, np. `Tensor`, `from_numpy()`\n",
-            "- `torch.nn` - klasy związane z sieciami neuronowymi, np. `Linear`, `Sigmoid`\n",
-            "- `torch.optim` - wszystko związane z optymalizacją, głównie spadkiem wzdłuż gradientu"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "id": "FwuIt8S-LAss"
-         },
-         "outputs": [],
-         "source": [
-            "import torch\n",
-            "import torch.nn as nn\n",
-            "import torch.optim as optim"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "bfCiUFXULAss",
-            "outputId": "83f6231d-ecc4-461a-b758-fdc4bc2a88a4",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "ones = torch.ones(10)\n",
-            "noise = torch.ones(10) * torch.rand(10)\n",
-            "\n",
-            "# elementwise sum\n",
-            "print(ones + noise)\n",
-            "\n",
-            "# elementwise multiplication\n",
-            "print(ones * noise)\n",
-            "\n",
-            "# dot product\n",
-            "print(ones @ noise)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "type(x)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "id": "ynNd_kD0LAst",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "# beware - shares memory with original Numpy array!\n",
-            "# very fast, but modifications are visible to original variable\n",
-            "x = torch.from_numpy(x)\n",
-            "y = torch.from_numpy(y)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "W9kkxczELAsu",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Jeżeli dla stworzonych przez nas tensorów chcemy śledzić operacje i obliczać gradient, to musimy oznaczyć `requires_grad=True`."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "8HtZL-KfLAsu",
-            "outputId": "47c6d930-5678-452a-95bc-227935138b40",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "a = torch.rand(1, requires_grad=True)\n",
-            "b = torch.rand(1, requires_grad=True)\n",
-            "a, b"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "Nl1guWZ_LAsv",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "PyTorch zawiera większość powszechnie używanych funkcji kosztu, np. MSE. Mogą być one używane na 2 sposoby, z czego pierwszy jest popularniejszy:\n",
-            "- jako klasy wywoływalne z modułu `torch.nn`\n",
-            "- jako funkcje z modułu `torch.nn.functional`\n",
-            "\n",
-            "Po wykonaniu poniższego kodu widzimy, że zwraca on nam tensor z dodatkowymi atrybutami. Co ważne, jest to skalar (0-wymiarowy tensor), bo potrzebujemy zwyczajnej liczby do obliczania propagacji wstecznych (pochodnych czątkowych)."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "mse = nn.MSELoss()\n",
-            "mse(y, a * x + b)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "vS35r49nLAsw",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Atrybutu `grad_fn` nie używamy wprost, bo korzysta z niego w środku PyTorch, ale widać, że tensor jest \"świadomy\", że liczy się na nim pochodną. Możemy natomiast skorzystać z atrybutu `grad`, który zawiera faktyczny gradient. Zanim go jednak dostaniemy, to trzeba powiedzieć PyTorchowi, żeby policzył gradient. Służy do tego metoda `.backward()`, wywoływana na obiekcie zwracanym przez funkcję kosztu."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "id": "Qb7l6Xg1LAsx",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "loss = mse(y, a * x + b)\n",
-            "loss.backward()"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "6LfQbLVoLAsx",
-            "outputId": "d5b87fb7-d284-423c-f467-b677384b2f67",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "print(a.grad)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "Kdf1iweELAsy",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Ważne jest, że PyTorch nie liczy za każdym razem nowego gradientu, tylko dodaje go do istniejącego, czyli go akumuluje. Jest to przydatne w niektórych sieciach neuronowych, ale zazwyczaj trzeba go zerować. Jeżeli tego nie zrobimy, to dostaniemy coraz większe gradienty.\n",
-            "\n",
-            "Do zerowania służy metoda `.zero_()`. W PyTorchu wszystkie metody modyfikujące tensor w miejscu mają `_` na końcu nazwy. Jest to dość niskopoziomowa operacja dla pojedynczych tensorów - zobaczymy za chwilę, jak to robić łatwiej dla całej sieci."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "DiCQZKJsLAsy",
-            "outputId": "2f779622-480d-43fc-b9d0-a0e36ff4b28b",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "loss = mse(y, a * x + b)\n",
-            "loss.backward()\n",
-            "a.grad"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "xNC3Ag8uLAsz",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Zobaczmy, jak wyglądałaby regresja liniowa, ale napisana w PyTorchu. Jest to oczywiście bardzo niskopoziomowa implementacja - za chwilę zobaczymy, jak to wygląda w praktyce."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "AKnxyeboLAsz",
-            "outputId": "2f939474-901a-4773-9704-686a40ae6e8e",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "learning_rate = 0.1\n",
-            "for i in range(1000):\n",
-            "    loss = mse(y, a * x + b)\n",
-            "\n",
-            "    # compute gradients\n",
-            "    loss.backward()\n",
-            "\n",
-            "    # update parameters\n",
-            "    a.data -= learning_rate * a.grad\n",
-            "    b.data -= learning_rate * b.grad\n",
-            "\n",
-            "    # zero gradients\n",
-            "    a.grad.data.zero_()\n",
-            "    b.grad.data.zero_()\n",
-            "\n",
-            "    if i % 100 == 0:\n",
-            "        print(f\"step {i} loss: \", loss)\n",
-            "\n",
-            "print(\"final loss:\", loss)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "2DXNVhshmmI-",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Trening modeli w PyTorchu jest dosyć schematyczny i najczęściej rozdziela się go na kilka bloków, dających razem **pętlę uczącą (training loop)**, powtarzaną w każdej epoce:\n",
-            "1. Forward pass - obliczenie predykcji sieci\n",
-            "2. Loss calculation\n",
-            "3. Backpropagation - obliczenie pochodnych oraz zerowanie gradientów\n",
-            "4. Optimalization - aktualizacja wag\n",
-            "5. Other - ewaluacja na zbiorze walidacyjnym, logging etc."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "2etpw7TNLAs0",
-            "outputId": "8ac35c12-6c70-41ec-bf57-414456fc3c96",
-            "scrolled": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "# initialization\n",
-            "learning_rate = 0.1\n",
-            "a = torch.rand(1, requires_grad=True)\n",
-            "b = torch.rand(1, requires_grad=True)\n",
-            "optimizer = torch.optim.SGD([a, b], lr=learning_rate)\n",
-            "best_loss = float(\"inf\")\n",
-            "\n",
-            "# training loop in each epoch\n",
-            "for i in range(1000):\n",
-            "    # forward pass\n",
-            "    y_hat = a * x + b\n",
-            "\n",
-            "    # loss calculation\n",
-            "    loss = mse(y, y_hat)\n",
-            "\n",
-            "    # backpropagation\n",
-            "    loss.backward()\n",
-            "\n",
-            "    # optimization\n",
-            "    optimizer.step()\n",
-            "    optimizer.zero_grad()  # zeroes all gradients - very convenient!\n",
-            "\n",
-            "    if i % 100 == 0:\n",
-            "        if loss < best_loss:\n",
-            "            best_model = (a.clone(), b.clone())\n",
-            "            best_loss = loss\n",
-            "        print(f\"step {i} loss: {loss.item():.4f}\")\n",
-            "\n",
-            "print(\"final loss:\", loss)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Przejdziemy teraz do budowy sieci neuronowej do klasyfikacji. Typowo implementuje się ją po prostu jako sieć dla regresji, ale zwracającą tyle wyników, ile mamy klas, a potem aplikuje się na tym funkcję sigmoidalną (2 klasy) lub softmax (>2 klasy). W przypadku klasyfikacji binarnej zwraca się czasem tylko 1 wartość, przepuszczaną przez sigmoidę - wtedy wyjście z sieci to prawdopodobieństwo klasy pozytywnej.\n",
-            "\n",
-            "Funkcją kosztu zwykle jest **entropia krzyżowa (cross-entropy)**, stosowana też w klasycznej regresji logistycznej. Co ważne, sieci neuronowe, nawet tak proste, uczą się szybciej i stabilniej, gdy dane na wejściu (a przynajmniej zmienne numeryczne) są **ustandaryzowane (standardized)**. Operacja ta polega na odjęciu średniej i podzieleniu przez odchylenie standardowe (tzw. *Z-score transformation*).\n",
-            "\n",
-            "**Uwaga - PyTorch wymaga tensora klas będącego liczbami zmiennoprzecinkowymi!**"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "## Zbiór danych"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Na tym laboratorium wykorzystamy zbiór [Adult Census](https://archive.ics.uci.edu/ml/datasets/adult). Dotyczy on przewidywania na podstawie danych demograficznych, czy dany człowiek zarabia powyżej 50 tysięcy dolarów rocznie, czy też mniej. Jest to cenna informacja np. przy planowaniu kampanii marketingowych. Jak możesz się domyślić, zbiór pochodzi z czasów, kiedy inflacja była dużo niższa :)\n",
-            "\n",
-            "Poniżej znajduje się kod do ściągnięcia i preprocessingu zbioru. Nie musisz go dokładnie analizować."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "4DNsaZAnLAs0",
-            "outputId": "70822008-530d-4173-deb9-8149a9fe5b41",
-            "scrolled": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "import pandas as pd\n",
-            "\n",
-            "\n",
-            "columns = [\n",
-            "    \"age\",\n",
-            "    \"workclass\",\n",
-            "    \"fnlwgt\",\n",
-            "    \"education\",\n",
-            "    \"education-num\",\n",
-            "    \"marital-status\",\n",
-            "    \"occupation\",\n",
-            "    \"relationship\",\n",
-            "    \"race\",\n",
-            "    \"sex\",\n",
-            "    \"capital-gain\",\n",
-            "    \"capital-loss\",\n",
-            "    \"hours-per-week\",\n",
-            "    \"native-country\",\n",
-            "    \"wage\"\n",
-            "]\n",
-            "\n",
-            "\"\"\"\n",
-            "age: continuous.\n",
-            "workclass: Private, Self-emp-not-inc, Self-emp-inc, Federal-gov, Local-gov, State-gov, Without-pay, Never-worked.\n",
-            "fnlwgt: continuous.\n",
-            "education: Bachelors, Some-college, 11th, HS-grad, Prof-school, Assoc-acdm, Assoc-voc, 9th, 7th-8th, 12th, Masters, 1st-4th, 10th, Doctorate, 5th-6th, Preschool.\n",
-            "education-num: continuous.\n",
-            "marital-status: Married-civ-spouse, Divorced, Never-married, Separated, Widowed, Married-spouse-absent, Married-AF-spouse.\n",
-            "occupation: Tech-support, Craft-repair, Other-service, Sales, Exec-managerial, Prof-specialty, Handlers-cleaners, Machine-op-inspct, Adm-clerical, Farming-fishing, Transport-moving, Priv-house-serv, Protective-serv, Armed-Forces.\n",
-            "relationship: Wife, Own-child, Husband, Not-in-family, Other-relative, Unmarried.\n",
-            "race: White, Asian-Pac-Islander, Amer-Indian-Eskimo, Other, Black.\n",
-            "sex: Female, Male.\n",
-            "capital-gain: continuous.\n",
-            "capital-loss: continuous.\n",
-            "hours-per-week: continuous.\n",
-            "native-country: United-States, Cambodia, England, Puerto-Rico, Canada, Germany, Outlying-US(Guam-USVI-etc), India, Japan, Greece, South, China, Cuba, Iran, Honduras, Philippines, Italy, Poland, Jamaica, Vietnam, Mexico, Portugal, Ireland, France, Dominican-Republic, Laos, Ecuador, Taiwan, Haiti, Columbia, Hungary, Guatemala, Nicaragua, Scotland, Thailand, Yugoslavia, El-Salvador, Trinadad&Tobago, Peru, Hong, Holand-Netherlands.\n",
-            "\"\"\"\n",
-            "\n",
-            "df = pd.read_csv(\"adult.data\", header=None, names=columns)\n",
-            "df.wage.unique()"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "# attribution: https://www.kaggle.com/code/royshih23/topic7-classification-in-python\n",
-            "df['education'].replace('Preschool', 'dropout',inplace=True)\n",
-            "df['education'].replace('10th', 'dropout',inplace=True)\n",
-            "df['education'].replace('11th', 'dropout',inplace=True)\n",
-            "df['education'].replace('12th', 'dropout',inplace=True)\n",
-            "df['education'].replace('1st-4th', 'dropout',inplace=True)\n",
-            "df['education'].replace('5th-6th', 'dropout',inplace=True)\n",
-            "df['education'].replace('7th-8th', 'dropout',inplace=True)\n",
-            "df['education'].replace('9th', 'dropout',inplace=True)\n",
-            "df['education'].replace('HS-Grad', 'HighGrad',inplace=True)\n",
-            "df['education'].replace('HS-grad', 'HighGrad',inplace=True)\n",
-            "df['education'].replace('Some-college', 'CommunityCollege',inplace=True)\n",
-            "df['education'].replace('Assoc-acdm', 'CommunityCollege',inplace=True)\n",
-            "df['education'].replace('Assoc-voc', 'CommunityCollege',inplace=True)\n",
-            "df['education'].replace('Bachelors', 'Bachelors',inplace=True)\n",
-            "df['education'].replace('Masters', 'Masters',inplace=True)\n",
-            "df['education'].replace('Prof-school', 'Masters',inplace=True)\n",
-            "df['education'].replace('Doctorate', 'Doctorate',inplace=True)\n",
-            "\n",
-            "df['marital-status'].replace('Never-married', 'NotMarried',inplace=True)\n",
-            "df['marital-status'].replace(['Married-AF-spouse'], 'Married',inplace=True)\n",
-            "df['marital-status'].replace(['Married-civ-spouse'], 'Married',inplace=True)\n",
-            "df['marital-status'].replace(['Married-spouse-absent'], 'NotMarried',inplace=True)\n",
-            "df['marital-status'].replace(['Separated'], 'Separated',inplace=True)\n",
-            "df['marital-status'].replace(['Divorced'], 'Separated',inplace=True)\n",
-            "df['marital-status'].replace(['Widowed'], 'Widowed',inplace=True)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "editable": true,
-            "id": "LiOxs_6mLAs1",
-            "outputId": "c95418cf-2632-41d0-de0a-9caf109de113",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "outputs": [],
-         "source": [
-            "from sklearn.model_selection import train_test_split\n",
-            "from sklearn.preprocessing import MinMaxScaler, OneHotEncoder, StandardScaler\n",
-            "\n",
-            "\n",
-            "X = df.copy()\n",
-            "y = (X.pop(\"wage\") == ' >50K').astype(int).values\n",
-            "\n",
-            "train_valid_size = 0.2\n",
-            "\n",
-            "X_train, X_test, y_train, y_test = train_test_split(\n",
-            "    X, y, \n",
-            "    test_size=train_valid_size, \n",
-            "    random_state=0, \n",
-            "    shuffle=True, \n",
-            "    stratify=y\n",
-            ")\n",
-            "X_train, X_valid, y_train, y_valid = train_test_split(\n",
-            "    X_train, y_train, \n",
-            "    test_size=train_valid_size, \n",
-            "    random_state=0, \n",
-            "    shuffle=True, \n",
-            "    stratify=y_train\n",
-            ")\n",
-            "\n",
-            "continuous_cols = ['age', 'fnlwgt', 'education-num', 'capital-gain', 'capital-loss', 'hours-per-week']\n",
-            "continuous_X_train = X_train[continuous_cols]\n",
-            "categorical_X_train = X_train.loc[:, ~X_train.columns.isin(continuous_cols)]\n",
-            "\n",
-            "continuous_X_valid = X_valid[continuous_cols]\n",
-            "categorical_X_valid = X_valid.loc[:, ~X_valid.columns.isin(continuous_cols)]\n",
-            "\n",
-            "continuous_X_test = X_test[continuous_cols]\n",
-            "categorical_X_test = X_test.loc[:, ~X_test.columns.isin(continuous_cols)]\n",
-            "\n",
-            "categorical_encoder = OneHotEncoder(sparse_output=False, handle_unknown='ignore')\n",
-            "continuous_scaler = StandardScaler() #MinMaxScaler(feature_range=(-1, 1))\n",
-            "\n",
-            "categorical_encoder.fit(categorical_X_train)\n",
-            "continuous_scaler.fit(continuous_X_train)\n",
-            "\n",
-            "continuous_X_train = continuous_scaler.transform(continuous_X_train)\n",
-            "continuous_X_valid = continuous_scaler.transform(continuous_X_valid)\n",
-            "continuous_X_test = continuous_scaler.transform(continuous_X_test)\n",
-            "\n",
-            "categorical_X_train = categorical_encoder.transform(categorical_X_train)\n",
-            "categorical_X_valid = categorical_encoder.transform(categorical_X_valid)\n",
-            "categorical_X_test = categorical_encoder.transform(categorical_X_test)\n",
-            "\n",
-            "X_train = np.concatenate([continuous_X_train, categorical_X_train], axis=1)\n",
-            "X_valid = np.concatenate([continuous_X_valid, categorical_X_valid], axis=1)\n",
-            "X_test = np.concatenate([continuous_X_test, categorical_X_test], axis=1)\n",
-            "\n",
-            "X_train.shape, y_train.shape"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "Uwaga co do typów - PyTorchu wszystko w sieci neuronowej musi być typu `float32`. W szczególności trzeba uważać na konwersje z Numpy'a, który używa domyślnie typu `float64`. Może ci się przydać metoda `.float()`.\n",
-            "\n",
-            "Uwaga co do kształtów wyjścia - wejścia do `nn.BCELoss` muszą być tego samego kształtu. Może ci się przydać metoda `.squeeze()` lub `.unsqueeze()`."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "id": "qfRA3xEoLAs1"
-         },
-         "outputs": [],
-         "source": [
-            "X_train = torch.from_numpy(X_train).float()\n",
-            "y_train = torch.from_numpy(y_train).float().unsqueeze(-1)\n",
-            "\n",
-            "X_valid = torch.from_numpy(X_valid).float()\n",
-            "y_valid = torch.from_numpy(y_valid).float().unsqueeze(-1)\n",
-            "\n",
-            "X_test = torch.from_numpy(X_test).float()\n",
-            "y_test = torch.from_numpy(y_test).float().unsqueeze(-1)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "Podobnie jak w laboratorium 2, mamy tu do czynienia z klasyfikacją niezbalansowaną:"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "import matplotlib.pyplot as plt\n",
-            "\n",
-            "y_pos_perc = 100 * y_train.sum().item() / len(y_train)\n",
-            "y_neg_perc = 100 - y_pos_perc\n",
-            "\n",
-            "plt.title(\"Class percentages\")\n",
-            "plt.bar([\"<50k\", \">=50k\"], [y_neg_perc, y_pos_perc])\n",
-            "plt.show()"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "W związku z powyższym będziemy używać odpowiednich metryk, czyli AUROC, precyzji i czułości."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "XLexWff-LAs0",
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 3 (1.0 punkt)\n",
-            "\n",
-            "Zaimplementuj regresję logistyczną dla tego zbioru danych, używając PyTorcha. Dane wejściowe zostały dla ciebie przygotowane w komórkach poniżej.\n",
-            "\n",
-            "Sama sieć składa się z 2 elementów:\n",
-            "- warstwa liniowa `nn.Linear`, przekształcająca wektor wejściowy na 1 wyjście - logit\n",
-            "- aktywacja sigmoidalna `nn.Sigmoid`, przekształcająca logit na prawdopodobieństwo klasy pozytywnej\n",
-            "\n",
-            "Użyj binarnej entropii krzyżowej `nn.BCELoss` jako funkcji kosztu. Użyj optymalizatora SGD ze stałą uczącą `1e-3`. Trenuj przez 3000 epok. Pamiętaj, aby przekazać do optymalizatora `torch.optim.SGD` parametry sieci (metoda `.parameters()`). Dopisz logowanie kosztu raz na 100 epok."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "id": "NbABKz5-LAs2",
-            "outputId": "086dc0f3-0184-4072-9fd3-275b60dee2e4",
-            "scrolled": true,
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "learning_rate = 1e-3\n",
-            "\n",
-            "model = ...\n",
-            "activation = ...\n",
-            "optimizer = ...\n",
-            "loss_fn = ...\n",
-            "\n",
-            "# implement me!\n",
-            "# your_code\n"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "Teraz trzeba sprawdzić, jak poszło naszej sieci. W PyTorchu sieć pracuje zawsze w jednym z dwóch trybów: treningowym lub ewaluacyjnym (predykcyjnym). Ten drugi wyłącza niektóre mechanizmy, które są używane tylko podczas treningu, w szczególności regularyzację dropout. Do przełączania służą metody modelu `.train()` i `.eval()`.\n",
-            "\n",
-            "Dodatkowo podczas liczenia predykcji dobrze jest wyłączyć liczenie gradientów, bo nie będą potrzebne, a oszczędza to czas i pamięć. Używa się do tego menadżera kontekstu `with torch.no_grad():`."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "id": "zH37zDX4LAs2",
-            "outputId": "b1f93309-6f04-4ffc-b0ca-08d0a32120a0",
-            "scrolled": true,
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "from sklearn.metrics import precision_recall_curve, precision_recall_fscore_support, roc_auc_score\n",
-            "\n",
-            "\n",
-            "model.eval()\n",
-            "with torch.no_grad():\n",
-            "    y_score = activation(model(X_test))\n",
-            "\n",
-            "auroc = roc_auc_score(y_test, y_score)\n",
-            "print(f\"AUROC: {auroc:.2%}\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "assert isinstance(model, nn.Linear)\n",
-            "assert isinstance(activation, nn.Sigmoid)\n",
-            "assert isinstance(optimizer, torch.optim.SGD)\n",
-            "assert isinstance(loss_fn, torch.nn.BCELoss)\n",
-            "\n",
-            "assert model.out_features == 1\n",
-            "assert optimizer.param_groups[0][\"lr\"] == 1e-3\n",
-            "\n",
-            "assert 0.0 < loss.item() < 0.5\n",
-            "assert 0.8 < auroc < 0.9\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "Jest to całkiem dobry wynik, a może być jeszcze lepszy. Sprawdźmy dla pewności jeszcze inne metryki: precyzję, recall oraz F1-score. Dodatkowo narysujemy krzywą precision-recall, czyli jak zmieniają się te metryki w zależności od przyjętego progu (threshold) prawdopodobieństwa, powyżej którego przyjmujemy klasę pozytywną. Taką krzywą należy rysować na zbiorze walidacyjnym, bo później chcemy wykorzystać tę informację do doboru progu, a nie chcemy mieć wycieku danych testowych (data leakage).\n",
-            "\n",
-            "Poniżej zaimplementowano także funkcję `get_optimal_threshold()`, która sprawdza, dla którego progu uzyskujemy maksymalny F1-score, i zwraca indeks oraz wartość optymalnego progu. Przyda ci się ona w dalszej części laboratorium."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "from sklearn.metrics import PrecisionRecallDisplay\n",
-            "\n",
-            "\n",
-            "def get_optimal_threshold(\n",
-            "    precisions: np.array, \n",
-            "    recalls: np.array, \n",
-            "    thresholds: np.array\n",
-            ") -> Tuple[int, float]:\n",
-            "    \n",
-            "    numerator = 2 * precisions * recalls\n",
-            "    denominator = precisions + recalls\n",
-            "    f1_scores = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0)\n",
-            "    \n",
-            "    optimal_idx = np.argmax(f1_scores)\n",
-            "    optimal_threshold = thresholds[optimal_idx]\n",
-            "    \n",
-            "    return optimal_idx, optimal_threshold\n",
-            "\n",
-            "\n",
-            "def plot_precision_recall_curve(y_true, y_pred_score) -> None:\n",
-            "    precisions, recalls, thresholds = precision_recall_curve(y_true, y_pred_score)\n",
-            "    optimal_idx, optimal_threshold = get_optimal_threshold(precisions, recalls, thresholds)\n",
-            "\n",
-            "    disp = PrecisionRecallDisplay(precisions, recalls)\n",
-            "    disp.plot()\n",
-            "    plt.title(f\"Precision-recall curve (opt. thresh.: {optimal_threshold:.4f})\")\n",
-            "    plt.axvline(recalls[optimal_idx], color=\"green\", linestyle=\"-.\")\n",
-            "    plt.axhline(precisions[optimal_idx], color=\"green\", linestyle=\"-.\")\n",
-            "    plt.show()\n",
-            "\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "model.eval()\n",
-            "with torch.no_grad():\n",
-            "    y_pred_valid_score = activation(model(X_valid))\n",
-            "\n",
-            "plot_precision_recall_curve(y_valid, y_pred_valid_score)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "vfQPIUQ_LAs2"
-         },
-         "source": [
-            "Jak widać, chociaż AUROC jest wysokie, to dla optymalnego F1-score recall nie jest zbyt wysoki, a precyzja jest już dość niska. Być może wynik uda się poprawić, używając modelu o większej pojemności - pełnej, głębokiej sieci neuronowej."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "## Sieci neuronowe"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "YP298w6Cq7T6"
-         },
-         "source": [
-            "Wszystko zaczęło się od inspirowanych biologią [sztucznych neuronów](https://en.wikipedia.org/wiki/Artificial_neuron), których próbowano użyć do symulacji mózgu. Naukowcy szybko odeszli od tego podejścia (sam problem modelowania okazał się też znacznie trudniejszy, niż sądzono), zamiast tego używając neuronów jako jednostek reprezentującą dowolną funkcję parametryczną $f(x, \\Theta)$. Każdy neuron jest zatem bardzo elastyczny, bo jedyne wymagania to funkcja różniczkowalna, a mamy do tego wektor parametrów $\\Theta$.\n",
-            "\n",
-            "W praktyce najczęściej można spotkać się z kilkoma rodzinami sieci neuronowych:\n",
-            "1. Perceptrony wielowarstwowe (*MultiLayer Perceptron*, MLP) - najbardziej podobne do powyższego opisu, niezbędne do klasyfikacji i regresji\n",
-            "2. Konwolucyjne (*Convolutional Neural Networks*, CNNs) - do przetwarzania danych z zależnościami przestrzennymi, np. obrazów czy dźwięku\n",
-            "3. Rekurencyjne (*Recurrent Neural Networks*, RNNs) - do przetwarzania danych z zależnościami sekwencyjnymi, np. szeregi czasowe, oraz kiedyś do języka naturalnego\n",
-            "4. Transformacyjne (*Transformers*), oparte o mechanizm atencji (*attention*) - do przetwarzania języka naturalnego (NLP), z którego wyparły RNNs, a coraz częściej także do wszelkich innych danych, np. obrazów, dźwięku\n",
-            "5. Grafowe (*Graph Neural Networks*, GNNS) - do przetwarzania grafów\n",
-            "\n",
-            "Na tym laboratorium skupimy się na najprostszej architekturze, czyli MLP. Jest ona powszechnie łączona z wszelkimi innymi architekturami, bo pozwala dokonywać klasyfikacji i regresji. Przykładowo, klasyfikacja obrazów to zwykle CNN + MLP, klasyfikacja tekstów to transformer + MLP, a regresja na grafach to GNN + MLP.\n",
-            "\n",
-            "Dodatkowo, pomimo prostoty MLP są bardzo potężne - udowodniono, że perceptrony (ich powszechna nazwa) są [uniwersalnym aproksymatorem](https://www.sciencedirect.com/science/article/abs/pii/0893608089900208), będącym w stanie przybliżyć dowolną funkcję z odpowiednio małym błędem, zakładając wystarczającą wielkość warstw sieci. Szczególne ich wersje potrafią nawet [reprezentować drzewa decyzyjne](https://www.youtube.com/watch?v=_okxGdHM5b8).\n",
-            "\n",
-            "Dla zainteresowanych polecamy [doskonałą książkę \"Dive into Deep Learning\", z implementacjami w PyTorchu](https://d2l.ai/chapter_multilayer-perceptrons/index.html), [klasyczną książkę \"Deep Learning Book\"](https://www.deeplearningbook.org/contents/mlp.html), oraz [ten filmik](https://www.youtube.com/watch?v=BFHrIxKcLjA), jeśli zastanawiałeś/-aś się, czemu używamy deep learning, a nie naprzykład (wide?) learning. (aka. czemu staramy się budować głębokie sieci, a nie płytkie za to szerokie)"
-         ],
-         "outputs": []
-      },
-      {
-         "attachments": {
-            "1_x-3NGQv0pRIab8xDT-f_Hg.png": {
-               "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxsAAAEuCAIAAABplJipAACAAElEQVR42uydB3wU1fbHz7l3ZmvqpjfSSCBASELvVZogIkWl6FOsWN+z69+CT33F8uy9UBQVKRaQ3qtKEQgECC0hpPe22TJz7/+zM5sQBFSaAt6vfGKyOzM7O3Pn3N8999xzJM45CAQCgUAgEAjOASIugUAgEAgEAoFQVAKBQCAQCARCUQkEAoFAIBAIRSUQCAQCgUAgFJVAIBAIBAKBQCgqgUAgEAgEAqGoBAKBQCAQCISiEggEAoFAIBCKSiAQCAQCgUAgFJVAIBAIBAKBUFQCgUAgEAgElzCSuAQCgeAvSlNRUxTXQiAQCEUlEAgEZ6SjGsvDIyAHjkJPCQQCoagEAoHg7BUVQc64R1gJUSUQCM4ZEUclEAj+UnIKgKNHTRFSV1vndilizk8gEAhFJRAIBGckpzgAAwDkWFRY8903y7Zu2cMY1yKquLg+AoFAKCqBQCD4faIKwK0q2dk5/33hy6cfn7Z81Q5VVQFU7R0mro9AIDhrRByVQCD4a3HkcP4zU/9VlOuLxOpWgAnnlEAgOB8IH5VAIPjLwEFVsaKqIjQi6KU3H7aFGRlvEFZQIBCcF4SPSiAQXF6qiTMA5JwjAiJpfJE3LfHr0rVDRocMkwEV5gSOwJFzhiI8XSAQXJqKSjdt2GTsUNgzgUBwPtBVFCKw43mnvEYGEQkBN7hkA9jdBg4uze4QDkwYIIFAcLErKu/QkGj/HZdTzRWV/qcwaAKB4BytjednRXllbW2twWCyBQcajKRRZqHKlIKCAq5S/yBfX18zpYDESZFRggzF1J9AILjoFRUA7Nt3MDs718fXv3Ontv7+Vk1lMUSaV1CSlXmQcZae3iosNIgQYdMEAsHZCyrggAS378ie++V8oxw0+fZr26a2oJLussKtP2XPmDZDlnxvv3NiXGKES3FyVVZcUF/rsPhRTqDRUa6v+BPmSCAQnBkX3Gog4t59R6Y++uH1I59eu36/2w2cMw5MZfjp7IXXjnzuxZe+yy+qFndCIBCci5zSBmqMcx4WHZa5/+D7781fsGiTy+lC7a2GBuf0d5fO+nDTkf0VhJiXLt0058slrnrTwazir2Z/X15s5xwYa1JUIo2CQCC4+BQVB56W3q5H33SHo+bb+duKimsRCUHpQG7lqpVbuFsdPLhHTItw4aASCATnOnzjyBhr3zpuyPDBvkHBixauLC+rY5wh8szd2bt27bVZw8dOGBIa4VtYdPTgwcMjRnVLaBWQm3PI6XAT0hR4gCIIQSAQnAV/wKyfGhcbNnhYp527sudNWzhwUNKYMT1lA5375ZLMjcdSerXsf0V7/0CjqFcqEAjOYeSGXIvOJEgA2PAh/TetzVq3ZMPsL7bcff9AVcX532zMOXSsa6+eg4Z39wkw3TT5eq7qg0pGODEbjJxD4/oYYYgEAsHZQP4AUydRSE1LSE6OZeD6/vvVxWVVOXl5W3/62V7luuKKbrFxNhlFCQiBQHBuaMkSAJGBkpwU2717RkhExGfTvikorTh4MH/HT3tr6mpHjxthC/IBCkaTwWQxm6wmq9lksZgIJfpKwEarKFzmAoHgjPkDfFSEcx4TE925a9r6dXt+WLtjz66ikvJjB7NyI1vEXDGwU1CAD4rsCQKB4DxoKq5FTUm+PqR37zarlkRu27x/xcpd9mrn/t1HUzsk9xuSSGQVNaNEtHEcR8KBaVHpQkUJBIJzkzt/wGdwDgbZ0LNP18RWQeXHqhd888PCRdtycwqGjurbKrkFpQSBCk+7QCA4JznV+ENzVUHHDq1bp8ZbDHTeZyu++3Z9VVHD9RNHhoYZ9TLJHgmFnGi/azsKH7lAIDhXpAs/agR9EU3r5MhuPdtkbi5YtfDHerXOHGgdcVVaqM2KXIuhEtELAoHgnOSUN6hcszk8wN9vQL9eKxev2bvlqOJUohOS+g3oCFxGzrEp+Fz7n/BOCQSC88IfEEeFBJGhajTisBH9kjLCSoqOVRVVDx7aJyUlQqKAelY+IacEAsF5NT0DhnSKbW1zOB12V22/4RlRMcGSBLQp3up45JRY3CcQCC4JRQWoJ0R3cZaR2qb/gJ6ylZoMPiNG9PMLCtTKRHgGiSI0XSAQnDejg56RWqjNPHTYQKMvBsUE9x3Y2mwmWuSUsDQCgeBSVVSNugq5UZYDAwOQKJ0GJLVLiTUZqFZ+BpsXphEIBIJzQa98hYgKh5LSakedo0uPNhnt42WZckBRwE8gEFwg/oC1ft4SfgYgx4rLt2/dwxXSv39qWKivhEA85g0ZET53gUBwntmzp3jj+h2gqAP6dg0LCyYS0ZKhi6gpgUBwiSoq9CoqBFyxfM2PazKTktt06Zrq72/VU3o2r5ksEAgE52EYxzkAW/T9qv1ZBS1axfTu09Zoljm6NItDhLURCAQXggs+XGPc848AOXy4aM7sBQfytnbuEZ+YGC5JyIBz5Aw54yK0QSAQnAd7A6ACcEQ8cODwhtVL6iqOjZvULTrWD1DlXOJcEh4qgUBwgcALLWY4B+4ZFeKerKNz5nzfUMvGjB3evkOM0UDY8bIPwhEvEAjOi6JinBMEUlZWkZV51O2S2nSMDAr206rUSNjMLS+yCgsEgktMUXlMHOeA4FTcdbUOQPD1sUoGCpwzzaihUFQCgeD8KiqGCgdVVQGJbPCM7FTPyI4iABWKSiAQXIqKinOulYVgngEiIiDRAqcYb8pCJXxUAoHg/Jkc7R/RzQvzmB6VImn+PkFhbAQCwQXhwkamH6/ljsBQT0zFEDgC4SJbgkAgON8mx5sLHfVxGnImNWZo0SSWcEsJBIILxgUfrnEERjQNBfjifz+4bvTDWbvyUWSfEggEF9r4AEgEKALz/Mo0sSUcVAKB4EIh/ZEflpeX//PWvQ0NDm0syUTxB4FAcMHUFCdAli/f5FSV3r07+1qNTW+IdC0CgeBSVVRNugkpR8q8L6Jer5QL4yYQCC6EogKAjz78sqS0Lq1dO3+rQU+OJyyOQCC4dBUVFzVmBALBn0J1dXVFhV1lwv4IBIILjogqEAgElycctAUxVPikBH+F1l787YTYln3f+NmpigGEUFQCgUBwPtEC0UUhdsFlx85XhrQccN+6kmq1+atq3dGjVXsqHX9eCRK2/r9/6+bnY/UQEvPI14crVaGoBAKB4HKycWIJjOCyQq0vzS2tdZ0wmY0Qft3yutyjj3cxSn9Ka3ev/deEG94pm7x0S35JcXFx1gsFM77YtLfo4tBUlXvW/N+V7Se+vqz2wn6OJBqnQCAQCASX0jjhFPW+iWS2/lk9OoO933745XLLjbP7tG0dYEUAn4mfzGZUluhFMq5ijuqyeqdKLvj4TSAQCAQCwSUMh6I5IzA49cWtDoUDFL3dM6jn2zth0YOIRqPR5Bcy4KPC41u7aqqmDzdqyMFt+76U2fROw9HMDweg/pYxbdQTy+q9xz/202fje1xx03Pvf3NvKypj98nrc5r7n7jCAffmHXHaFf0FajDK9Ljw2/Hy0LRg/ag4cmZBpVN/uXrakOhO//sJlj9DqUV7N+PVQ8edb6qbzb1e38sQEJPy9Bbvh9UUbnwgpWXqE7N3TE2jErbqf++COgCw52x/p7/35A0dxj69wg7ACrZOvy+h3eDXNhcteHxkoBF7/3PJrirPUepWvnp9RoDB+117/eenAzWNl+f7e3pJk9768Z07BiZbjEbrQ6sLqplQVAKBQCAQ/CU0FXOB2qB4e37VUf3DfYNxcSfO7LVVux4xrb27/T1rdL1QW/3ZuOB7D/59rbPeXnz0i35lj4y7cV41B7Dn7fzimbEb766y2+2Oot0bR2X/+8HJb+3xSjYqb14185/vzo59udylbPyoVyxtpiRSuvRPT7PMuOOOaT9lVzPGTojm2vHygBEPl0/edLiioaFw+i1b/tbthS2ldap+WPfuh/vi465t9RV2u/PrSVmPtO706mHPW8zNv55omLDilsVOu72ibMlE83Mjrvq03JtSju07tPu/j91W8WCZW9m78vURPvVHts569qYd91V7Tr5w59orM597+M53s0hExxvf2P/zovu6RV75/Pxih7L2qSGp/pA1/e5hVzwA9y45UGu3251bX4v5rOuo137URRVXUYqZ9ffu/3U/uDynxl77Yr9IfyIUlUAgEAgEf0GYkfW46+Cb4wGpwdji4Vdvd5VtzS4E4Hb7rjdfWBZ0/6z/dgOJBoR1efzdu+pWTv1gE4AlJm3ytP3Tx/hTSiEwLGjItf12Z63euN8r2VzAW44ac9udVwUgJeTEUuOYcOvMj964cVDBE31TbDbjlJm7ChtUzjlwqFzy+itrU9/69NqYKCshtvGvvzoKXnl9Rn29Wxd4bj5o9rpn2plMlMKVH6+8STn02YLdAIq6982n5qhTvnlnAFBq9U177JNHjVvuf2M1eNebEGPb/o8/f2Og52QIgjW+023Tdn1wjZ/n5G3hoYPH9dmxe93m/YgEPBsgJ4RKSAkCVm+cPWsZPr74yTHdYg2e7VOn/OuuYfyzd9fllqja8dUqUO9498mu0aFGeqo5VqGoBAKBQCD4a2CBti0TvXKHQFKrFPgx6xCAwrK//fpwxPWD0x0absYi45Mrag4cqtZkE2eK0/O600GpHBPfyqV6J/e46jZHJHfo0NnndJ8Yf8uMpUdr1z11ZWvzR7ekR1punZtZBmhfs2R9Ud++fYxGon+iNSrZCNkHD6iaolIMbNKVIySpMQQsoW2q++e58w8BPfTdV/ukm4d10/dyKUp0Qtsa5779FVoxdE6N4d36DfRrfgKcNZ28LEkxCa3cTD2FGMLarZu372wITfTzP/5dohLaRRSsWrCnvBSAoOKsjp0wLMUv4MziwERkukAgEAgEfxmQ2qHwrSus7zWKDUL9kjt3NCBw7izaPe9f7Sd+YDDoIkrx6zb+zESFT4+pCzZNzZ5z3fU3Tb9p6shus/oaTEFBG5/s2PqZps+TLdZWvoYmJ9cv8z0gSBLxbKeAMuMq66wmz49kjWs51tRMIzXfkXNHwY45z3e88ZPGk1f9ek2ip8wlgZy5E1tEWX2OfzdDdLR/cEDz2Up25pdW+Kj+IBRFVRSVi6w4AoFAIPgTIeAPkfdtcDbRYC/dufal6/3cFfvnT20/ce0Dq6u014t2zLw9pKROPYtPSL7u6ZsHx9kPHLQ7nJRVlvd+MetYXdPn1VXWbXupS4DZmyuO8WbihatuH0hNjgdANAGdvPz4eTrrK/bv/ODmQOCnEDuust1znup447bH1uonX7j148kh5Q2n8lEBUoPBmH0kt65GaXrNkXO4vLzOIJ1TRuA/QVExr0REvOxzxGgthXHW4FQOHiref6i4ts7NGNeAi0pdeUsFNVYM0ia/RVJEwWX2OAoEl1F7RsSz6UIpT8zoACXbtuU0rsrj3FlXVevkam3dgeUrIaN7/85mT1ftrK2qrFN+n8JQHXXVtXZ3k9JxV2VlFhS17dzKLEckpEb45u3YVlzu9j6Dir2qusHt7QJRhZ93ba2q10/GXb9j2z5H//Q04O6WaV1A3bI1q75J9rjqKmscp3YdqVU12cvXYteuvTtqJ++oraq2K8QrcRCBIiiKoh/Kp1PPLp38S7KKyqq9CebdDdl7fy5JGH5NalAowFmXrSJ/vJzifx37xjzCpK7BPmfeigce/s+zz39w4HAhY+yS6G9E9yO4/BQVb0z4KRBc0m2Zg7uhsqyspKxUp7zOBZyzZlqAs18M27m39yW+pivvf7FN9rO97ltS4dn16N6db93a8b6lNdTf0qpTF1qb+fP20tLS3O3rZ/39njll/ibS9KlaqPkpOTDrwV5/u2fhD/vLPKdUduTzZ15ZfHDg3x/tFOIDyROeuq/V6uuvff/nPUc979YufbTT1W9uqGzQypZTyXjw82FXPLG+oKC0tH72hJGLE255enISoAGH3v9O/7IXMiZ/U+k5Zv6RIx/e0urm70q1R1g7mWbKh1pNrTt1gqo92snnbF392QP3zy33lYm2iX9gSNv4sH0b1684UlpR53Bb0/sOHeh+4+EZa9YdLC8tLc3/6h/3v7sr/NY7e0YHawf3Oj7OFBFHdQFRCNRUuz748Nt33prvrHb7R9bX1F68SfnxxGIdotcRCASCixFDcFIf8w/39u/mUvUBuinqsXk/X2+OaRtJA/XwJOrfMjY+uCnuGtHgnxifHmzUtvZp9fC2vKTbWt6W9LULUIpqO+nVvdMGGgAg6YbXVheOHj+m9WuqIfWqG+7cNH3PU6vMsucIksEnomOSK8B8yr6h9S3vL/J/9N7be91a6DklYgq67dNdjw+I8dXUzhXPf7cmfuItE/q/VckYmMMfnb/lgS4WSRvnKOj824dFfRb36JhR5XIb/O797sj/eusOHxI1ZdWxxHvi/taytQtADowZ/vrhecN9ABihxuDuiYmhvsdPxhrV9m+vrigad+OY1v9T5fTRk6es/XjPvzeaZO1Q0WlDH3p29w333Nf5jdQHF/5vyqAe97w9P2bqg0+N73G7mwGVW46fsXPqkBaB+uWyhLRITYywnHH2eeQXePJJnz5Cz0969/1PL/nup8+/fKNr12TOFcTLuT4E56y8vO6dD2e9+epM6gomaAyMCHrnw//r1S1aW4qJuifyoqK590xE2AkuZfTxOB069Oaikvpvvnk3rkUA0/xTomELBBcPVZ8MbHVL5FT7zCnmy0EJCPNyIbSUR6TW1tVMfWbO61O/jQ5ObZOahgqXCEdQG0cMF52c4h59DaTxn5j1EwgEAsEFBbmqAuPcrVwWX0fM+l0QRYWI1VXV2VlbElJtd04ZBar/o9vXGtFGVH3ojBf0o89OTjk1fa15SD26zw1gAKDidgoEAoHgwkBsbTqkBwYTRKGoBKcW3Yic8+jomH8+90itvaZnn+TFC3YhdQJnBAHPU8vhjVk8EPX4J8RmC/ROnEw9fXCUZxeOoO3KORDkHJjngPor2iao7ykCqwQCgeCviEN1HWkotMl+YcbA83tk32veWXbN5XOhhKK6IIpK/3+3Xgm6bHEycAOxU6IQ/D0eKt7oyMJmiojhCTqJcc44I8Ap5wzQiZKJcYUA06LWCEdJU0HacRjyJlGEJ6gsxjlXEalSXaMcPCCFBZHQMLtZxqo6diRH8Q+k0dFOA1BAGageZSXmiQUCgeAvJaem5y+b8vODYVGjtrd7ONIULK7J6RD94wXEpahu5ubAPaKmUW41ahne7N9pJBU/aQtvNjTtaFqVIo7UVWOvP5hrysvXRRcvraTZOXJZBR5P04AMkWnnwLQjqBwU1HxRCIRSRqEs/9iqx/65+dkXXQVFVgfL/nbBqpvuz9u6lVFQL+Q0pUAgEAguZjk1LX/plMxnwSe5uGTdDfveE9fkVxA+qguIgdJTRNtxdlJQ+i/1iu6Lakq0oOdCJZqgUoGrnt+RcKZqLqjqvIL9H85IAAh/8kFZNu3/fB77eU+b8aOkvt2BGvWCklxlHn1GUZ/jU4FzVdW8aUgAnKBGtk7ufuWIbS+86275raF9u5KXP+neul1oz54cmAwyCvUtEAgEfyWczJ1Vm7O1JvuuzGfBGAayj+Tbeoh/srgyQlH9SejL507h4Dmes+J0YVW8MZdB8/1d6JFTknd/lDkgcFNsdECb5KOPvO3bu6e5vKr0f59aR/dREuLAaCCgx0MxlnPMfiSfxkcaYyLcBoM7P9+RfcAnMlqKa6EYDBSoKhPz+JFROQdyPv4usmhei7QAnwducoeFcEroqeYcBQKBQHAZy6lpx5ZN2fUEyAFgsAE1vtxi7INxY8SVEYrqT1JTnAPX9AyeOK+HwIATr8eHn05OeYWUyy073MxkUGSKAFQFqcFNKDCTrCJIno9gFj/flCsH5W3bXfzfD2q2FcX3TWwxfhyLb8EavUociT2/YNkL/4toldDlwbshNPDQtFlF8xal/uuJ0NhoPbKdATNGhaf26f3D28vyYVe7jk9AuxSnRBgQA4iKNAKBQPCXwMXc26qz99QfnZL5NJiiQfZr5ZtwR1DHf8SOFhdHKKo/DURUKSBI2vI+CkCQAwIhRNZiqbjm9Pm1ijSEM0dufs3qLdg6xr9DO6fZrO7JdW09YE2JljukOE1APLKLOAB4TLRpwtXko37VAAGT/66kp7gkYtbSSqnA7YD+GWktBnRzPP0xhsVUhfqUPjOn//j+cucMMErImItoAVhVVUU/7/QL8POtapezeVvE/gOYngpaBXAEryzkF19WUoFAIBCcLzk1LX/ZnTufADkIjOFATS/Fjn1IuKaEovqz0KsBEUI45zU1jpLSatlAyorLKSFMVQoLyw4eMksUoqNCJNmjmvR48V+qMc21xRDtDsfPCxezbx2DHv8Hj4/e/d679qyjbf/5QKiBEG0Trt/C2jp+KMcJ7Y1QCXuPkrIKGhnW6OjiBNx2X3OXG8cf2HMk9625vKIudkg7+vBtaoCNAyEABAhxuY99s2TngpWD777GHBW44NW3lU+/iouMIBHhnGtTk95gdk60rNPIuYIeUUi0rA0IoHqTLHh/IvNGvmsThkCOvyMQCASCiws3VzdV7j5sL7oz8xkwx4DqAGp8OX6CmOkTiuqi0FWIuPmHrM9mzkVC8o9WQQOUF5VN+/iref5mWwB58eWnLXJjcgNvyqfjqaSAAwGuEgxIiE3/27VHHvlv9asfG3u2V5Zu6vDA5ICu7VXCiUfEeFSTgWHdzt35H82JeHh4YFbRsf/MD2+VGDDmSu5r1XJLKQZQFM4gNjK6f9fM2SsSYX/wgCkQF2WXJALcwLkMpCK/uObzhUmtWxvHX6MmhYaU5rneXVA7ZGBgeJiiMkmiWo1Z1KcwFc45Y5yirLuuPN8WVO6NoEeOWsp1fjyy3qOoxIJBgUAguBhRuDo9f+ntO54A2QaGMJAsA4O7D/NvLeSUUFR/PojecPTaSldubr7brUrgm9ohnXGporImv7QkNJgwojumGIBKG++CW/tpAOAUVM4p44rVJPfuGHnjoINT32s7/5u2t00yjLvKbjJwYEZOmBbWXpVzaO+ns/xK6iNvHE/KKg/UvVw37esOLWJo7wyQiTa/KMtIaupqajJ3+YGpEmx1P/3YYkQ/8E9kwLVZPNaAbvOk4dFtWpO4cJeBptwwvjwuxhEQ4DlBShjnBNB5pMilKOZIm2IxK5T4VtWUVVT5WX0NIX4qggzUmwWUcQ7opiB7JBbjDHTlCGLGUCAQCC46OcWm5S+5feczYI4GtQGo8T8txj0aP05cGaGoLg451biQr1fvjpFRT6mcIzdxxjgQLqHC3RaDYjDobhvOtXnCZlqDM23KT18DyIHJFkNAdFQ+oAtKA4MCFV+r0xuExQkQWVXspRX1gYEdn7idJcdhq8TW991av247q60jLhdIZu2YRKp3Z8/7tvDb9QMfGGunbOPrcyLaf2+650Z3oK8CBLk7Oi4O4hK1+s4cQDXHxyfEJzIg4GJIPd+II6/dsHXz8lVdRvS1XTUYXK6a92dl5hxpN3lSYGhbUJh6rKiqoCA4LBTi40BVHUdza8orbZFRGB523PcmEAgEgosDDnxp6ZZiV/XtO6eCMQyo6eqQ3j19Ex4WcupCKyqvRuAnLPnySoemHOHCBdGkq7SfUVFyVFTSiVexKWW5qjY4iOJEk6wSwgmiixnsdpAkl49Zj21iAJLb5dyfnfv1spDWbR2xg7YvWduqZ5ppyFBFIhwVChRAju7UNbprVwCoAWZgasTokTB6JHDuQCZpoUwqZc7MLNebc2N6drbcekNdkKVNcUXVM59ae6cbe3RRjCZzub2ipMQc4mMIsFFi4IePuTnHqEg0GlUDkfUIKoDwtLbKrDkVU16NCrSVVJbnPnZ3xn3PWBNiFSCUqXWZ+7c/9Fx6z86hL/4fb2g49uSrFUWlXZ56QIoM51oed1EiUCAQCC4eOTXt2NJbdj4Jki/IfkAM/4od93j8deLK/BGKSl+epuspgqhyjggEvUkfGedCTJ0M0zIoaPnN9Uyfqh5T5AKJqKzhwLH6LdsiEuNJv+5QZ6/dccC592Bo5wyeHq97rxiAWlxy9KtvSwor+j98mxIfvvehZ8qmz4tOSqatElQAormqFM/hVVdFOdQ4pYgQbpHUqtqaikqzrw8G+XNKCUA1Mv+JQxJ7dGfxkUEmOfi2CYdS4hXkNqYgcKiuy571VXRYSPTY0ZW11eWvfhSQ0dZw/UjJYGSNYloFUNvG9//HLUcefK74jU9qjpS4R08IumuiKyiAMoXJ1Ng1I+HaoTnTFvh0XMgBKpdsSXh2sqFTMtOSZumnKhAIBII/nYUlmyvddbfsmgrGcCDy+LDeqeYoIacuuKJijDU4nSVFNbIkh4TaDAbOGlfQqyqUldXV2+v9/X38Ay2o6a2/fLfJOG/yRHlUJwWk3uvsUUmKNsWn5S8nikvJm7OoCqTUmDBWr2S/Nd3tUkK7d+XaOjnKEbhaW1jEDxe0nHA1GT5AsdKkW8e7Fq4qzT4QkhjnlqimZ5lKEDgrz8mtnLsiafQwKb1N+dpNuVt/Thw2SA5or1IicRLQrk1o2xTmY1WAq6Aae3WKT09BYCBLLgAIsgUEh5RM+zbK6HN4d6Z97c+xVw1Fo6zFeBE3EuRAgDUgt/Xo0DC0R8Er/4wHY/Qrc5RWcU7gFkSJo93mHzHuKvu+7NJ7XpEhMPquPpFXD1F8LJJWDKcpoen5C1A/fflngUAguKQ6jl9Wtz8hA+B5NnEz8pfdtPNpkKxgCAakz8Vd+2TCeHEPLrCi0jNlc5afX/ryy18aGBl73dX9BiZxvUAvkoKCsrf+N7feWTNq3JV9+7XRoo+P1+P9y+FN18S0tW/IkFEgAKTW4aouLmtwuiiVAoL8/P38VAQrY4Agp8Qnjxy4+e5/R7/0hjsoDNdtS3jrUUiJZgCEA3IuITFERUU/fJ8lLlIJ9mOEhIwfVdstnfj4AiID6kYGoEocOAX/IFvZjqxSxR1aXFL7+TehIUF+gTaQZQWAIsgN9mO7siSbNaR1kmQyV+7Zpx4rCOrUgVgtBg5uX3PLCWP2Z2YeefKdqNID6sx3Sd8uTqNsAoacKWCQPJ/ipkR2Ox0NFdUUgtzgdOQVh7oZlxGZR9o5JJDiYkjXDHnuNBmM7s43NMRENgC1acYCtQWBnq+F58VCcKGoBALB5dJ56PmYL7ii+qZ4Yz1z3LTrn2AMBaUOEP8Zf72QU3+cjwoAfK1WpjZ89NH3x45Vt0l/LCTIrIBSU+uY9cW3/3vto1FX9wsP85GQMBDxx3reJsYQKNKS0rJvl2T+sHlr7t5ch8NOiBwYE5aRkXLFsK49UxMZgMtsDpw4NqKipPSpxzgkxDxzR9iVAxzopiAR9EasB0RGuCIjODClphZ37XOFBdnS04Cz6kO5cnm1JbklC/DVhCzxjYuzPTDJ/vc3y1792DR2cOBtY9WkGAJg4NyBxCSZDm352bFgVb8pNzl8jFvemtamY2fM6MABJS3ICX2sgaEhxaVFQSBZYuM9e3A9xJ4bAVSgHMBSXrPtrffUaWvT3vrvgYMHSm97JpxYTRPHOowSAPo6Xe71W92zV/C+Exli1Sdfx7ZqA906OwlS7vkUIAh4PFnoOdmKU04yC2UlEAguPTnV5Ljnx//0dqf6Wyd7sM6GcZkvzS1YCCiDHABUXpD6L1/J3NeWJu7BH6eoKNLAQN8rr+y9ZlnW3syc5St+nHjdAAaYe7R03tzFMf4tu/fs3jIp6qw6NDwxzh1P7fa5hJ4M74o9pCjl5Ve8++4ny+ZtC7cFZ3Rv7x8a4HAoB3ceXPTR/APbtyp//1vP7ulEK7incm7wSBbCVRVUlXEkIGnfnCDqU4ja8KWhoXD5ysP1db0mjQeJbp35WYRPQLsWLRgS0Jw/jFAaGIgEHXDUbJDBbGASUuDEoz64K8A3Y/Sokp/2FX88j9XUtEyIajFmlGoLVBAo4RKQ4h+3Fm3JbHnLuEMrtykfzOgcFiwnRauIKvcchAFXkVau3ZD5/bJBD1xtHHtVeFmJ5bMt275eGNctw9Smtco5O5y389Ovgp0Y9Mq97toa16hHdn35TUpUDGsRwfUjeM6EUA76LKCei+tsVzNoQX2o5+1iiKKIs0AguLiUkraImzfKJdRXaJ/G4KHWfXBtrTfX1BM2Cit+kvvqrOXUIpD8QKkDIq9u/1Q/W7q4S3+0okJEoyyltk/q2L3N0rmbv1+4etAVvawW9cfNuzO3HerbfVinLh2MsqwFquMZ6qnGRnbZOKg8jR8RsLqq8pNp82fMXHNjeER0hKVf94Sg3t1UWT7y2YJ5hw/vmJP5b/d7z730dIf4kLp1G/M/X5Ay9GZ7kG/F56utA3tb+vVsAI/EQe+zx2UtrB39fAPat6WvfVJW/SkaZTlrX9gDt3N/XxVA1oWJvaFq6QY5LtCWOqX8SL7fuu3W0Cg1wA8BLSrWUEVKimsxauCO+1+Jr9wScv8caBvnkmQVmBuJT9ahHR/OiAqL8LvzhoBBXYuv/7+ahCjr/be4AwKAUpN2s9wA3BaQcf+UgG6d3WEhvoF+lg8fdtjrJEoJZ7JbdWZlK4xF3DeBd88g1dVRj40rP5wv7T2itoj06DZK0COqFAkoQ2SI0jnZCK7FyhPkTMv6LhAIBBeX68kzZEamew44A0T59GGk2Lh0HvVqsNpw2jMI1TrWc+olJ+15TeHq3MLFIPkCZ0s6vmgixr629uIe/YGKije6ATgCgbBwW78BXRZ9vXrP9mObNu3r2jVhzfLdJvBP7RqV1jFG8TQWOHV4zEkNiAAoCA0AbiTkN2Ku8FK8mgbAH7cd+OqLhT0HDptwXZef333HOu2L8G7twcmqZs8bkxTad2j6xNfnfZm2Kvna3jvfnZnsNvm9/iTNy99+4Pni92b0T2pljArmAE4Eg1elaQMYs8WvX++OR/NLHnhNtfp3fX6y1L+PwyxLwDwjG5Xn79xdsmJd6i3jA7t3znvtzQ3z5mS0Tgju1lmlhKPbyNAIrC6vkFQ6C4D4Zx821DnRLAEyAgRkmjxqRGhSsqttQnBKXNhsWTUaVC5x/Ra4HKSsyiybeOeO8V06Wt0cjhUzX1/3kB6xQKwGCyDh4Kad0ju1TbZGhbtkA/UPDLrj5uCKCgwKcQMn5TVk9xFiM2NSi3qTZKm100OHwOWG5CQI8Ds7+QpAGHBC6PZteRs2bxpwRc82yZFEqCuBQHAxDLA9QggpentYhioAg1PII9Rn+rRQU0AkumuCMbdnf0LPsSu8fs//Zucv8vxGrcCVNR3+I7TUn+ejaryPFouhe882LdtFFmfXrF7xAwPHjs37E1rGDxjcxc9HcnFOtTVujY4n3mxXPLmZSUgkAOV8Lvu6KEYkqudqoqLADxv3OOzqbVNGpqRHBRdcUXHLqzWfzS0qK3VvzO7xxQR71/S4lYfWL1l7OMLs7xvY7pnrITnBGGJLuuuGmm9Xw487pNGD3LoPWF8+yQkg9zyOFrMcEqTCYbU+yuzr02C1MK4Sj6ICriomladPGh0woBfERCXcMNZnww9mBqgwkCSGipFL2Ws3FMxf1uGeqyudvdcvWNytfXvTVb3QZPSMjWIj46LD0WByUEYNxHLNMFVVESkQdIPqcDp3zZ5nLaxq8djdskHOnv5lZXVFhxsmOuODoKLm2Nof/YN9w9u34eEhNZk7S388HNutN1jNDdERhuhwN6iecVZ13c5vFtcU5/W852Zjj04VP/647/1pIV06JSe35Cd6N/mJol6bHMRmGh+1KoFayyEUOaxctf6t1+dt37q3RVxccmK4TIgIphIIBBdBj8AVxnMO5M+bszAmJvL6CVcT6XR18Ym2qt4zPszcmb1k8YrU1LRefTqYfQyN1vFsusobsl6zq+75RcuAmsFdA0Ra3+GlXrZUcWv+DEWFTfLIc0Mpp7ExtjFj+774xDeb1mTm5pSUF1cNv653717tGQD1bEM4AOOq57fGe+/dv/FPXYfTBrV8y97KygJwu4FTwKbib+cn+O5PVFQeUcWd9Vwq2LQtlRD/oqLK1YesgGXJ/u7H3vCBSvn5R5RBvYh/4OAeHb7/9ktnVEj6fx+EkFBgnJosod27BcYmQmyMAxjYHc6aGrT4GH2sCuFu5AbGlX0H9yxeGdBzBEGatXBlYueOxnYpoIWPo2wITG9L0tqA1cIY88no6JOcwmUZDAaPHAMj5pcUL1yJnVP8brmOGQl95f3K71dGdU6RYiMZoGqQqRYIb+DIgHOZUplyziUAiREwmKKjorM+/jYsJAjCQis/nht1z0TJ5mcAQhqUhg2biw9mh999W4M1IPuld1LatsMe/YCDkat6dCUSzsP8/bqn1k5dUTJtth9zl38211jmCOncCXwsJ4cVNBdVjVPDje8gY6hyLhEg9vq6r+dt+vi9z44dcrjtSFTGQNQOFAgEF4ePClBlSm5O6WczFnfqlHrVqJG+/sC0Pu+Um+tzfjmHC776fGndKFOHzmlmH8KxeVjMGdi2SXtenVW4FLgKxARq/Zoub0hIegYKOfXn+qi8t9Dz08/HMnhwzw/fXHl4/8Hiw5VBMf6Dhg3wsRoVLTZYy7LEKdEzJAHTKqno4pppuxOvE5S4Kx0bZnzTgEUmh5OBDOi+5CLQTyuqVGYER7VsyT/iRk4Wv/1lp4pdgQ0un+xcAvkmAGOgPzObCMEQWyBX3BhiMyfEM2AKR1SVo9kH3T9kBl87Bt1ux5LVBZl7o8ZfY0xOVLWH0F1Wvn/2vGO1da0eudPpdP30+nuOWXM6/P0uHhHCGUNCiK+V61PxnHOTCU0m/c4h1+IhZbnt4IE0PERJSrAYDV3uutV4rBAtZsr1qG4OjVHi5Lg7UZvKR64YDVH9elRnZ9c9O8sZHRDWLzVy2EC3r9XEOQQGRAzoXbtmXcE7M4y+tgCFBw/qp5pkjlxi3jJ+MnDVag3v00WeMPzQB/NSdh0GVYm7a0Jgh3TW2GCawbSay6SxYLRHcUvcmyuBIXiuFeOEQnlF1dx58xNbJmZkxC1asJAS5JdNSxIIBJe8jwqoJCWntHji6buCggPMFmD8V8qKaOYWWGpaq4cenxIbH2vxNWoRN2fDhD2vflG4DFAGxQ7MtbHL2z0C24k7cjEoquPKiiAmxsdec8PAd1/8WHbbUju2vGJIuyb/EiGcM9i/7+C6VVvSMlK7dm+rck68MzXeVBt61Ro/k6n3lf3TYiXuciOXOCqglwy+DJwLHCXmqjf5bJu1Jmtz5tCrhsda2po3ba3cs8kBSMG/dOGKtj26qultsvbvoxYfk8UKTEGuNlDZRGikT0DevPXFB4p9Hhqzb9rsFjFJvqFBoLi5JCMH7lDiwqPC+/S29u5mVJSesmw9VgQNzubFf7Dp2Wz2JwFknLtt/r59OrtkyU2IkaOc2pKnxIDRDL8eeaRN4LoBIcSGPdJM9VNhv8LuvcodHuIkxE8Ft9nk2yk9bcyozAdeSYbwtE//wTqnObSZN8kbHsApB4VwJSwER/RXF6+wbPo6YvidUp9eTj8rMi6fOOun/UZ1S8I0CUX0F7QFLxSAav9pSUmDHn74lvDwqNWrDixarDIGQlEJBIKLxkcFBCE8MnDENX2pRIjE8VcTHBMCjKsxsSGhEf1RIpJMUI9iBvb7P/SGrNfy3XWrSzcBSuCq3ND1HQmlroFtxO24uBSVtg6BBQQYx47p+eW0+b4y7d23bYjN6AYVkWiL0ujB7LznHv/kYHbuA49Gdu2OTCVaz4dEC35xN07+2YMMgQM7hnWMV5gWI3S8ueCl/vwgggPAgiTewedlZe3wCW43KHXXuh02SJOhoQaKpcVznald6grZunU/teuY1iI+tMEjEiQL52gyBKa3ke8YvuiJt8Z9k+13RZDpppG1AT4yBzPjHJkcFmC5YRyzmsFopMAjhg6g9Q1gNeMvMsGdPAZCoBy5TJlsNoE3oTuXZS7LcHxpL57mBiBwMHBOCwrZnMXlbftYTRbXt+uMA68giTEOmXBgFo6O8honlFeALaiihridgEZKqZsAZVrdaAQZ0VLfgDv28U1HD0MEPZgTu2e3MTZYoUSbWmx22nbHnkWL2erNqVcOI4P6EgLFc74uWrM58eqRxa3bNnALuqlZdkVFWi0WY6euqQbJtH7DAe658Ew8zAKB4OKBIBKJyj7mX+3hGhcfMUSQCAWLWeJaXLIWo84a02b/dv84ac9rswqXe4bAigOYsr77+2Ka72L1UWldq6pATZnT1WBPSmvRvUdnPXIYgSHQ3XsOPjf11czNxX42f0WBZpnTf1nOzSGhyyC7zSbl8vIoIHgEpFvLZdBjQNf4BRtf+2S6T04bXs3bv/n3wk/nu36yJg/vtGr5TxvXZznr7TfdOC7AamGACgfCmcqZ6m+x9OtpDp1WlbswPnmq1LJFDYCMBLUFItxodBvNCJwypiJyk4GbDBR+V8oKfSOi1QHkTdFJHJuFe59aUXGOKjBQlJxla6tWb09/+h/o679/ynO53y6Ium2Sy+YvNbjyftx2ZM36HnfeUUfM6xcs6pDeytKrO9OWrTBQtcPL3OUu27U394t5kcPSo6++8uiHXxR89W1CmwTaMoExfoKiMpr8QsIObNixb1du66gopbJ856vvJyYkF1XV/eeV1w/nVqv1JDk+4Jln742OsRFZW43K1RMXQwgEAsFF0Sk0VXfQK0Y0WeNTGGk8nupTH5836yB/I3v2zXveyHSVbavYAUjAWb2+20dmaujo3+qCfjt+5imThKJqfsdpTXX17BlLfSRj564pCfGRKucECQJjoHBQ2rVvmZHWeeOa3Vx1IoCkR+d4uzqUvKVIwKRwk8oNAEZPX9o87u6S1lfelmXwCEiekhhz310THnvstbdfOtp3UIfk8IR8a0BDbENOcvrnu1ZkF+bd+ujE4UPbNVSVV+3LiQwIVlvHoMpJg1KzaRfJdUDYVcX7DkfsPezbs4Pmw0PGCQeQG5843XtMOfz+TCW/2BC1fCdNT+npDuPWF/VW2csqqqMnj7UM7acg2h6fVFlSEFlazmxBWFBQPW8pTY413XOjS3GyJ7LccxfRjDbE148B5YSoWlked3FF7twVrvKGhEf+5hrax2Kvyn/6E2Pq0qjbbsRAvxMsB4XIbp0st4/f+cJHfq9/ZC8uja7G+HtuqYyO7Ko6k1vWMTePCvX3MRmBg8rdFKn2aBPG9XA9gUAguEjQY160PEQe40R/zTbjybVo9L2YlpFQOp2t/1vW6zMLl2ur52VwFK3t/rFY0HfxKyp0uZTtP+5e/NWaxIywHr2SA3wNWu4yb4No2TL+tjsmbv8pc9OGbVwLo2HIqbdR6FmtNC8Oawru0aaI8bKpd3uCMKQSGTiw03vvPPby/2Z9tWXDioNbI4+W0HrlwLwFUYSlhbhv9iVWleV9uiBr2/bIO293AkVFqdyybcf0L7veeqU8dvChl95umPlVSkqC4u+jEK1QsecienPuUtSz8R4f3Zz5uR4fAf3Kznr8ErWaU0ZfZTabWKAfAkRfNzKiulYODjQDkEC/mOuuSggOgKREi6p2evohU4ObG4zoctO8HCCSFBbisMg+qrt1aCC/71Y6oDf4+YWOGm6KjKK2QACuItPaCdN/cFDcRhp0/aiQouKG56cByHHvPOlKSzJZLeNGDQWuVRAkxGq2MMZN1AJAjcZAghaLj8EsS3ptb29yVE5AeK4EAsHvgDHWFFOqjVv16bYmG8K08SwnjapIZYw2bq9yb9TUSXKKe1UUAuNMm9j79UEw0fvG5va5cf7jFHtNznpzhT0/r2afx9657aDWr+8+/fzJKc656tF0ekotLZW7viDRe6H0kB0U49gzVFS6c6+qvObj97+oBWeH9I6du6SgNzunfu/RaCT+AVYqMYU7vSVHuEoJPWtdcukqK32W02KWe/RMe6NlzM97y35an7l34ZKaqsqb/+/uoR3ic955P2vmzJZWenTW962H9cb42HoAn8qqqh9+atmuZehDd/FInx7jryn+fFH51q22QQMbEIy88cBNGvbs3K3YPE8Y/uYVp7r3zWKwxkcf3zk4mAYFAYABAAL8/Hp3QUKBosTBt1NHUBnIEqutObB48e4tO6+8607SNT1r97aGdetb3XMrBAYQ4HJMdEhoGAfkBsrQo7P1J1UL20SmhZ1XBlgscNAJRDHJRJI4of6+Zv3zVX3sxnHb1gOFBWVbfsx2K+51a/aVlhT26t01MsKGFKhQUgKB4HdrB0TcvWfftJnzBw/u3a9PN6P8S+nDOeOAB3IrXn75lf79eo+5ZmhuzpHnn39/0NA+1429ErXl7r8wy4rKso/kTpsxOzEu6fZbxhBknP9KghdyYj+IzdIQ0VPKqWmFy4ArgBI4Ctb2mG6Tfdr5xJ/P3gy5XgUfEDjRkiJq01K6ogRCVDEtcKaKSteknHOrn88Dj99278M8JiYiMNAMwAiQxmBglYNKCFJqNqCvRE0EtOJ0nHneQtqkuBlpPrd30kzU5YPnu1BKwiJtg0KD+3aOPbL1+4bs4vRhadZQm/W+m5UPNmXf+1rMsLQWY4byEF8bMBLo3/JvEyRKISiIA5ivGxkzpB+3WpBxE6KqVSaQ/qxLdIpo90Y1RsjxIjCeB596/nkUpdWvU+eg5Rurp30VWFnjePMzS2pL37RkRkEGRErBQjXpxGXOVfSYI8rBRZAhykBg7nLzK4vt/cap+UX03x9aO6WrKUkKZdTTrvRnmCOSr+YtXLJgeU2d2a3yzz/7RnXnvP32a+HDukunHdQJBALBKbo5QsjWn7bM+vA7A1q6dko3+vs0TsM1bsM4Y/yHzZnT359dWy317d1n05btsz5e4HSbBw3qH+xv5vyXgStOp/vg3txZH3zdqVu30SNHhYacN5M0ec+b04pXaH2vHdzVq3vM6B3YDs+ryWOe7y+pFRV5X33t3JHd5tpr4Iruam5e7szZrNaReON10C6JnhQnLfjtun56g7OYDZ27tgdETweqz+N5e1VOgDjdvKi4qiC/xtHASopq8vOrbDZfyeyNbjnRh3nZ+aV+5UEFToji60MDucNYW2GlKnAl2N+nFqQSKLEaCBgNyF0ABmY0GMJDFY4qUyUicasP8bEyQMbYJZn2VJICWrduN3rU0Rc/ali8PbR9VMSkcSwkiDeNaTxDNQYcCRKuFQdVgXGUTYB5O7cffPvjCJs14en71MOHd97+ovTO9NR/3EWTIpinsXlapKrVXZ44aeygK/orqlnLnMWIWte+bYosY2PtHn7ZNzCBQHA+xoweK9GzV6+np1rSO6VYzCbwJhjmTd0XQUII9O6R8ewLT6Smt7fZTD26dH/6hSfT01N8fUyn7N7MJmP71DZPPftweFhYYCABYOceyn1r1lsf1+yHhnzgDBz5a7pNizQFtbRGnXdlg7qc9LGYY2OLPpyX41LiokKrN/2U99WixBvHQUSoCxQDpyhM7BkpquMNDpl2z4g30o7oxf/17h7LSqs/eHvW8kU7KvOVmflfHzm27447xrdNjbqk06CfD6jnqVSdCldduluv3r577nwTFCZOubFo6YbSNWuC4q9v0HSGgROqAOFNdwQVAqiVVcHTxDRetCgAtX4+clJiDdDoo0tDBzzkatcaJJk1Jh3VTBQwh6Mmr5QYDXKoH6Oyu7LcmVfgXrPJ3yS1+MdY0jlDTmnl/3RR9aYDUlYOjQnmRgoc3IQzBAZKcpuo5FaRwDTnHWcEUaJ6wlLWqNrE4y4QCH67g+Ocx8VG33RruCwbJJk22pDj6aC0VVSkRYzflCnXyrJBphAbFXrP3VcbTbKRwskOKr3bjIkJufHGEYRQLcjzXGs6eORU4VKPllLt4K5Y1X1Gb1sqwQsy84bAKXA0GkM7pynXDst5a7axrqGmrCI8o33k8Cu4v1U0m7NXVNBUEaSxNjYyPfBXm7kBEmgLmHTj6OHDh6oq5YxZAgwR0YF61Br/NQfVZY6Rc2SMA3GhpMiUOFnZhvVZM2d3fvMenxGjKnzZ5s+/vKFda0v37sC4R6tSpnlbqR5TRLTHmMAvMnheAsgAQeUVFRs2+DfYWb8b1v68t/vSn6TB/RgFlXDqNU/InM7clcvkrTkp996MAabDr3ykutTIiSPjRo1yBlgVq5FazMl3TVYmNRB/X9VAVE3PG0CSvYUUVSSEEqbl/kQ9e3+jHRRaSiAQnIGoohKVJQr6KvXjq9Abq2A1BhT5+1p1M4OU+Pub+enXqSMiIdxqMWnTOuq52KPb9739YcUOcJZ7/nAWrur2caIlMtoUcoHklPf0tfSFSkiQ77VXBe/LITNfDUy52vzkuIZWiUiJWeXNiswJzlRR/SJMr9l95AAmkym5VQLTS2sDR/Rm18DGrBp4fNtLDH7C+f9yGcaJFwhPlvmInKkcKTKkwCGAkYm3TsYJV4HFkva3SclR0VBarc2jIqI2c40nTlfxSzL0j7lcudu2H1q4pMfkkYbRV4fd/8+CaV/FJcRCSkLzsRz19UtMS89/d6nju2UH1erqLXsy7rzJ2qqly9/CCJEY9VwVm40EKEAJEiJzdCDajxU01NRbI8LM/j5IUK2qKS4qtPr7+4aEEioJLSUQ/LU5wWHUVEnid3mqtL0bx7NNC4Eaey7mHbXp3RpvlB2/liLZ2wPqUTKncmSdmHaqeUfT1KPckfX2h3qRPiTgKFjR7aM+tjT6O7XUWYfbcG2WkoLMaY3DWVZUGgjg2lvCykttqqpQEZJ+jooKTyEdTtAQBBsvclMT5Cf+rrfWxrK3qGrL8y/2zo9xUD1NyzPCMABROHcjSICS7qfTMhqo2qWgp2qTKiLjTHYyk4uDLEtDBjBK0GjgHIytWxsTEvRnHak+s9esqp6egeTS1Abc3mDPzcdB/aXrxyixMYZHbyn6brGppDg8Kc5AjpsXhRDapo3j6k5HX50RXvJj8HP/g0HdHIH+HLjEiXe1DSUSkfUr0QCMAPIDhdtfejMjIsTywkNuP5/q597M3bMv5ZF7MSRUSCmBQOipxtV7etZxLU4Fya+IiCYJpiLT8xJLaPBaX+/wVtuEcM49x+TcBSB5FI70e4Zv2FiltFnOm0a3F9MWLzdt1PwsEeDOfe++X7IZ1Dptbxc4y1d1+/gM5NS5XEYERevSpKISOutry84c913/p+w+aJy+wJCUIqW1Uqm3IIrg7HxUcMaK2JtdQVdRHE+9NV7U/imt85cQGVDOFVX7MrJHuCNXVU71ki6Nj8FJX4UBbxbO4xnaqEajSj0CQfdfgcmEpx84XLqNlfr4tBo7OpEiWsxUopE9uka0b2swW7QmgU3thCAYjcaQ0PCSErcTIDokmBuNbs9FJcSbIuGEkZuMRAFu6tIuuk/H7P/MDOrbhdfW7Jn9Xbu7JvimtERKxfMsEAgAOEPI3HVw9+68Ab3TolrYflOEafMqKGk5E1XgTBu8HR/ieqPU9bhWLZcz59ow+IzA06ot7y9c92Nxz1id3rn37ffzF2nvEXAUrez6QXv/hEDJ9/zIKf6bZ8cJcKWuYf/adTnfr+h4w+CQ+24tX7lm5z/fKJk/r33E7SwiWLSzkxG+u9+4Ps6S0mMbfqg4cIi7VAXR4FSLduwp3L6L19kJ93qGye9WP3hqZXnZ2TOJuG1+aoCPapBlDsRscoUGun1NCnLG1aZHmgI4KypLtv0cMKgdyH32rl5Xf/iwxDltjMTnTQUZ9BLKWuJ4bjUmXz3E54p2R559P+ee1yM6t/IfNYSF+XFREkEg+MujZdLkNTU1i75fM/WJt5Yt3WCvd/6GWdbIPnjoXy+8t3njTu5i3lznzTL3cQ6MQX5e6VNP/GvRgjXeRE3nQ9UQgOMVaFBbT4/09r1vvV/wveZaUzU59X7foLRg2f8P8E41nhtXQZHr7H6F5clXDggZP9oRE27s1z1pyrgQpxvyi1TR1ISiOoshhbmwbOt/38waOpGu3WACBjPn5mWMPDZ/qVNVFWRaRUtgv1soNRZ5apqGv2xblRnBCmgCjkQ1APPjkolTSignWkZPBCdFV4OzYPk655GSmMfurF38ZN6RvPqZ35FjlSqAA71OLM60mVfOmVbDT0J0A/DWSYbrrvE9XBYOmUmjr3bFxdYRAxcNViAQVlubHHA0OMrKio8ePbg360C93f4bIowxAFi8cPGLz7z9xeeL62rtjcPkZrpK22zxgk3//s8bM977vqzcqb2lNM7ana2i4kBUoNrwUptEI3fufRtXj/mwcKVnCOkqX5Lxr5oh6/oEZZxnLYUn/fulDUcDEBIaGHH3zfFTH4b01iZwWVpERt93T/jzj0NGG5lxMYQ9GUlcgt8gtXX3WydlPfjP4s++NlZW7Zo9r337jkHXj2F+foyf+TQy/yup0WbPrnfBjOZH0haIaOahvt7kaEi8eTxt3yrZz9zyzrLKo0V19VVGbqOIRE8/dTyck+tJQQklhoM5VYtW2MBSBy0Ofv1d2y7pNDEeJdGYBYLLHz3s6XS5nbiWO8pms/Xv1xd40IQJw4KDAn7PoUYMH8Fcod16p5n8rCcHpCCiJJERI4c8X/Zc504dgoONjLOzrl7hPVHv0idUwTNWBMDbdr/5UdH3oBd+cVUt7fLWFbZ0huT8BjSw09rq5nH43ggNpLJKOEdOPCoLUSaNbwlBJRTVWUDR76qBSfuyC1+fG/npmpCUSOtrT7qTo90yMx7XB0JO/arHCrVcB1ocPzY6t2UACAyIGn+tQqlTRpWjcdK1oaoKkqSn/2ROl8IUWZZVA/VYHYeLMZWajMYGfvSb5aHT14Z+OrWgsND0yCu88xK/yRMg1AZi4k8g+GujjcLAKBuGXdlj8LDuBorNq8L/cuCnl39AVFU1PrHFXQ/GENRWsnN60pacczU0Un7oiZsIoRwZNpXtO4cxJ0dQEWTEm/e+PT1/ERAZUAZ0fOEePardCLRFKagtzDkvY9zGDkg5lbvqF7ErjCNwSghXgbs8IoxKQCgw4rHk9BRaTCAU1e/BCZwQQ4u+vWu+W1NXuKFtz5GYklhrkLXgQa2miucBdLsBnUCMnOqVUpq3ttOJefyLuKiaDJ23NGGzTBqUgIlob3AJOKUUJKo/8AShfO++vPkLW7Vr53PlYKioLJ3xmTMxKuLasbU/blm9Ymm3+662D+ocDcZ9ew8sWrSsb4d028AeKIngdIHgEnU9NTcerNFwNvlT9MTAHJFo6aJU7unzaaPa0QyLnjJKd2tzJhGUgHoGZ79jCZRe/VcmenT4qTMheIbXCB4z1VjP+PeO4LyJFhr/0BZrcUAVgSGXOb81653p+d8AMQNXgTWsDn2gb3wfp9VIoHE9HZ7LZeWNfRkzOAEdikFVVavJaaIG5iIOJ3GoYJDBYuV6TWjFCU6FuoFbLZpAYEY7Q6cLLDI3GgApoHBQCUV1DuIAOeRs3VK5KzcJpE0L16feMlKKjnRq684oA+Seh1FF7gLV4Hl8CTk5MRX7S8mpk78invY7a2aQc8BmpduZ9oJ/aGhxdV3e028lJyfv//EHdd6K5P88QIEFGOQxt91kbdO2LjCg1mBIfuT+hG07DQaLaKkCweWlsPAX/iQ9L4Jeb1hfHMeRnHrR+JnXjEXEX9Uu2NytdXYm3JuOgeteeI/2+7r4h/E7nwZq9sgppMDsq5Ke7RfZ3WHgDIikKarzOLZVSsoWfTgNC0tHPngfSYlzFRYsfeddU6172AN/hzirHrxaU1Gd9eXshgN57e+8Nbhtq7qi4qzP5tUVlna++6aAxATRLoWiOieMHGpWbM5/9vPkET0dVz0KL3wiTXrR8t2Llrgoe1mZixosvr4OHyOrqDWXlhnCgsHH4pYMqFVD0Qv3cK3+zK95qwQnogWZczUmvOXN45fm5kV1vTtEraj+f/a+Az6qKvv/3Htfmz6TTJJJL4QkEAKEXgRBREERxYYNdZG1d13bf11d6+66rmV1F3VXRVCwICpWVhBEUKT33kkhpLdp797z/8x7MyEoKmBw8bdz5SOCk5k37917zve07/exicH+vcKqZBnURwPaDFwFlJDwwiy5KAdREBIfs4iv+Pr1JqhMak2DbidynA3S43ZGUwjBkSOH5qbWurpWq92SnOwGgZRirKpnvtJU0DO7pMLQngThR+FUh7zmsAmiWGcIRgtuKBtMDOLDii8vXvcQMJs5Wrcg5dqhnUa1WljQsGyEdEATA0blJcCQsqCYkpjTtQt55D6oDmtP3df6/Az3k+9mvfEIZGUIEJQTQYnmdhanFS3/w9t1DX7vPbfWfPklfXT6iLsup7lZEA6DLMd3axxRHXuQpG/bN3/m+5buSc5JF6T072Xbd+Cbu59P+mxOwfljv/nok+b/LDj9mmvk7sVrps0Ir1jb7ZG7rI4I0qeHpHm/Yzi+98f/eZh1WNMhAC2FBfl9Snd/+FkW5Of37hmyO8LG5B+AUAhlsf5JwXUGBGPRHIl3U8VXfP06lxC4b2/lyqU7Snp2ystPNek6DfFzgUQEg/qa1XtffnHmgv98e8Elpz365+tAwK7dletWb8vOSu/WM48atUFTHE1wEda5KkuGktd/WdI3ynBtyGJwFDoJzan4dtzaB0ByAjBA/fNO9w5NH9qqGL1VCO1S9j+PtjE6qojRSqpEe4w6Fa/43adTPjxJJTvXbe5x+2UJF5wb1nWmSKY1RVXThvROv+uCA3+ZktoYDNXWOi4dRi8Zy2mbyY2vH1zxsP4nlk5E8eDBxQ/dRQf2arTb1YvOSZ32iDU/V9a0HoMGeHc11D35SsPk1/3vLyjpO0T1eVFCZrQ2miwjxKiC05h0bzxLdVS2wL9t2/6Nm5PyezYrfO/KVXpjEwHKgMqCqty0TUQWlFEJ203DxOoC8RVf8fVrCarMAJQGA8HZs+fcNvHPn81eHA7zaKJKIAoRDPBvl2/+w/3PzH7t2+p94cbGiFVtCQQWLFh0wxUPTnv5vdYmv0lngCDCur7465X//McbW7ftQ6D43/tabR3fxveIfJt3axbZ5pwybsPjIDmAiDuxJxa8PDj3pHol8hoJQYqxNtCfzWFoXoBk/GIAyJC7VbzvavmkzuG3/u5wWp1XjvdLcliRSFTMghAg3JeYdt5peV1zN33w79R1/qKxp4ZyUoOAOou7r3iO6ud5dTUvKyMvy5DLEYoQ/oz09EvOVQH8QrcmJQ26a+K8R54pfGh674m3SReMEFanACEdAU5tx+gWX99DsSbNQmX19mlvZ24q9019dNVXC6UXZ6aVdGWDhggXFQSpLhttqyIMlAqInPRYWBeHU/EVX7+65JQZ4cuK0qtXt9PO31FYnCVJDIUgEUghWpsDn3y47P67p1WXlUmyxrgsGA0CSJpS2DnnrPGDuvfJs9jUKBAh2NzYMO/zhc//9QOPOzE7K81i+S/x1eHB38PA/bp/fs3Ki1feA4o3AnWQ3eUd/udO17XaCOPECRhigMRU6YrckXCH+QgDKxl8PyECEkfe4q8FEA3NUlMTAxCc6AwlQ9nDQHWoBkRDXTMCtPCgo7FJ0sMhiXJAKe6y4ojqWE9BZOuEKYQAFBGWgBCklBFmijFRQ2SmezeS7BXrQ2pWKmhSJKDCXyGMP8HUgJBEbvLelasrtu/od+3FUNKlp9tRPn912VffpvXuw4idB4LQ2CxkRuxWzoD4Q+gPcLvGNDVOoPC/c0jbaubxR/5/ZjHGBg7qM3BQHzAV+YAQiv7W4Afvzb3v7r+KGl9BjyJGpXXLt1CINqUPHNR34KC+ZqMVCkCKukC3x3PqiFEadDpp0KD/Fpw6aFYJ6Kh/VLXk/GW3gJIQgVNEPAB9Hky8AkoyG6mQgDECFJFiR6tqHPpuggCta97yt8l791ScdvYNa+csr/rnq8m9ulNZEbHOeQRsrK5eO/tjy+aK/ufduHfphq8/+qTHwFKWkc7iR+1EQ1RIIg81yhpyojlzU2hA52ECYUaAEIkCDYetGPkvJMRPOUOQDUFNmUCwtnrz45OTqqH1tIkrZ88p7FWgjDwlrMkQrfWZFXFyWDdw2O1+tIsb7yaZJXKzizMa6VEUSKKqg8T4t9FlFCNqNykfIj9kELcRHdH4vsToUQKGbSnnQ7XRo9f8fYI40qGOUjYeRVrfUm+fnprH6ZcILcz3Tn1G+EOS0xYCpq/bsvmOR102Z96j/w+L0lr/Pa3m1mfp64+kn3tGSKMSMRPdbW2q8fVrREo/tsKAOqAfJApoNWWLDp1LwB8g8MB2c/nxdSJlqET0d2L26nDTjhnSqCSs89ZW7ktN6Xt26TkXjpk7d+Gq5auYQMWAYAefLzWMGhKZSAA4ZGjxkKHFbbJ9v0SGLVqtQ1PSNUwpA9CRV4Tqvq5Zd8mqe0FLhQjoE3e4Rz3Y6bqAmxFAJ0g6IKGIQA1/HOXsYz+H7aq9xzWBEoEmKuSmQMWsz5v+NePC26/1//HWlCdf2/DgFK3PNOekS8M2lSJE/Fxrs5izAF982/H7i+GGq5o+mQV/eJHkvCXdfR3V1HDEKx6F8FocUf0PL0I48tC+vequ/XKPLtzrwZAf1u9glY3Qt0h4HREnTQyiXJCkQHDDrM/Wbd923u0TSXHOl/94affUdwtLesjZviAhMqD0c+QJjsz10JieDTF1LaMNiAa7OEVErgt/WIRCGApBiAMPga6DjgQUNInkFAU0FRVCGSWKirboUAoe0hUpYk6O/AIZgXbpQTnRzQhB5IqgSIC5XeCMAj1rSRfH1Rcuv/lP6VPeCA7utvj1d0ouGZ4+ariuMNnAjhRI/MT/H8NZ7eE9RSChsBoOS5QxjUbCe4gPe/6qFz00RotOR1MgAoXdablw/OgePbqmZvhUK8z+uFXEdOgPY8RJNDpu66c0uaZ+kV1KYgU202ASHfisqkUXL7sd1ARQUyIOV7Ldl3DSo52u0W0RBEagjfP4uPfOM0DS2Ly7an/SPdc4rrsqZHN4x4+yBmrXVO8/qbpGsaUhCEEg5A/sCzQnXzm264QLIdmbNexU9YbmXa2BzMoDztwc0XaRGEdVcUT1k6EGwoHtO8vv/Xvnu69MHDu6duuWpc/8uyDkzC3IBK+DCSFIxLtHHLY/nEwsI665Qh05VE+z9Jt4kfyf5TwUproQctRCHG8tyTa58jY/E2JhneuhYLAp1FzTVFPZuKeu6UB9S11DsKkl5G/RW3XgnKCKxMokl+Z2qu4EuzcxMSnR5U3VMjXZJsuyCjKNREfRlkgenWqOVtDx+B8jU5kr8suILiUESUScaTS7gMg1LW3cGNv8b3c8+wF78f2C0szUSRNanCqlqJkXG5+g/L+bvCJckD0Ve79ZqlcccGWkJgzopaWlIKNxG/9/BVFF/mimyykxMRLa3GrfAUUIuKeiClEI4PiDxuN78OqX26IkCvtNoS3B36tafPHyO8CSHrGjhNyrDXks5WroZOOGNWOG6obpUI7ThWI7KsDIJXndfSdexFRJ2G2cAOmc0+Xem0kgJBwOCQQnEQxqczoKzzlHYlS4HASJkp3nu+EaHgxYLDYUSGmc3zOOqI54+1FZ8nXvUp6RsO8PTydyJAtWuJZtd/zp/4UyU3TBVXOizCTl9dh9E88zDT1F4RwyFIYMNeqG6ADxC6VFiZEsJ5TTkJ831/urN4e2rt+/ef2eVRvLtla1NGFrWOHMK7vsmkPTVFVSGZEASCNGYFdjaGNjsLlZD4CMTKbeFE/3tC4FOV362Lv5VJ9VTragQyYKQQLR3jCzzHjcAz4OwAkJoZARVI6tEKaMMWJqLCMTIkgptVlTLzl79fyFfbZ/6x1+GZQWCSKMBCLV28lDxLMW/1eOZsQ1hCJgmelby/Y88JeGtxY3dXVs2VDZ5/qL0++5jqQlY6zYHqfP+PUuAlG4JBmSVRglTFYMainz+TIiFAIsFjmdUBcPOiAH0orBfa2VexvKLlx5G2jpIBiQxHt8Ax8ruCYgg3ZoyHdcAQoHCAFoxvGJWHFVUZMTiTEPaUHQKbU4XcxpVsMN1gZAoTKmanrEhAYj0JZIwmEnDjtGfsoQoIlP/sQR1ZEvOSm504Tz1t/7+OZLHgyD1PnhqxJ7dAlJVKKEGeUnjMkeGAEAGnUxAOQEdCKU4wqkDpEIjXy2CKK/IVRf3VSzrXrb4jWLtpRv9fOQ1aYWeQuG5vqyUjKSE5IcmsNht9uJTQO1TVM9AMGmUGOTv6mupaFyf2V1TfXOip0bv922/qtNC6zzCjsVdc3tVZBcmGBPTGAehooU2SpmTfCHuLY62DYxwqC+vnFnueJyscwUIfTW7XtcQYSiLGZVA35/5adzrX4hoHj34mW+racovYqMaDZaBI3HUb/yhNShKYcYUbUiYN2KVdWNjcPfekQZ0q/q1deDr3zMLx/H0nwnoIuNr3ZW6zA5pPbLrOIh59VV9Tt27s/NSUnxudGYe6ORXwQP5uMRo9Ed/JBw8n8FVQtABiSM+sdV30xYegsoiRE4Ren98sCHLBOgODWIQhYUDIkIGsNS5HgbUoQYFwMxukNIrGctdvtih4vEigBAYrktQ8uCxro+SLyZIo6ojnL7EZ1ROnJQ0Yyu9dv+ZVMGuvt1C6bZKAWZCwwGI2daVTiTJJ1jIEgsGlDGolJURlqEtmVxsEM9DB58S4NVuBVbahoPbNy/ZlHZgrVl6+v89QXeoqEDBnf25XfyFPrs6R7Jc0iOBg/38J0ALoC0yJ+qW8vLGvbsqtm+9MC61fs2f1b5udeW2iWnYGTiKbkpnVOs6Rq14MFp4PbVP9KRIap50YgSoWxP7bcPv2RRSJ87rz3QWrfuiReGlAwgd18Asqj+5PONT7wz/LqxLaUlW/78L+vf3kh8/h7isYeNtnQaP/i/ciQVJcc56JXNOQrQuZ6en5dw9/W8tJvutDenJ1scGkWzShy397+GB3twJqnNtBloKeLoeTisf/DRvIdumPLAU1dPvHYsM7IsIvZaRgQlQhjK6wSxw83sUX2d9kGbufNaUN/esm+3v2zCstvBkmVkrMjdCac91PX6sIxB4FaMqsqYrX8dOyXBhcC6BsYocdjBbB2rbyCEqDY7MjBEEGkbhhMkcmMZEipijiv2VSgQxfxuqCAREugqQEw2J17xiyOqIz/maCJ6EVq1+sDeMgW6ihBvXrvRXtrVn5Qk/K3h+V/rDU2uwQMgM6l57Xrr4jXknNMh3QfIDYE62sFEU2ZQZuSiDI/BZZQoEj/49wfKv9w/b+mmVdv270kEa6+0viU5PYuzuiVpyTawMJBNZIcoYqHJdy6HG5k1ZjASR3nkvFaf15pUnNq9Pww/UL9/d+W2FXvWr9+wbQ15rmtafp+ifoO9Q1wWj5WYOWJOmJkTEACso46ZIZgQbTBGFLRLTsJlo3fe90Tz5Cn+2mqn1w0XnUrcrsCGLTvfnK2c31u77jLI8iXt3bHtqY/Jpae6ThsaUKgFKYk1KBjSX2gyMsSNwQl7Ck3xEUFIOLKfqBSJpDnFaHiCADqJISaJJfct4QbyDq3ZUDN3cXrPIpLs5axNjCS+TqAlouNvoo3eONaFbZxKIQxoQYCYuRMKjGXnJp85oXdaZkIERzMSpUc2WjoJBBCFGc0Z/wOF0WxJzSZP2m7q7vhuWM6NT2oTZOEgcRCfH/jm3CU3gpIAWgYAS1HyJrqLHut0XUAOK0itMcY8kyMhspt/RuR3yEysYcebQ8Hwk5N1QhMnnCN3zq+vqCR/ncy6dNIuOpu7nDF1L8NTGTeQm6RX1NRWPTjBTeEQnEiMJBeJ09LEEdUxbFAkQPfX7PrXNKZj0XP31C5atmXG7M6F+dLpwxiRKiqrVr4w7dTWkGVgj8UvTy0oa8kZNYzAkaS0f5ZRMvwNYUA41auDdevL185ZNWduxdx0d+ZJJQOGFvQvdBQkQCoBiSJtm4ciP3oIiBkZmogrprgOEWcmJwqLz51W5Cj2agWJnvWVYv26jeuWblu5KXvbiEEjiuzFdskuE0LMkjohHVpiI22nmiDhMhSNOz3/q6Ubn/6XB1y933sSMpPCCAJFvyGD5cG9eEEnrtKSy8eHUzJaBNAQEoWZvelmW0AUNpN4IfBEj2u4UX8QBLlROolWlzEqz2ZygTCjtSZEjbLEgZq9U16XKg64br+R+3wIGE9RnYiIKvoY20aRWXvpLQIYDPGmpladC0qIZtE0hzLylKGD+vVWNQsxQHIEfhhq6sKoVjHKJGoq94lowMQFUg6U/oLPPzqgh1HVPqYDf6/q64uX3gJWIzVF6K3eEU8l/RZ8Ko+ECRI3+VzaCNBJB/sLRLBoFpdm/+CByfmS6DpxwjdTpirPTD3llT9zVdWN1l4lhsF4m40lcAhDDoHv+TH6XdMcH/qJI6qfcN8YhS3ByMnA5jWb3NO2eKf9Tr5gDJYUNT7wZPDfs9xFeZif6xk/NmP1+rp/ToW3PsmoqXU+coeemWbkoiltN0/R7mCLnxe2g8neZXZv+UOhnc3bZ22dNXXNe0nEdmnJRad3OaMoqRiiXHjUaCFCPKKNb9KdIBKiC6BCABESieXRGW32B1cs3/jY/TP8deyzpY9uy9788Yp33tn1wacVn4zre8ao/DNTrdlekUQwllDquDMWVe+JNkJgSNclp0eCBIQwJ8gkQoHZirvR4m7CYFe3IEB+vpqfrxldGA4OYYphCgHgEoAVpLBxjVKUSZ3ELcIJmCTmBHWCLMj16mraXAc2h+T1oqJGAgQBwDmvrtWbW6jdTl0OXdOk8srtTz7b+PXqnvfcqA7vrysyRB67FH+0JxacEoIA7tuzv7KirqA4zeG0Glx5RtsCw2AwvGdf1ZoVexcvWldfF9QUqaAo96RhnfLy020uRo3kstn4A4iBYOjA/qpAQK+qbWxobCYgNTcEd+2oCOkBt8ue6LXTiC+Tf4FZFCNgY+bH6CA4wLKGzfXBmouX3gxaBiAZTDsPSOv+16JJBwAsABpIigEAdTA4PCHKENiBOR9TqkcGgPtvclbvIw+9w3fUeKe9Lj9wl7jg3GZNNu+iTiKOhAEJGABXi+I7Ir7DAvqjbiN+wOKI6icMOsb4T1SAsK63WqwZk69zjBgACvWWdO1+8xXahi1hHqLIXQ5n39NPnT/nK+vKT3pecbdSmKfLksDjgdzxIAmUgZRqgjWLyr9cuOyrrQ07zssaWZzbI5N1qdmor9izLT3Dk5Bgl2SJCHo0bx8515yT9Ws3E1nq3DmdKowQSoAGWgLz5i557tnpy5ZsdbiTGluDhb7clDOu6rq38Msli75ctLi2vOmUkuFDkoYrikrNIjzp8CeDkaguxPfO/XrnzI+6jx/i37dvx3sf5Odm0OKCMBKZo2BAKSOAOiInROG6oJKgIDc0tVYeoFZF8qWEFGTN/paySquqyKkpXGE03l55giWGRXSClLQ2N2+d9ZH04hsJIwZ7b7hCy8/XjY6T4IG67X//F/9iRfqtE7xnjgzsK2t8+qW6p2d0u+kKzeYIr1jHCjLB447fz1/02R1BjVUIoYfDb8x4Z8o/Pp782kNDhpQKZqQbEYIBfd7cpS+9/P7qpWsSk+2JiU5/IDD/y9lTpiZceul55553Ukaeh0QTzUgo1NTUPvu3fy9cuIXJlorqJk22L/xiw6Stjyp2/cKLT7/o0jPBYHz5ZU42MRrjDWkyPmf/0rOX3QiSAzQfAN5tO+lP7iuhKBmDIZuqGKIy0fgwsslJLFve0Ysag3iCkGHjz9v2xsJV057MgD6+yy/UZUpDIV5dwwmSpCRghAOK6hquczXBSxQJo11VR56EiBvPOKL60QgZY0lPiqCpcuaQ3jCktxmBUI/NO240GXc6CoFIw5z7G2uYQ0qBwtbaJvA3gRBAI+HU8Ut9cAzvbdz7+eq5/9r27yxn9rknn1ui9F702do33nu7oa7e5lQGn1J60YWjOndKMisjRzbkQs0KZ8AvJk+eTjTl0T/eaFVVLlCi0sa1O5788wsuZ15WZ9HQ2CoTGTgkQcqYzPP6OgZ/uPPdz1bNWV21qrV7a5/i3j45gwrJaFMiHZI0bMsbCkJCuyp3T/nQ3T0v+c5J+yrLtz8z2Tf7M0emj7ndAIxFAjMkiJLJBEgVTjAMhFXVffPy685woO+1VwU6ZQfnLlo6fWaXM0ennXOarlIlbhFOpCTxQSUZBNlmSXd6WtZ+0bS2XOuca0nLCFo1RQjYsq318Wm5UJeccAtKrOw/81rfmN8FbLUr1u3YtIGiKHzkd9bePZGak0mH3/ACo511Is6p8UshKtO6ZmdlnXLayZrqFCiB4IAgOC5YuP7u+/5mVXw33HL1gCGFiYmuQCC0ddPe2TO//ev9L1buqbrj/13u8zFhEHUaU/2EyRan2ytbLYk+n9TDApzwQKtq5ZKsYXTM7hdyGuYs3Od1a4LhprOX3WrwI+AYkVeQ3PlP6ZNCXgUQqapoAuih/QaiQ2jQD3tNxGBDBmhWCUtSnTUJDlBDGFQIB39L+YyZtZX7+0y8Uu6U01xetvvf021ul3bVJZLiNDrYjrz5LN46EUdUPxIfk2jAYQoemduKRYtDSICxSIzEgQhOKRXgX7t+49S3C4vyHePOW/HR3KJ35ydcm4FJ7rYf7Wh/QziENh9YN23F68t2Ljst5+TR/cZkKMVvT1341z9NGT6kz+mjhq5Zt/mFZz8SIeXuu89XVYpIjxDZmC+TJFpf2xySrIxJBDSJIiJabNYzzho6oP/Jzzz1xqa1WyP3iRIkAgUku1Iv7H5ZrqvzJ8s/ffCbx88Ojhzf/cICSwkTHQRUDnKmExmxkeq+sYOyijtD1yJPQV4m5w2BoAZhCYQeeSAEQWgIOoUQIYoxWkOBgC9RzfW1XP94yJMOZwzd+cAz7n0Ntntu0S2yDqjGD/2JdAhpzO9yQFnTUgf02HfSBXu/mp0xbwkdMdRamE9a/eF1WxH2Wq6/iXQr8kvE2SXf+sSk1kCYCeLUBSFAkrw/EjwjAcKYWZ8mMfqQuFv4uY/uCOwMo5RI0tjzzjpl5EiP1x5r3iTllVWP/elVytR7H5s48pS+Vma0igLtXpzfq7SLNw1nT/mqW2nRJRMGMxmNhLrkTU688dYrWlp1QhgKJJRF5/wZeBIsiiJ+qfHeSCDqJzC3avHYpbeBpJnCMnfahz7BzoVu+ZxyagIuBGr2YhDQwdTFOq6xScSkW+pbV7zythQSOVdfPf/FD/o8PSXl3ptEgs3L5OVPTMlAW86ki3e8N6vl4SlFT95FnTajWmj2WRxR4ix+cOKI6nBJqcg/Zk9htCUbCTVlCyJ4xIwqzIiWmPNySAklzY07vpivW1TPpMul4hIr4dVzlzrPGSknuX7ONjvcVLEwWwbDwr9h/6YZ30xbXb7+1IGnX9xnfDqk79rTsHThsiG9Sx546NaCfO+qNXuWffOnxfMX7bt4SF7n1Bhb1GHfvq0HMWIU9u4pr6trbm6hrU2Cy2LVip0uh5bodaWkurp1yywpua6x0S8xaJMGjBhCY/LXAa4heSen+zJDi4Pzv16iN/HLB1oyrdkWYUMC7ZLaP+eeoMkR4czPdnXOifZdKvauZ51pNKOGBAgUwhQeMRLWxoPiQjJctG6znHTpRZUzl6yZ/HbKN8sqVu8b+coDvGcXXdcljPMqnFApqnYI35wlT0u1Xz42+NU8febKwMUbtPy8ugNV+xZ+44QsdtrQUKJbl2jWoAFs0CBsn84EQD1EDne4OEXNHw7u2EsbLdHhCyLid/4oTZShA0raKKAoHEJQgj9y5BlBO1A7pVBTZSR3uA7yt59+sX7e1zfeMvHs/GTYFonZyoVc2VKXlJWTl+e7654bVsx75OOPPhp2akFmltcMbxVFzsz0/fA1hjvkXB8OVYgoq3kMUcyvXXlABC9cdgdoyQBBAHFL6hlPpP2Wu4CTsAQyi8Tn5izfIfucHE2w/x30Ysw3xlSWRMQ7mYi2/XuGwmEx473NH3415JoLnBddaFX4kufeOm1gb8t5o10XX1CyY8fuv87MaPVXf/5Fj2svUC67QJC2dq4jF8CJW884omrnpXk074/h2vqWvRUWm9Welc41wLrm2j1lsqp4crJB04yUleBR1hBKkXLAAOGOviUJI4aRwuKgxtJ+c3Ftz54Bu1XiSNjh86Xkp2TE26acog/DyCjrRCcgBUVgdeXi176asSi08ebhE8/uNi5ZJACFZJd+9VVjLHZLQb4XQYT1Ro2EbapdZopJcRI7jtguR93+aBuj6ESZNevTj95bFggqFTurOcH7750aDvkvunT4VZNGUatfYooQgRDDFoMl3oRhSI3zx0BGtdDa5Y+nPPQmnf6PndOaIHBR/3MH2k6OERTwWOf7MfpYEqO+BkTOOaVRkQbdYMEioDAUgarqul27s7wpel6G1NxSu2WbpFoSc3NBY/WMtjqdCfdcse7cm/M/eTVn4q1w0dnNqKuMaILERT5PQEhFYuVqYbfxUwa6Th/Z8NmM0OIVaYMGtGzcXDd9bs9zhqnFRVRRLEY+KxzZCebId8TPMwAiKcoh/EDRkxVWhLavbtUjL8oNZVI03Age+8jI/+ZTEhJBGVkrQNj4C4UIYiiXtj0B/kNJeiGFQUgg1Mj/jTyxlipHypqFO7NAcm3ZWXnhLVwEdUV6lfkWbNp27kN3XX/t6XaLMmLcgPdmTqssr83OSuOgC2KiCGCHJ3GlQOSfj57wUEXTNqAigDPUjKw+ee/A4nHL7gYqg+oFFJfIfd3ejKeLrwtFh/5AGNiTmnAqpjUvHR0sQcSIC9DDYdFUJysqWGxhwiQhRHOTkJgkq1yV0ZAFa/9O9c1NNV8s7Hn2KY7LzxcZqb67JrnK68o2bsqqGxRKSUi+/w7ns5+u/cdDg2CQ+Op6TLIGjbsmYVTsJ24V44jqqI9PjC8O+f663W984Gpq6nzjFViY3vLZvF0fzUkYNdKTnaMbm8zgColxhBtkaJLDnTXkZGbooQOKxNRkd2qyIszJbgHHqtIaPXfR4y0iVkNIfh5Ys3flS0v/1djcdOdJvx3ZZaQb7CYcsjvtw0cOMLyFaGho+WbR2obGlnMvPi0lLcFMJokohbB51TQWP0b1Q83bgAC9+3Z3exL8AWX6ax9zIV80YaBFhoIueaBQRi2ADNEPaPLAAUbCeiEMMEKBCkN2zw72cwafI+w4a+WH0/QZnv7uTp4CGe0HB/V+viknhDFmphQJiYbFBscvbWhp3Pf8q3ZvivvmK5vXrN039c3Ey8Yn5uboFFXQg4CB/VWaXQ42eVh1PezZqxVkU87bhYDxXpoTzG2jMX1K0Jma2PnM4bs+m6GsXJ+2+Ft96bd+qHIO6wsetx7tuCIsNrtBgTBCCR4+yqYACrB6VW7McJVlkai7i8KC+DriU2iWsSKGz0gMm0GJOQdDTa4pPMhedOjihBOkBqeRSaPAa4l9+4adNGRzFmbvSQ9xIZBRb0UwHZqSm2si9lAS6TnJ4bDe0qibhi7ygPGwpHfkeOblzA9gzLBDAPDZgSXjlt8HiieCLFG/2XPKM4mTIMsTMgSP21Ft/dzPFob4jt7YVD/zU0LBPWqYlJnVvHULfjBP7t5FGtwPVMmMMtu62QghFkXpete1kJSIvmQh9MLMTvThu5FgyGkRELYHWphsbwnbdJ9NawqgR+gSk+PGMI6ojjkaNjcOBeSMaqlJyZ2yK657okZirvNHlr3yjltV04q7cllGs6RvirygQAoUKDPPEAgZUKZEEkQHDBrsBsxkBsV2+dOjgVPtOf4jXkKgDuG1lSunLp5aGai4cuSVozLPtYONmX2XwmD7RJ1S6m8Nz/1k2czp804e2ffc807XNIZGrhkOEqWYkjnt4/aDiGrwoD6DB/Xxh2DevAUI1gkTTnParQgQAkQdqERkVZOJJKGsaEyKXCjnMR1QToQA1ITqldLHF19CZDJz0Qcvh168fOTELpaeREgdrgFB2ooNUbpATMjOTurec+mfpvawqXuWr0h1WLy9e3FZ4gQ0YOFtWzY+/s/Ebnn2y8aseeKd5E5T7Q/fwTWN0+PSGRpfP3/RtlSy1Wbv11PqNlz/Ym2oeapYui1R7cz79CAeu1FOiVJs0zbvhXiQge177xnZzL6EYbdNTEuxYARPRUnY4gH50Ry+GAlrxKQISmXGGNc5R278tWhfDfxujkoIVVaQSFwEOBeEgK5Ln9U+1Pzl5qGXXZKRxQMiYtpKlm6Stmzo5WRAdOTY0tAkS0xVjQJaNAuJ8AumlzFmzwUyicif1CwTQh+z4l6QnYDhi+RSd0LKM3m/bbHZKKAc6yWgHfK5Bl2OQJAUObCjYtOsD/urzDPy1M0zZirT5hT8+S40YCaJIcwogzGiw2oL9+5hBCcRtCsQgl3zjXotWmpqvn7lNQf6u1929erp3zheeLXL726hXgcQLgyGsHiDVBxRHTXwb2OilBExwZk8Znj9uvXLn5898N01NENJvecirVu+TnSFK4Ha+rDu15x2YbdSXW+sqZOpojlcksKoUfsCBAnQLmJCR4bMnzBVJI8eS+hGslkyyHQF8LKWXdOXT1seWn334JtOyRnhEk6OIkooZwAmRmgwrC/6cvlL/3gnIy3r6uvPzit0cp1TEsFUkpFcMzSFJROmGV32BjKMEqmbVNSR/wyHhKzpKuU8HAoDIyCpEIFuZfsqahv9gVbBQvL2Xbs8DmtyiocyGo5YDY6G5EeQIRPg0TwXdr3M4U9+YO0j2reuiQMcOXJhNI49XiEz4YggydpV4/WyPf5Hn7WndPZM/QOkpfgZKABQUbPm2Vfl9Qe63H+7f3CvzhvLv33qlX4n9dbOGOHXmCMekJ3Q55RQImN2pjxueGjd001L39IA0kdNDHTOASpLEJYMFW0EqgOVwciboFl7MlDWoafPKPRjrUL1RBckOYhxyEhbYji+jjhh0zYMxhHWb9pVV9fQrXtnlxGD/cTisLuicve+8q7FnRwOGzdok3x9u1e8s/rrTbsv7F3aasggO5zMpQcc/hYA5g+HVi5YnZyQmJRiB9DJwaai4z5ohu0CXUBkEfNOP6xZdtaKe0AIkFXgwZvdI5/xjocsXzMj9lAUpZsTQdgxzAiEEClMgDidzkvH2LZvaH5tlrZ6V+g/X7gnjpaGlOoOhYnDJ8PQoOgzlJgjboAbO14PB4NTP6z7w4vp99+kXnxha6qT/+VBkeZTb7gMWOT+EoNeKx5qxhHVMR4aihACoKkpaaOHVzw/s67ig5TR91p69whIVEYJBJZv2bz/03lde/awjxzk37Jj7/sf2wcNTB86mGjU5ADWo2KX0UDZ7Buix5qYoe1C5qZw4/sb3tu2b/tFw88+rcsoEgkgDAGVdoqxLa3Brxeve+n5d90ex3U3XdajZ67OkVHCkTPCNm/ZeaCyMS8vNyXNbSTbonQ/m7fsLN9Xm5fXKTXdLTMwGydVhV40fqxEVc1iQaCwbVfV5u2W3E7vTJu1ZF/l3vIDVBKPP/KCz5c0uH+v0j5dMnOSDW8UCf5ZJIqLYEGH6jqz/xmbyaqVy5d/4vh4Qg+fjdoJyB2cofpelwzIUrLDEQCmWlWVqIIQBoIC0ffuqUMx9InrYOTJqseWc+tvKt3WPWX7ugSDRLPGGh7i68Tw1XCwYmT+LhBJojtpUN8GW3Fjy0I7JCb17849Hr9RWzEapFHaW1G7bqOWlmYtyAdVgViit/0bR/OaiBIiFYKZBwFJfGTpGECG6W4Zgaa6uslP/+ujt5e8/v6fBg8uJeTQZtGIVTkUU4RCM6bPmvLSB89NfuiUYX38wCUgp444aUanedOnTS8dlJaWk6IRYhjPyDNqbPDP/mLJovlLL772jNS0FGFK3yE71AAcx8xU26cwQj6tWhoCcfbq+4FagAYvD3WxZeQ9k3GVcMscUEbjRSCidwA7wKwYHAhoKr/oBDxdi/qfOXrzjU+Xz303t8e49DPP4F4vb6tomKXG2MeGw3q4voFICjjtPLLdCa1ppEIP89CmDWtTLzyjcMJ4kZXV85Lzd6xev23LxpymZupJwCixVnzFEdVReuW2gy5AcKDQ2NSwbQcDOQG6HygvV/fspdlJOuiMyZbURMv63bWfrLG0tFQt+ta6bm/ymDOZTdEBkaJiBMZmtkYGwjASNJN2Gk9HO+rGImYfBfAm0fDlui+eX/fqb3pecF7n8+wiIRLjMdFW3SCATc2BeXO/eebJaVXbxOU3nKOTli8XLnfYLJ07Z9mdGiB9Z8bs99/55t7f3zxqbD9NY7EiOX377Q+nTf70vgfuGjd+gGRTzQEWRYExo082e3g5iKrZc7+5/dHsh3+XZrWmpeZ0yimWgDT5m7au3zPr1efuePCSm24418jIRRxb1IcRIXPqJNZJPSZOrvZ/sP6DPE/ekNyhVkg8TjGlWYGQuV43e87eDz7v9dvxFSu38GkfZvTowjxOLiEvyj/5vtssXg/KCgckwwd07d1FDgVBlTVB41olJ6DPJgeL0ggoJFl25+eJMV32vLkQigckDewLsqwYoQXqvG7X3vCr75Q/9veU+25Sbr2GWxQF8VDp7oPIW0bUBGoC1PZAKy4AeEwhTSSKASzKyvUPYi5JkYWgVDJKUBiFU9HyXHuIJbITk4b26p0gWSQBFhIBIb26db7upkuefur5vz/88kVXnlWYnwEB6YBs31xRv276Zw88Mb1v38Kzxp3ucFp1CAIyI3TFmPRLx+27776fWdkEydiOcw4sG73mQRB+YDYQ/pvUwU+7zqddSwI0TJFIyGRTjfKgJk1HnggW2esQpJQ63KovUdkBCRYnMqswA3AzzD50BfRQ1fRZQSD5Y0ZiXnrzgZqaKe+5UpOSTh6Yfvskm90OGVko0Nq9OOfFP/v9IcLsZh0jnp2KI6qjtwkYbUMKEwwRhJbGmtmftNz6ap/rz5JP74P3v9z4+Evu5JvUwq4CIKlTfurDd6558h/lVz7sHlxqOX/k3g2bnIJ7e3ZhVlvF/srqBd8k+3yJvUvQZgkTkFFHQjkwcy4uppp0pGZbGBR2Otff3/jO619MP7vPWeP7T8iQ8tDgzWSxykYkeEG+ZdP2V16cvW1TndWT9s6HX7338QK9JVRY6Lv57vP79CoUiCePGJSWkVnYNZVJKERYxwhGlACGD+vn9SaW9E6XVQmJIKYVQKKjCNMwM0TT5IF9sh//ffLJvXsVF41WVErN/jDYsXX3ksXLepQWCWFkgYg50UdMoXJqUK2na1kTBv0GF9Gn5v+zSW09P+3SaIHfiN06sAqoR8w2qVi3tnz6Bz3PHZt83QW2r1dv/9PLOPOT9PHjwm4LOl2y08WEQIGMcJ1IFrcLAcIYCStJPEF1grnq9sphRk8U4YitzS36rgNOyLJcORZ690ZA2TjEzbv2Vrww071imzWyd8Oc6TwmcX5Yr4ZIdYptnNDR1sI4qj7W5UlIuPbGS0JXC4dboxKD9g/QlNM89KRrqjb+4rPHjB3lcVsJBdk4fZoq/2bSGanp8uv/+vTmq5/ITE+2KXr5fus7r31bl7zliisuvPT8vt26pBvjbDK2cQZ2dELqIJ0OgVh2isgE7tj6cn245eXyj4FIQBnwlrfzbj/fNbg1yaNy1ARrB6CEQSpLOiYTGL2LkXcLEZQJCX67fOOLU3N6d/VcNmrl9A8yJk9L+93VwexkOcp4dYiirKZZkj3ur+79i23bzpyJl8ydNjX5b5/lzHyMpiQmK6kcEDhnRmk8ISsv8pUFGnc4XgCPI6pj37HE7LFu3LB12exPUy8tdd/229YUq+WKqq9fmJ757n/63JAnnDSC2pMSVItaA2sT/V0tvoTG6e+36p8mPXobycgof2Hq7o8+T73tOqlPSVSRN6p/YOioC6T06HJUBFCH8JYDm95f+Z7ms/2239Xpcgbh9KClMr+CIQ+amZl6+91X6iGBsowoMKwLgVaLmp3h042X9e1X2qu0RFEVyigFwkDWAYXAPv37di/toSoSYcxofCQAKAwWPgnUyGkj4OnVzV6QrzlswIhKiRStxoiiLhk5uT5Fpkii84Ok3S2NuisiZ7sLx/a44NtPVry3cHaPsb1zLTmS0EzRie8Hu8f8FCkBgsLhTSq8+zpnboaenGwZNrBTijdslaiMciwRgciBEEEYMWkY0OhJNsqgHdRFGl/H4ZwanIOisbXpm9X+JV/48oZZzhyGDtUARcgRiMedNX50wkk9vtmzw8pAEjTKyPvTQDkOojpm2V2WH7ixh8U9RLPImkWOTukaL+aCqzZ91JghhXmdF6/a+M3iZYlrdyINnDKod/drzsnrXZLkEUgENZL3xzHIjlaBI79ChOggbEDu2vrK33a/AyIIzAqi+QPPVSwj44zE/mHGFG5IrAIh7ZiIO8C44aH3ziCMljhprdy/4d8zaqsqim6dpPYt9mPN8odny6VdveefGXJZ6KGN+gggU6qcc0bKns1VT72fuGOf++MvfM/cq54yKKRIBDkzmlXMi4+cJmGOX8Xjyzii6oAwAOxJ3gFXXWlJ84mczLAUtl98Vq+SIhuzAEcOXEZxYM7ndSs3ZgwaX15T760o696n9+p/v7vnvY/cNlfFg9N6ThrpLe0eIoTU18uKghYrRUB/SygkFIsFFCXGbHIk5gC50OtD9fM2fF7VWj/xgssL7Z2DGGqfSTbfymCaownJiSeleCkXjTt31Tc2pncuog6bAKQCQ8ZYhyxLqszMTvmVKzc1NjYXd+/scbukyKJojjqjydkJlJCysorVK7b07lOa4LNxhUkJzpjaWnTeBREZoXarJkAnwDmabA9IycH+JjRaVjWmFqV1Pav/qFmff/TZ+k8u6nOJF7RDb38HnF9jxh6cqWmYnirMYWOXXRvQ04ohgREABYEQhHWiUl2WAZnEdWj1c0khmiyAxHUUTvBDGoG+ZRU1n8yXoN5z4UAsyAOhE8rM7C9NcNq9iWBTajNUp0HwavIpYHuXdHg3ESciO96L/kQ421YdNAapNU0p6ZWf0y3ntJF9YOXWd/7fX0YN65F3Wm8kwEXQAGBRC3R8EBWJwbVI4KUyogK7c+srT+5+BwgFiUGofnbqHWOyTwan1dTMYAIPkiT88Hjjz9n8sY4slAgJNLdme3xFN06y9+uGXmf3i87hAU3RgYUgeDjOA4GgO1nXcefsn7Fw+8ev9YMheOkF3GExhSIYQjAapBOM28A4ovq5x6fNHyNhTJWyMlOzshkBFMICKqamp/vSJSHCIBjg/uWrN02blVlYkDrpvH3/mV/2+tzcWy5wXzY09NLcssp9PfoUpl1zOe+U3dxQVz95SiJQ7ZqLFJ1snvqmpDpzzztLT0uU8MhlOwlHvqFi7dx9c0d2OXW093QQIBPp+xX+2GQhciCwr6Ls0cnbDlR7brnaMaKf2Q8qAzetD0eZErJly86nH39184a9dz808fTRg1WrYsT5LMachWZ349tvfTL5qbduue22CdeerGqGWodRpmNGl3DbyTXiS6ntotqfZ9L2C8EuW8/KH9e4o+XzTXOKM4oH+4YrppQy1X+oLnNMmQwqCIRAByAWQXSKOkEksulK1VWb182Zl5aX6j7r9FaXXf9oTvmCr5POPdvRtxcqcUNyop9TisibWv0A9t/cAGcPCzOJgi6ZWVCjKBgCUIRAhBDBIEW/kbZUBWD82f5KHjKN9p1GcImiSJmZqXzfLl+o2iq3AIiwQd4ikHAC9DgmFwkhNGTAC5WRO7e+ui9Y/eb+BUaOqOlJHNe1uOco70BhIVToFFnkhUyYCg0MaEfuNgKH8BcgSBFbj670FPnmy8FhCdo1gTyxoAjuSBdIhFuTovI23/ERyIC2VO9nFX4HeFuhnlZUWRx2ZJQY2Si5zVyTjmHOiq//6RxVmxRA5HBQEmULpFQypip4BERQCoQKHtRDqWcOy+7dl/XrluFxSnZnOCM1GbC28tNa2Nqt9FzIzgxITHE4HEz+6pW3T/Z5mlsC+197v+v/u5nYVEGIQGRHOlOG9aJ6wfovwpJ+WrfTvZAqonxY0cisXd7boNIxlJgIo8ztIHoYNdWAQMgJMtHWgC8ISIosWeya3W1VVdkERcbbktjAE5ikPhar4vSqDpfKgEpG4snMjrWRWqFRbkTCqWEEyeHEPqI/QoSEkGXJPr336MWfL1iyblGRtzCVZhvhU4ex8nKTJSYsLBILAYQoUiQqpwJRZyREQfU4dm7fWvHm+yO8SSzDu+bpfzr3N2iTLo8m1+L0wCd2loMgsWZn9rzjOu51BnMyADgF2pYQYNTgd5YVexBdgiqMGUIIyI1mvvhzPdGNsJlyipgLZqIIDqhznTXWM38j6CE0E+hAKeDxnR8w6neKAS3u2zrlyT0zgftBJhBqec914/Dc4c7EpICEERBv0HuKiNcQUaacozQhP/4TGFOZMEk9OIkKKst2K9it3KgqMKQoEUxJMs2z9D3Sf3PYnFbVr371TXeeq/T6uz57elrGc/8q/v2dmO4zL7qNzy+eooojqg5LUrW1sJp5W7OnRm7b95HQl6b06iV16yYrCkgyze+U9NtUaGheO2dhAji80GnvS/MTrxoPXk9YUb2XXejaX1n5l2mBcKDz+NO8IwaAS6EmMzM5onOno1hdvXrVrtW9BpQUJRYyIYcNFso2IfU2CGMMFaIOQkKOXk/azVe4AiFLaqpuXLhOkQiJRs4/J0QI0DMyU2+798pASzAzK1VWFWzXbdJ2VQLE2LNP7dOrJDcnT9WYgbfM/iqk1OgnMzrRI/bNSLod9iiaOmlG6isCJiWmdErJ61PQa/3mtZtL1qWmZAM39WtIhzxEASDruHvR0rING/qfMjzUNTewt2Lz7M8zenZN7tUTLUTk+nrfcsWu3lfu/PsrQZ81vHxTwUuPsPwsQXWDbTveQXWiH1WWlKAkuEKUoMRUc0dGnSCBULi+sjx56WrHkhpL0i5pyRp1QAl3u3RqUJHF169lYVsPjzD72QXInCjR6IzALxH3ELh329S1rWUfVS8xaPqCsyvH2Ut7DkvsGUpyBA062Sijn9Ekq0Pk+o7BfAhzUtvsfjcWHjqsZ5BCmYIwEUQVIEQ1vBIF3TBY1NBUNaEXJbEAo71dJAB+wev++NfQq1/kPn0PjB2dbGV1993RkJ6h3Xo1WhXCpDiciiOq44KsWLtsR2SH1daRVeupxEjPYmHTaKjVsmgFJCSEu3ZGAqhKquqGNz8OT5kT/MulqRL98I/PDXxpWl6SF3MySIav4MxTG55+SwY9edDQgMcFhCmRw2IqM1A43NY34BZGYjOCfhF8d+1MWVFGZ53jIi4iqISiTTKGI9TXt1YcaM7K8LqsEiCTjJQ5qqo1N8tmHleDZI5ClA+6bRhWlWlhQU4suYVwaINJTLwA0nzJab5ko/hozr9wYYCjlubwpq3Vhd1SJRm2bS6f9+k3Q4cO6FmafvjEwsFbSwkhbsUzKv2c5zY/s3jn10NTTtWpYEKjx4xk8LuYOBKueezVL7/btGK7+/c3Vk2dLl7/xP3W3xkhKpJWRfWW9nL+/Y5lN/2lB2zO+utzbOxZLYqqoJDi1uTX4GyBUUKpAsiihe7oU4t4tcbWtbM+a3zvI5oQ2rNsleVFvSThhsTS7pIstYfsh+1iPIwCbXx995gdMZJpfyrxB+87+QHlGNk0gWYNzeBOMvg0D6pykYOsBOTYvkb7vzLa0I0uShI2rkoFAvdvm/qnPTOBNwO1gF49M+nWMQXDIDkJFcLMIZjI5RtkmoRKZoqUHMNdjQIp2k6pzKDfAnPmmnBdq9fBpqHKgKAiuNTcTAHQYgnKMgUiQbseeFMxwDgWBwNjg2G0qcUl9jUAAIAASURBVLp2n2ovePZe54Vn8aTEot9esas6XK5aclr8QlMpI20J+vi8cxxRdbzxMKn7CSE8GNi26OvKRd8UXD/Rd9rwPUuWVz72dNFNV9u7dQ0iV3VRvmFz7RuzsvsWJZ55quJx5ZfvLXvzP2l9elomnA/h8NqFiwoVX0so2Dx/kXNwj1CCGqUpIeLH0iFGf7jg+tayLUu2LD+/dFyRt9horBYkJvgAQJpb/bM/mTd1yqxJky6/5ILhEGXXPMRykbYw6jtEc6Q9cPquoSTfuxwklMQOLSL59NMvn332lUuv/M1lE4Yu+nrZU3950d/a0rP0cvLD+b828ycxJS8xvyC7aPWOjduLtua6c4lo0+n5uTbfYMEgvuKCtPPPWvvMmznA61duKLh8rJafyZXoWF8E10oUIUwBdARQLNFSaDxEO/FjHmOXSIcrzgpAarP2HHZysKhQJigQiKo40jLY4R8p/igyj6/vgMyjuz2x3oHvQyrDtB1Msf9gZNuW88YouQ2FDnpA3wdVhvSqgWEIEtB+v33Kl027F9atBqFHUFKg/M3OD5+bOJR7rAbJJmnXpRSV7Dsm7ffo7dXDuGXTjg3rtldV1xACqelJJSXFuTk+iUWMYtOB6s3/mO70JuSdf6bs81Yu+rps1kfJJw/yjTwFZVUc/i1J+3sY+VYIbqej813XWDUrOu1IwOJNzLr3ai501eowBjtiTyR+DOKI6rjYEoyWlmWP2zOg757PF9X84/WU5lDdwq+daVn2wi5UUSDQVPfVMvmjRa5zRyQPHRgItO6fv6rHgH4HehT7szJ40M9fmGJ57m3Hs7fZ99fueHhGWu+ipDNOC7sdElJJ0B8CVGaVDITUCg2L139JBS3tWupiHjS8v5HuNVNcxJAUZKATdnjLJH4YI7W3dEd4hszJOSZIJESjDHg4bJGYQqBnSe6Vk0YPHNT1yG+v3eooyer+7c4VC7d/kdbbZwNbR2EZChCkGFQU11XjGzas5q/8OWfEpbbzTm2yKUC4AkwDUrd9R8vj0/J6ldRbeu9/8d1+xT0so0/iwHWUpHh89mtMLMc2srAoju75tu6duYj4EckgQqQkyi8U76Q6epfPY10PFL7XnfMTPxtxziyGm8TBSTU4liwIHldjT4OC0DASDbQ/bnv90T3vGakpDbDm1ebx+SX9Bqb1EXIkCCOiXdMG/ExShMiWbG31vzdrwVvTP9y6tq6msoUS6s1x9h/a/dIJI/sP6MJkYrGplpbW3dM+zXQmQHH29qkzXasrveeOY6qMUXmbQ8zf9yf1DIJoUDRN92lhFIpAZjZveD0KINVRHEKiG19xRHVcQmEwOM4IaKpzcN8uky5uvPxvu+c95StMSHzqNpqbBQBM0aC5aeNXXxennsnCbN/0WS2hltTrJyblZIBE68oqd5SVFd46wTb2dCkU5v7G7du3Jjb0A5fV6CrCaC/59w5ZlK4TyK7AjsU7v+yb0qdbQomBvwz/EM3mRI6A1SKPHDGwpGthWqbPJDv4TpYtlhcympiAx9JA9NDhXmwbFoydRRH7dzT0Mv6WQ9Se6JzB0KF987Iz07LSgZEe3Qs652bYbDbj5JKfNpcINknr4u2abcmZt+vL/r0HFRMvkg5T+5MERypB9QFRUVkPSay8QquqUjvlIWOEEXlP5fI//x2qakf/7Y7KRFvd+Xes/OPTPQozRVYGZyjHne6v0O1DrB4kRXMjSNkhLk/gMVRk/tfvKgHCBa5fu3ntql2Dh5Zm5yZzxCPUJEEikEuLFqzauXvf6NHDvD4roDBnylCQJUs3bdyyZfSY01IStP/uYzGS48CQMqIyAg9um/bHPTNBhIBRCJS/lXHPOYlD5eQkjGwsQQyVPnKY0PTYbrAIBkNz5yx5/P7XDlRXdSntNHr80Lrahs//s2jWjI+5Ltwed3G3dLTZvJecUb1ta9k/pya67faG6pRrL2c9uoSYJBkU6Wa6LPKw0EjmGYR81BCt4JxTanRmGUlDyRAXayOXVgwlWEGj3KucQvvR7Pg6Hov+zwa9RlGcUEOWiVtt6QP6pQ8rqgkvTElwSyWF3KLoAJRKCQMHOoeUrpz58aqHnsEPVxQOP1lKTZUsVqpqiSmpJffd4b16okhJ1LNTu955U49JV0oJCYIgEhEFOT+cHuOCb9i1fn9L5UmlQ93gMX6Ctqn8ESPwppQmJbu6de/kTbDj4d7HgIS0qaV1x64KbgpMERplMgCye1dZ+b4DQkTFyc11qJ+idfU1C75Y3NoSprEQU5AwAW61SUQRSV4bI1SVlYQEt6rKh1U/OOxiKKVZU7tndV9ZvX1j2VZDXxA75skBSoRRPbRh8gueypr8v/8lINHQ5GkqgoqUAzTNXWhfsmXYEzfrwwepA/ucfN91wSV7ts6Zz8KCk3hb+q/2xBqjqhIQCYmKqCHXAGVAFq17xEf9juW2VlXVvPDClHvuePLTT75sDYSAEHGknoNWVTVMefXtG6+5d9GXG4IBIYxaX1jw+qbWV15588abH/h8/rpwWAgh/rvfEYFQqj68dWru8nv/uO/9CJzChtmtI1YXPXtOwSiS5m1lXJgzdh23iUxjd2B/4/vv/Kd8p3/w0CHPPH/fvXdf+tijV//1yRucCc4Fc1esXLEWEVtRd3fvPuzS8/nm/dVzXisZ2D/p1EFBhz1gNMYSw25iOBLuSoQBIUEQhFDTvTBCjM5VQg1/oSCJRIzE1LUgCkbOC1BqNiMKcxIrjqfiOarjE6MZdXVqCHQH/LXLl1fMX2+D/L1bdvrWbWMer1AkBJBSklJuuNT18fqWb19zXn2P1K9nq8ehgCGOYFHA5gsBSiLIgbHERAAII2jCaGUi5LCdHMLoyqQEw+GWTXs2gl3tm90PQPbTsMWY44jS+EbBkREykWhW/dC3QkGEBLRyf8U/n399/fKqx5+6tXNBmjmvSAjdvHHLo/dNJsR+36MTC7tkxQL9NsJzHnn6nLz64gf/eG7G7bfcfsV1w1WrTIEIEQkrP/xg7t//9spVk26+bGI/BGTRnkZKYikv+qP+DwlxqO6emT1gA9+4c0NLer1GbMcmcC5IVN/azEWEKFF1vvuzuasWrz77uivppefZFLLoby/2nbPIM2KIkEAeNajfkJ5qUmrQZbMA0a66sHTscGFVJAlsAuMSJL8+t39ol067dkHSLn0l4r7iGLy+0+UaPnIQCqlrSa4lYvE4mGmOn1oc0eWx9T+5O1FDhd1TmWJGZIQRYrWqQ07qxUlLzx6pEvvpCiBBoMIIhkh08K9jvp0RPkrGeX9o++sP7J0JPGCMTNe8mHDzqVmnhRJcuqzISDVD6UsnwDqOQ5wAhLm+v7x2w8bN7qTQmWcPKinOEcAZwe7d8kuK07/+z866A/WEMJnZGCXB2gbe0CAAArsrrU1hKijSaMmAA8j7qpa8Mi1T52mTLqZ52XT9lvVT3klMyfVdPkZ4HfTgwNPBAfYYF8nBcoUE0K7BLb7944iq4+1J5MwpnLeuXLtm+ruesV2LzxmzZs7n+pvv53bKFTnp3LAcwbKqAAlIkCRqakhjI3AvYcw0EwyM9likFKNiLAZFIf2R/WpiESFEVX3lnqqyTp3ysrUsbsyVfC/PfLD9UJj1NjyoShY9GkQQyiRZAYqSIbMlDL2qSGDCmE6BUUEj8QxF4MZ5bmv/jEb9jDFCuaIY0ygxX4VIGCU6CiZRYXyQgFjNDoVuDGEBOagRcRijSYhE5bREX2FCzp7deyp7leVZO5vjLeY3QDiKthfS7vbRyGMTXl/qGQ/eaevRI+SypY8Z5U1K0lKSgVIJiOxLYUDChEloKOi67KrLbnwDjNJ8Yayj4DtK+YcbXPpfXrfeeuvatWsBYNasWU6n8wTLWUVdb7seZ/K/YrdiE1+HTMAeYdqk3YsRwKppZ4waMWzIYIfDTikRMeq4I3gCRNXYRePHjDt7pMvtig2fRX6XZRh37qmjzjjJ7XGZZAE/GNQKo1JgDgnRKFmVOPpU0CHd9eLgt2SUPLz9jT/ULIXWMhBhYK1vlZ1SWjgso3MpuhzCELoxjCMRpMPxOGGEZuVm/uGPd7YGcPBJPY1RbC6Aci7CfqHoTJVlaiSWapasXPv+Z8Vn9vfYh69dtzFr3lfe9GTusgmTYgIJpCZavY7tj71kS0t2jRuz7Z8v13y9Ju2eQdyiiiOpNNE4C18cUf0SK3L4/OUVFdNn2bcdSH/8Vhh2ktsmtY6/70CvUseEc8Bm1bdur/jndE9Osm/UNdVzVrZ8Ps/lcxCvzzDggpnRHJEZIbRtou6n5C5IJBLUdzfvrg00D83vqYFFcE4o/ZH4iJjppUicQRHMOt7/Z+86wOMqru69M++97epdVrcsd9mSewEbF4rBBtNML6GXQEJJSE/4SYGEBEISegsQWgDTW6jGGPeOe7csq/dtb+b+387bXa1suYBljGHn2w9sebX72tw598655yAqJfKUlJQLLz6j8eTm7JyUEAZSRS0JsqAw/6e/uowznpuXJoA4ch76XYvXqMKIqtfMPHvyoCGFAwYMsNk1q9fPqgyPO64ir+inRb37Egs7AEaUPy3PWjpwXYHA40oszx+8YvGKzU3bCpwlWtjc/av5yLPYYGC5DWpa0qD+bGB/0LTQXzPS9BOOIwagK0EbdWoaQlcBrbBOZBdEFY8y+x1Lliz55JNPAGDSpElOp/Ott95yOp1HCD7t8WcLlBNGOIP0vXMok4foqxNRcmFOh8PpcESgCGd4kLMy9EaP2+VxuyKtfwgRlqXL5XC5HF/h9pJQJCCkr3IbKSpmFQOsWZQxj/h/G5751bbnQfoAdZANT8nzZx57Ms/I9NptGoGNIhRS1nN+Dl1OS09K1Y6dUikl2G26GfoiZpq4eXv9lyt3ZvfJzy3M54Cisa7q0ef1bfWJv79Jy++Ff/lH0/UPJ/buZUweTdwOQBqQtPOSUyaumz9/+9Mvy+Xrdz3yRr/fXZw8bpDp0gC7u62wj7QwHu/iiOqwpnuMgCclpV90eu5FM219ykyXO3PqscEP76WkLI1r7W0dn89+y7tmZ78//DBpcP/tKc/OfvPd6SUlKVPSwG5IGYnikU2+g3hqZQgPSS3I/Ftb1huS9cvuq3b3OEBMu0y301OirxWbGgMpmZphA2GanKu9OIY5uZlZWemaHooQjU3+luZgRrrL4dT79C/REJFzDtjaZtZUt+X0SrTbOxN7IsrJyUpNSTEMG7Mc2CNULLfDY2hZiW47USiHUxJzocgVDNDWbe25+S6bsZ8uQiIkBObWnQNyBy+ev3xryyZ/zhgN7GEXhEMIU1bYZoYR8cYJpbmk2aSM9sVg9G17k0ytopTsAqrjqp/7iA5aOD4sXLgQAMaNG2dXT88nn3wS/acjWKnh3+v1AWNw1UFesXAHcWhhpz2LVd1qrBwkyu1abv5aN0WoXT9A8VVqVGjhJ+iUK0PlXmdD+N3G//y65lPw1ylXGwLfzmcKfn5GzrHSkyC5zpVLGAM8fEjDIrprHJmmWzcKJXCmbdiw+747X+to8Q07tfeAQYU+CnpbvTI7rfRXVzvHDzcTE/KvvWhn1ms7a+vyWwMs2aFuMJnAtILe6Vf/wH/Nnzoe+mPvU3+QdOZp7RkJWpgPEs0c44EsjqiOZFBSRgRuj1E+iCEQs0kELSlJHz8KyGCouwQfMXWqMXaiNqiXTLD3/cF5JVOOcyYlA8OvzbJW23fgDwS21WxPdCXl2jKUr0oksO0DbCCgz+t9afa7Tz70yvmXTj/3gunIWOgVyc8ZcIJAQLAH7n/8vTfmXvfDyyYdP9KZYFhCDJLgH/c9/N/n377+2itOPXOCJ8EeNoRQv2p32GJLTkzJac2e/d7ddz5wxeXXXnLFFELUFGXVDIr/vffFHbfffeaZZ99401lCmgjImJJV6XrkFotMBz3HmZXoTthVX91BXhckYs+pzsR8F1ptxrE/2eebLZ4+61Jko+4M9ON8q71LVtYfhg0bpuv6/Pnzj5RUIIXVEiDSyIrfn/zbqswRdXlg9/OsUkSqmyxNTcKosxV+m0g1jL4mHoju96mzIxtjv9j49B1bnwcZANSAml9tOm1IxfFpOQW6Zg9gtHnusANeFnb8YqGgT6hx2LJl25133T/vw2XDJww4e9ZxxfkZJM3E9IyBP75c1zW0GZJj4rChnv5lnHOd60KSxRCUAHbGO/xB0dyWALB9865Ur48hKoMaJBCKshGPV3FEdWThFHKprPIYt8nOmMyBe6TSENcdnA/qLRGJEUNi2RlaVlqQSGMc4euVWpSfAIJPeLd2bElPyMmCzM45yA40RwV6fSYCt/b1lJWBCppWvT4MkqQZDE1jzhlTfjLKmjSUvQV8QSXPYO24UVQddI88DSMQw+cPSpIUy7BX4TgQkFZIDmGp/W7/cdB6aXlZrqzdzdVtgdZkW7pG/PDf2APfFybBz0EAalwigQYYiOT77Ovx57/TNarPPvssPz+/oqKitrYWAJYtWwYAgwYN0jRt6dKl3/yBBYEUj1jVmLsWG74HQ6jMK7xPRWQqG7gDR3IWeuqZUGK7Cl99J4j82KlSIwANhj/f+PTvNz8X+hsDCNTcn3/LSVlTuNsdimKCGUwhy280WyIJEhls2VRz/9/feu3xRWVDcy+9eubwcf1FKCXWhQOl0yZCeS8aAoKa5k1McKiSIjEpAU1gNilh81bbP//TUZwWPPk2+Y8X4enZjh9dFsxKlQiatQDE41YcUR3x6ajUE6zmCFKVC4VbVHbBkASCZKEIpIeF6yzRzS6R6Cum6cSBSxJ+M9DY0TygoNzBHOEk8wCVLdIN44RpE4dUDMnM9AAjrsxEw2eh6jOCGDDz/AvOOOnEE3v1yrA5NVWOYQQkQF540RmTj5tYUJzldOv71i/HcFLLYMqUcb2LSwpLCkl1JobdTXUcPa78gYfuys3NgLDEA3WnUNVJF/bonqyUjEWt21t9bWijLtsUPadf/jWKJRyQRYobpgKXEUpC6L4fvRNj7dq1p512Wo981IYNG6w/5OTk9OrVa+XKlUKIsrKy1tZWAFi1ahUA9OvXz7r4q1ev/sbO0eIvYpjP9/1SLbSMA3w+/8Ivvmyo906bPoZx84CzIxAIrvxy8/rN9WPHDsxM9yD4LWFPOmg9lMN+XghM0sGcfNcYQwpho44wp2HFhFV/BtERSo5YxzO7Jx5XeqKzqD8ZDmkKxlTIVBJNGKvWd5iHVJSJbVt33/vXp19+5qO+wwpu+sVFkyeN5IZmSuKSdKYeY5QMwlY1dkAtdGMEqm3QIICjwzvnuRflx8sq/nSD+4SJ0ut9f/Zrg8uLMk89BV1Oy3aaIK4NE0dURz7DCYECM1yfEKpvmCmKRghdmYp8IMP0onC7hL6Xh/FX+joVAyhgBjtEMDkh5SCTJSU5gsjNhARITHERScZ0Sz6UA7a0dTTWN+XlZRFCZm5yVnYSU92HSqxHdfAgpmempmQkMG6Zp2O3RxY5R4mELqfu8LCkFJuMeTsieJIc/cvzOOeRK4D7O1cAu65nJGW01XW0+9uoG73fwwCkKGxiuH+ICk2tTIBMdnMWCltI5G1u1pDpCR7Z08f5jY3ly5afeNKJVVVVPbwqKEmhjIwQjN68ebMQIi8vLxAIAMCaNWus95SWluq6flhxVXT5p6q6XcvWMhIZfUtZQRZxwO8RrNIkQFXVtr/f+9iaZdV9yor6Dcg+4Bxpbm5+5P7HPpuz7Zd3XDtz+hjltvttumRolVnoKxZ/FDxSDcwfNa6cuOzXIPyhEC6aH7dfdPqYaYHsdDA0E8hADvBNY2/VTI4aQm19w1/+/K8X7v+0d3npzbddNeWEfsgjzc4KQhmWyY3SntLQMvITFr2eFKKCbTs9ze0515ytHzOmIycr/eoLCh3g2Ladd3QEnI4QAItjmTii+iaHGXoRC72kRkFAA4AL9cwHQDhAV7bJzDJQMJjFYPYzyTRmhH4ZTSVZogVV0mAcQnpDQuqMd3S0+AL+lKRMBp4DMNmVBABDtmtn9W233C3anb/+09V9+2dZjXcIWFVdffedTyz/fPt9j/20T99eiAbw8LaeSn1Cv4sggUse7m3Z1/eFFX00DIKwvfjs+3f97sFrr7vtshtGE4JkYV4rIWecK+U50+pQ7hZVRQnfuuZI9qQEhdke7DAhqFEo+7J8Hr526V0hsz1jiAhXL8CvxNlx6+7ljz5RUVjEzzkZDB3++vCmoC/v0otYRooAEj5/4+z3Prv7wdNmTGC//DHze+H3Dyx59PWMR37VZ9qUYAxuPrpGIBjocTgVRVTWSFW6a9XV1RYbx/prtKBVUFAAqv80Srr6GsvQPn7EBCAzoeOTeav/+I/W95a1Q0daRfHQ391kTBhNLqcGnXLf3QJitpd1wNE4GEokyspKG39sZWbKtpLizNDiy8NiCqYw1VZtEMBmca0sROV2u6ZMHsdpYf+SHEtkXoEqxXkAKULzO4RppFTyB1FB+m6URASRiIjAYHTz8Ss/URDW2wt/vABJEkmySHfMnnepUzOi0z0QCYHj+42rpyz7DTANRECRG+qeLr/jjPRxBtc0xizzVqWjJw/nzY+EH+osuUkQOuq7qptvveGhN1+cM3rCsbf88rxjJ/SORbs+gPrNm6tuu7OovLf7gtMgNxs+XrDrD48Gpo/LuvBMmyfRCeAAgD4lg351CyBKm40R8aHlZf3KGGNos9mQxXXY4ojqGw9DkZnEgLXUNax7/hVnq6/43DP0/Hzv5h1rX34t0eXJnzUTExN99Q1bZ7+dWpyTMbIiEKDNH7znaQ9mTz0GMpJRefDioZUvGEMi8AZ8GiO7ZhwoJ++MahzRZtM7vEBkNbVIVYMKrSKcc82hIQ/bm4X36SiqOxAm8lqq5Yw6M9doj0/M91hBFmy6ruka1wk7Y1zMamVZjx4QWaotQV03EMkf9BN0alEdjnJjzJ8JkhNQii/ue2RU/8KOpsaPH32m8pqLdLvDq4I5M+yp40dnvv/pnNufnlBctC3Ts+vJ2YOnjkocP06aUvVQHt39+GeeeeZDDz3UU5/m8Xj2+ElycrL1h+bmZiJKSkqy/rpt2zbrv9nZ2Tk5OYsWLdr/0wFRMYtOpjXhPmB/6Nmpq1/15luJTtuItx8MSN/C+/65+7P5hRVDgk6nsuT/XqwsiOB0OK648hwphG4HU5AWmbpKfK4LxzsULhDtNtu0U6Yef9JxhmETQlg1ZhVfrDeTCKEZ1HA/zEiKkNw1K6khYBHQ9rWLONY0U22I3ReRqPviFIBA0jmb07BiypLbVIhiAL4X5fQTBp+qZWdrKj1mR9IZPRSJ123cdvefH3r7lfmJSanejuArr3zw2rvvSmFSUDCGY8dXTps+Pik9rTEr5cOHnxtbVujs753z/H8LahtLhg0Fl9sK9QgoOCOnIwLVADhHl4tUt3kcS8UR1ZFBVLbIn526PVe6dt72Yq1hyzvvrKbZ77Q/+krf6y4Ejx4EoWm6f/WWNU++7PnRZS0d7dVPv5o28XjgWhCkDqFYoh3qwh+a5r72Nk1Dm2bQ/mvGlnOAKuqmZab88rfXdLSZxaWZUlHOMTSlRHp6xg9vvKi2rq5XfqqkMOdS0dEtpdGw3DqixiOipl2Px9Ke7jTdY2AAwuQTxuSXZPXrOxDDqqAWPCMCwZErOMXpYCAOgqFwmd/v4+GuLHaYHmVrfbATQyl8HqP/WTMXrtxQe+td9jW7s84emzX9pKDLbqgFxs9Qz8/s/6NLdz41f9lvHkpPMexD+ybdfL2Z4GBS6ke/ALeu64mJid/AF1nKn62trUQUqwJarUZqampJScn8+fP3B7kjRQtL80zb69pHRW4R0NRYcmW5a+ZJYtiQQEtboKyM1wbALwC/V7RcRETDUApsGNA0ZklJECOf17dx3Za62pbhY8pdoTXYtDATItN1rhtRjMFVuYtMEVi/acemDdUDB5Xm5KbLPWrYXWYAIYIQYsnCNXW7m4aNLk9N67EHTLHF5V65VkzBsvNIpEDpA+4E/mHDwuMW/9pyXAHZdp77mJkDLiKPC8M1bNaVGPCNsowQ0N8eWPT5utefXQABw9scWDF/+bL5S0MBlEwOFIBAWxONO3a8O8ljXDwzYfPm9j8+Kwo8CVu3e66/ONi/jBg3QKIiIEhSzjN4KBTe+Igjqh7MFzpVO0hLSEiadtyOLdt2P/BGzsqqwKIl6dOP46eeSMyGACzBlX3xyW3r1uz8+X06o/4njU2ZMZZSnKoqzgDokBqLyNo+F37Tr+pdfB/znKJlo9ZWs76uOTsn2WHX8wuypSRkXDXgMauYxDnk5KRlZ6dGyj9kscUZYFMD1tU2Z+Q4Ezx6c4u3amdLXl6qw61hVOscsKXNt3lTfWlppsMek9cCJSa7RowYHO4JDG83BInI22puXFuVX5SVlmozD0YOR+krAIAwAwTycKeFEaEdJhD04vz8E49rvPLGBIDKU38XyEwPcHSrSp0GENS4u6x32d8un3fjj8q2ZuRce7HsV+gHMBB0OphugfjoHG63GwDa29sBwO/3p6SkWD9vaGhobGy0kNaQIUMsvdDOtbGzjT9cKpUIAQ6MZOgRR0aIkdpF6EljEikxsWDGScgFM3S+cLlcvlrMOCWY5Kbv0d3qapeu2maiZaL6usa//eXh1cs3/eUfvxozrsIUJjLGYrQWrM1BVc8LwafGxubHH//36y9+cfNtV8069yRusL0e/dg/s+rq2vvvf/yNZ7949LnfTzlxnKZzoqh2PX796EySocUc3/ebQkGcmYxroC1uWnbMwttAc6qgF7jEHPhI0sVtg0oChk0Dy+vuGwYcUWsviuiMAmneXsWeC6+e6gty1Tarav6hnNYEIhEMlg8pcxmgkUwfNKDXadNXXnoPW7h88BXX2ceM9HlsBEGVtSqWZ3cC0HFEFUdUR3jIMPGH2YpyBp0+re7ZBaseeyTjmOOyTjtFZKZZYuKEkDyw/7hJ49e+9heC5PzfVmKvNBNj+m3xUNMxjKhSHVD1uK3N/+KLbz/64NPXX3/FOeedQCEMZlp2xco8EKMiVhhee6z5HG6NfuCfjzz37Nu3/uKS6aed+ODDjz3z+Fs3/fi66WdMdLp1jEDDJx5/7t57Hr/llhsvOO9Eu8MIL27Y6dMSc4QyYIp33/n8N7/481lnzvr17Rd9Faonqcr+4UVUEZs3tFTljebmnatX9od0BusWLZhfPnyY39Bc6upxAC8IZgbqli3zgY/B5k07tubrGATQ6EhuFRzVw1JUdzqdfr+/tbU1LS3N2iuyegPnzJljs9nGjBnz4Ycf7r2kWmqtQRBIpAOLqPKTWvml2rqSoZvD0O/kdrDtrt5R/8QzJe6kXqOHSY+HoLP8+l1faaKdMdYVYjFLLHg8CaNGHZvgLMzPy1MK6HyvX4zRbwLyeDyVlWNqtjmLivpwQwcIsm6qyNFfhNTk1MH9R5gnphYUFio4Fb3wh37VD9BLEmF5wvtNK6fMvxm4DUQAyDfLPf7R/OtEkkM6bEgsIu57RO6LBLTSBI4AbsM9Ynj54EH91UY2h07maITIwbnDDgTMp2leDHaALxU6jOZ2MEK31iTTAG4lFSwej+KI6tsVhMK6NSQBvci4kGRKbG/h0IQtXvC1AZAATag4o9c2b9mwsQk0FzR3bNjoqqvQclIIhRKHZGGfmUMqmFnhTBCK/RfVgJgv6G9ua/cFzbCLutoVCU1aJS9sHS92CmxaRxZUL/QG2jvaWkzhJ4KOjkBra5Pf9EqUmiJHCZSIvDXQ0d7c0u4PHQwyKWU0UeQWAJIEEWMKG1LQNP1+f7MpfJGvMyMqTl0G63q+EqPC8IcrmLWBJEauUEglPwVdHbzu5XeTnpyb+Mo9Kzdtlrc8rBUNSJ1xQsDG1Z6HTGgJtL707s7HHhhxwZUbk5N9v3lWy+6VdMW5pmn6DEMniqu7fO1hGEZqaqrVDFhXV5eTk2Otu4FAwOv1xj4kUR+30NQKBDWvP/Ss2Q2vjdvVLhBHYBKD7UGSJtccnGtO1PSla2pu+0ODh+X+/Ma2ijIHkl0Q7avVQR4Fq9FXVDEggAB0J8WVmOT8wdWnRNRRJOIeiAoh6ioQyh1It9lPO3XKqadOUqYIRKRHrfa6O0hpcxjX3XQmWFK5FISwfcuhbqih5T/R/datxVWQiPoHrWsmzb8WtATgdgDzXF/h064L20cMbkSDA7OBZGSx7eEQLXoOJjmPjXJWEZBQA0l+r7+hrmH9qvaaGq8rkeWVJOQWuRx2Q6Jfk4wT1xT5IXSuJAUEgmjgnIUrHnu+aHyhkV45/7MFfV96N/GSWWZKsjoHycOnFAdVcUR1pMJTNKXaizPEAAwpvJu2rXrhFb13QsUxv1719sf1L73VJ7+I52cDki0YXPXqa+sXLp141zVUV7fif5+U9u6desJY4dAtDVz62v0tljKBWiS4EYpcJCUL88W7ydeUbZbtrNOnHTN2fGF+Zlgu2dq5RJWZKtsVipnjFukciEkkDdi111xxxswzcgtTXHa84spLTj7plKLCHJfTTsokhpA4yCsvOf+YsVP69SuwO7glbSVIsGisQKtJ2fKOQUPjJ544viD/kaLCgq9SnSIi4qj3GJUhzNiPmh0rrSwEbgJwaYLUNO7bXv3Z6hUjbjhNThgzaGTlmkVLFy9dNHj8CC07NXTFhWhcserNx/4zYNqZKT/9oeHt2Dhn0bx/PjNw/DBH39LwYh8Rm46Hia86TNNsa2uz2gBj7bQ554Zh7AGFLRFrMM3GL9eveOL53K27cqdPcp13quBaaN0hDKzdsPKfj6S1+vJuuoYN6NO8eOmOP/4zYePu8tuvAadb7Gqk9CTSNVX+ZXtVhIlFzSQhlnWNRzRAhfCTzysXzF+sM33g4L6uBO3AG2cUaxXDY6sdsWGPrEINhSn+QN2YrYT7gNWFl2g5iJNlqoexO/17Ri+0+mKUY5U1M3BPL5uvPthe5TeVxllaK1ICmOomLmxcMWn+9SE4RSaAeYFe8WTe9bIwxYFKEwbIUN4R4R4HOgy+Mp0qexTpr+nSexgwadO6nS89+9abb3xSX9vAdVuQ/LqTVw4rP+fc08eN688dXP1qCD+GUS9j0NS49sU3fN5A8q+vc+T32vy3f23696v9KgYbY4dLXVf6hxL3uifxqBRHVEcCUXWHVKipteXtj7Xn52b96iI4Y4ae7Ky+b3ZpQR/9mjOZoQVrdxlzFwyYMcU5a7q3oZHVN7F35kHlQMjPMhmFDQEO4YFmCEEUdo/HHzSF6bXDvpQ2Q8FBgkxL8aSnJgCBKWRra3tTU0NKeorb5Wxtba+vbUpJSU1KcguFWhCIA6utb2hpbktPS3O7HUmZelJmBgIPEqWmJ6alJYQFsdSevKaCckqSe+wIdyxusHY429s7tm7bXtK71NCprdW3Y8eugsIch8NudxrDR5Yi4wfpKMaIZDAgJBmGrafILogsEPDXLFpqEKaW99Ps9ubd9dtXruxb1h/y00JhSqDuclZeeXFyRlZrgtPhcfa6/eb21nb0GExxdUmYtsaWYWPGJs+cHOxX4vP7Mn95Q82cub4dO919Sojz+L7f1xuBQMDn88WS4hWHOoSihg4dOm/evK73Mey0KEiaGqDL4dlV737pIW91oxg32FXSxwQUPn/74qXe+/6aPOUc5nB4q3bteOTf3v++lgY5a/71VK3O8odV5lx3vpmXxqW2N/plFH1KZdh26luwHlnL6aZ1VXf85m4KuO6655eDhmYp6uMBt3eiG3BahLXTWeWyKn3hj1BSA7K7cpMl+csVOyDylTFXhfb/7RhpSGFfB0Kx2P8jhI35FDqJzVNRho4RVZaI7NPmtZM/vwb0xBCcCn2vmJUw9sk+NzUl6Q4AGzD7nofCDk8dUaI3AEKCSw9dOWAggmbA1FBHGxdEGzfv+u2v7lny6dpR40b84IpR7lytrcW3ZN7qD1/6ZNPqqqt+dPGMU8c4ncwEwYgxdSGRwN/UkuznuZddbB85nJJdxeefGfTN9m/abgwdQElJoQwc4voIcUT17UBVImzDEt6XUrkOtrS3fdmwI/OGaZkzT5JpCSlnnrizo2Fx0/bBtXVabq4vNbXXr39kT04Dt9uemV5++y02bwBSnIyCADpXi8ChzFfBgBG6bW4QWpvfG4QADyG0fcQfxpQcVSj++n3+12d/8ui/Xr38mhkzz5r6/luL77n70UsvPvfcS6agTgxChyYle+SBF197+dMf33z5CSePcbo0SVKiCcSY5EqbSiV9RPshgSqCO7792kd3/vGRa6+96ZxLRr7z5ty7/vDgpZeffdV1p4MVSjoRxz4L9ZZgVkBgh9+ro3A63Aj6nq3yX/feomETH38+95EXjv/drdqwQWvvvXfHl7v63v37duAOYa798MPc9xb0OvUE6J9s+CA4bwG9Py9r2rHk9gQtnpnBHJNGlx070nTaScokw8ZPmpB13CjSuFWDPNprU0KIjo6OQ/8cu93O2IGfd6/XS0RCiNh2P0t2oaSkZP/aVFZ/mU7MkZedMXNi07P/4HPXZ74/F7ILyemQNbX+975wQVrw8hmiKNtb3+A8doxekNsmTAN5iol6fgGz2YD2oSCG0g/oZ9gOTFcTl/CQCio9AKes4jJAYp5n4Lh+uuZxZjvbeFjbZf+/GSVAOULXjaLERPVMo4zWr5TPpXVtrfkpEDQCXYDJrHcyU2kZd3M1uts7pR4tjVBkJ5Yx8CvjBRtwCh0gNwGDAA7EIIJQBf0FjWsmz7sGjGSLPjDTNuC/WVcHirPbGTpDgIR1dD0ohtSD8ixW61BYbEpi3UOvLv3w40nnnETTp4L0wwOPLVm1MueqH6QPr2hr8N77p9lL5qw4Y9Sg89t3DtDb6ZRTRXPbCd62Ex+of6+67l8PvpSV5pkydYgZ9s5RxUGQ7pyMxNtvNJ2636EhUsq4YfqgwZIx8LhlHEjFEdW3biBElU+UZ7BMSU+fdNstqktGB8S04uKJv/wpmCZomjSlU3ewgjwCLkF1n2RlQNCMsKdUf15P1Fh0rjt0W3NLCzsQPEMMf6eUsrWttba6trm1VQjqaOvYXbWrsamFiAymGGCAQkJHh6+pvr6jwyekSsqJ80hAVBQDUv7K+2/BJUnQ0tpRV1tfW91AJFvb2hsb6xvq6wFAZzwshXrgAKv6fgPB+pYm3WazGbaectOSqspWeN45Oz+ev/CZF3svWVz17mcz7/yzLMoPINg0m8eT8O5dj+Zu3zzoz791Nwf+8pNfjGRJk04/XqXEwgKNQRsXBtM419XCFNS5YC6dAWffhSD2nBqH/jkLFy4sKytzOp37wlVtbW3dClalpKTk5uYuX7784CBGaI1x2RyugQOaYNwqmJP++TJt6iR/UWH9rl1b3/2isnKMs7R3Gwc9I6101hkYg8WAQEhiSoQNulv4rQOXkSKVPNJVKsvaWZCZnJJw5+2/BIAOEALMg6lDRLsmQvg1NJslizTuSow08QF2JY+RJTJneZ5YxlFhdnoItSDCHloV3SAS1T+MDHpAaF1JX6KMfpnK75QzjCrZRPhkgmS78C1v337c51eBLc2ysTjPM/SpoptFBg+EzoMxoGDo0nW5bIIQe46YHjZWD32sIIT04ZXVf350XuPjY/qXrvI2b73phwUX/CC3IL/DlMs3rnv58devvuHsH58+dcNxZ72/bOXQyiKtqe3De+6rGNvnkvNmvXf3f95/953RY0sdLoNhp2E815k/zaYatxkABXTwJdtsUtORxeFUHFF9KwYTMRlGaL2UxDgi0xBRmhIEaLYAY34Q3OenlZta6qpTB5SJ3Kzghs24eqN7+FAzJzWI0iDOEUljSNbedygQEB6CYLp6GVJPMJJcPKGmqboJGjLAfRC/KO0uOPuc4ydMHJ7bK93h4iefNm7YqD5Z2Zk2OzdFEJkuIaBr+rU/nDXrvONze+W5PTalYgIETIbyoSARcaYdRLRhgPKMWZMHDi2qqKgARmfOmlo5om/v0mLFMQ8IQQbaVLHKahhm+ynb+c3m+uadaXpCui2VgWYRRg+xKM8ATQGQl5nx2x8bI2+oef31aeddHDh+eNAOyRJ9GMgeNWrS33/+2V8fDtx1f+vy9ccu2NRnzjPBirIABAz15SFUxbjaZxBBJOCkEdeRSUZSZaTKjjo+YNiwYQCwfv363r177/FPLS0hNJ+SkhKrqJ6VlWUJqa9cufKg72YI6UjiPiB7Xq/Aw1fVX7bG9cQX4tyNLqer9r9vil0rnT86DwryGWgitNSSiRS6a8wy9wO7oqXEErY611dgyf6Ava7Bjj4hUIbefoQzf4yWdlH41T6dRqgBHrhuhpYCjC4J2hE27qpr9IuRhVmMiMs9a8WxviRKa4W2N7RUtfrKslKT7boWlIRIDLrZ3u4ONeHBbAl+hfkbkVy2YJo0cVeLe5vgbe1G1W5TSj+DJbR9zIobwEgCewbI4AVNOU/SD8whJR3+etrJNWkZsIY+x9grVmJ31bWvX+6NmJUFEaCXY8ZPz6u57uf1v/qrY932DBgxYNaFXtPv27xt5RPvpCTZjx07KLEAB/7fBR/denvw4luD2cmVKcm5f72pKaPXqIWLv1y9o3q7v3dfF5FUzrEh/CjQMMLyFiwMMXlYfZ3Ha1RxRPXtGQLB9AVqly/LWrtFGzEU+vWW7R3+FWtw/Vbn6ArWu0BZobCdu3as+9cj40+YmjBpwrbHn2qraSivGKS0yCWHcDIlACQDLaz3dKiPORIYup7kSa5prJdkHmQURtCJpAYeM6gRQWKSJyXZQ4rEqaiZAhVyyshIT89Il4RSSZ0rIVBkiA2NHbVVzTn5ae5EGwstOuwAhTHSHUZKwBc0nJrDaR88uFSoIp+3VezY2pCZlZKabpewr54ajBA2ZWugsbapOjE10WFz4p79Al/zOkoAk4MuoMBkVcXu4KbkgM1w+ARyI6CDDpokmXjWjMJlK2rv+WcTOMb+5kY5otI0TY1HQjnu6XYiUDIWKwR/VIp86rqen5/fU59WVVVlmqa1+xz9YVNTkwWhsrOzrW4+a+Tn5xuGsX79+q+TZ1i8dSLhdutjhudMmLj9oxfccxelBmXbo29oqSVmxUBwu5SFFGC4DVM9wVbfPkX65XHP50ToTNa0fHbHI5VitykYhZYx7xFXw1clNRGZIwhfZS8cQ0kitQj90TVbF7fjn8eWujXu8bfviVpkhDJNUhI2Odhbq7a93aBfMbhXRZI9tbnZp3GTs25DDTtsIiesq74wl9BuA4kyZ0FVeqC2/a9PNnwytyaRalICp0/fDbb0UHRrC8yqwgev3rbt5Pt8T8kAA8G43SRry1J0kY+wTnzPnk86JJcGVfGSIJmUTGgEmjdoA1b/ylMSWDL02XHv/W12uQNS1n+0JAOTG/7z8tZnaoINDVngaFv2bnBZYdHffmIfMkDUNvQvSntr5Zba3W29+6ZKKVj4gUWLVm9x4njUwSJSZKRDcOuKjzii6qmAZWmNhxBA6/ad2y/+v7Qfn1r8ixs6tux49/d39fbpQ8r7KWInks1WOKTc07+88Zl3O5as863ZWHrp2UZmpiTiUXlBQMHCupk9xHhEm2HPTsmq3rKrUTZlqfmjqBWdzSR7x6KAz3z/3U8ff/C1iy+fcdasqZKZwXCFXFdRWVh5ryQh0fqoCNsJgQN75ukX/vvs+9ffcNkJp4x2uxxKf8FSxuq2ow0/+N+8O/9437XXXHX2+VOlRaFEMk2YP3/VH353zxlnnnn19dNjeBrQ7T6B5GadqKlrqi0uKXXoTrWfEL2seCgbB6Ffrmn84NEni3qnF47pu/7xD4vPmO4+dlhA11RhUkq3090rB6ABoBBy8wIaFyh0U3BkShxGWkdghs+cKXnJSNd5+D4fffT08vLyrVu39tSnHX/88e+++24UUTU0NJim2adPn+bm5ti3FRcXM8a+DpbqCn/U0gKeXjnFM6bs+ui/Ha/N8azeatavSj/pdLNPsdB1DaRBFFn1WRdM3B36DQIEkRktpq2hLamuhZQsN5P+b2I7RW3DA8du+mQEEJqkB4G0ztJP2EeFdZc+MLSMV8LFJ1MiszNbeW6eZiQmNta7CBNbWvYADdxKdyicW3IXH5iSWZedmS1b3VX1ybWtAUMPGkwRw2nP5E0cNkQlu95xApeDJAq+vTEFqh3bHVsGBiZcnQ4+AtMBjM+q9/zn7O2NA20NI9G2fVeCTzPtXOjM5qMQItVB8NCry/ELhnsgwkO43dYWLbM2Q1F6dWJN3iCYTvBxoBZoTF2/2+Eymtwsudm0OwO22vrEtt0NvjYOHYkArRDkviCYgmmaJiQKsOq5iF3hnvp0gZ3paXQ79NvQSBEf32tERRC28A2ls05730kTdv3w5M/++2ZessdcvzXx7dXpr9wlB5f5yXRIHmTgy8mwnzl916erch//y9ArfmqecXyrTbNLqRNFAgzqXytN4DGFDhbhM1jVXBd3VnjKn2tbtT6wtp+jQpIwQ/m3rvbXu99HkwLbWzpqa3e2tzYTESMebuMFq2lYj7REc+VoHpq6QkrGAJkpQW9qbKneVdtY3ypMTtLSnokkRF234SQJIK2xqaWxqam+0a+wlFQlegaC2lvaamqrmpvqDwZetoNvuXdtXaBlcmJvN7hRohI1P9QAwSmEmRoffdz/7mfG/b9L7933Ex1rfvq7qY/dawztE0BExrTPlqx5+uWiY09xflz15TV39ztmhMjP9NqZLtX6FLnCvMc2B76DwypQWZYyNptt6NChu3fvjv5rWVmZhbRWr17dE1lG+GHkLrcxptJfOVVb9FrHYkiAwpQxw1l2FifJhWo7R4BQ1kB+JiRDnTQu1UTY68kyAGymrO6bXvnYb9Nzk/Cbu8kCTJMIQdMQg2oXR4tdolXpW3QXjbueAErgikwOCCaFmTYYmq4ZCNdFWVN04BPLBCgFOJMii3k0uB2pEfnqhBDyDQaff+X5R/5WfMGM4/t9Aq3hfz3DOeQ/x94EppFMRnJsYTsqZvxNHL8ifZGmlhVM8QW8s9/YdN5P0i+4Zk11Vcp765Oe+D2M6W9rDrzyl4c3/XtOwm9uTRrdy/b8c4suuigVwA47W3/6VMr4sS05Rauq2myp9rQcqw1Ww7CEVbi4ymMKVNGkLo6k4ojq2zHQUltBIpBJSWlXXpK7ZOWKX/7KgPzRv7jYPWliIBhgOgvXVc2gaGnWbExCbnNji6OuXk9O6tJM3EVa4FDDiIXNDNCyE7MJYe3G9TDQMnPZT4EqFADtNvvpM08ZO2Zibp6HIQppkkTOOYtKm8TonFtoSWNckhQkDZTXXn/FjGlnlZRmuhJ1IYUVipGUXZoAqVm5nNrzQs4YnHHmiWV9Bg8fWUIs9HNuHZiBk6aOzst7pLh3L9ivALqluOP3ejduXW83jLzEXEORqBB74DoiQnObr8njmPG7H8O4MWBzT7/uii0vzYbWJhSScZSNLdv/9oA9Nan017ewRV8+e8sf5BP/HnDz9ZrdrUJYZ9LaQ0L43/ExevTo2L/269fPMIzFixcfTBvgQS6uGHnOJYKWm+06bqRY9I4PyEgsSqoYLDROpgi9x+cL7q6Xu+uQiGUk86x0dLigCwmpy2RlYUK1RQVmYTDDDmtGJ5EwQLCjqt7nDZaUZhuGbi2fMcpNGNE37Tzm7uiF6A+KDWu3mAHZZ0CxXWd7VFxQInwlgXCMmUJHZLC9sadEBl9mBK++IxECH4NXU3oOSWcm9nm+5OeUJEFxWKELS+GbK9yEADBjCMzKLYI7d7/06FPDxlZk3HKda926Re9d1fCfFz1DbzHcieOOGfPkv+Z89OEnA5LGVD/0jMYGOGRHG1TVQf2CR55ynjRjwWfLJ04ckJ1nC6ouAhY2tgj3COwzIsUjUxxRHWE0ZbH6LOCvGB/UKyvn+OPkp69JSHdXjvDbDAnkkMLP1C7Uui01T/83KcPN77h13cvv5j/+UuZPrhEelwmo9bxrCgtzUkErSCxISUhau3ldcKBpIthJVzVxgu7FugkZJaTpSelJREJKs63FX1NTn5qakpKSEK4dY2xiRYygrqapsbEpOyddS9DSUp1pqQ4CISHQ3Ni+Y/vuvILcpER3W0vr9q278grzExId0W0GIJIUTE4TgWBA5waGdXxMFWKCzgQhwE97UUL3uA2E1NzRsmLrsrzk/OLEItZFk/CQ4gQRJLmcST+8KtzASEKv6F9a0d9azBymXPnxx2Z17fAfXirHjWMVFbaWOtsHc2HCUvvk8fEQdShj0KBBNptt7ty5uq4frsIYgJmRxieMNu+qaIFFeOmIXpUDBADjIMxgw+LFdfe/ZJ+3Xqtt9Y3Iyrn+YvfkCeB0KI7vPh8tjHa7UjSVOFxLsATBUauuqfnT7x/esLbu/n//rHdBltrswRhKjGULLCJNbwjEeTeFcKyqrr7hhj+vW1z/1ud39ynLVvUpTe6FHrWjSeuDwhmfAOAsAOZC37pj8H7wJVu35RSj72z35VjeO8BIt6qPEard4Z27FIl+kdxWOUKwsA0ogCmk/uanOSm5iT+Y5etfGuzbq/jn163bsa1s4ZdJ48eNGVU+7dQJbzz+Cs1fW+nMGnPXWc3vvt1oysTy8pVPfVz9zpbk4t5Tp0ywO20STA00Yt0h3fg4ygf7jp6XhQCkQGBCimVrq976kMFIAFn72rt6XYtugj+UXzPe7qtdurLK255y/qmpl5ydcNrkbZs2+qt3KVNOENjD0rsxKSIme1KLc4q3btu5pmMtgT+sO7XPqgwyxBB2IJNQCgkLPl/5i5v/8v6b80VQWKoIkbNGIuTAOGMvvvD+zT+8+9NPlvoCfhPMIAlBnIPx+kvzbrjyzk8/mm8G8Y3X/3f91Xf8741lAb8pQ0AKAE0knPPJ0h9e86e3X1+FGBYvBmDChMXzNv74ujtff2EexoShbsuEfunbVLt5e31tSV5JuiNb9uSllISmBFOEbhGw0CmbQgoiVWZjmNKv3+B/3u6aPpVxlImuU665vPBPP4OyYkAWn/MHP4QI70yVl5ePVuOLL75YsGDB4YNT4U68oHAJYiDtMCJt8nEiPT0IFEQMdPi//Gx+PQRy/3R11it3+Ima3/oIahqCQAEW1QTY70oeaU81D88rdPChjAidDvvg8qLho4vcdtVhzFDFExJAYT1eIlQym+qFTEqSkvYaDodj5OiSyaeWOR3IgDElgHD0B3EUwARna9p2rmjZdMwnlwFPBWRGu+d0T+WrRT9rG1riA8GIAgyDDIFFeKzfzMqxZ34aeiptRHaGjukTJv7xJ1nHDOdIHm7vdeOVo352s6dffxNMp9N29TUzCwbnvfLFsg/cuW/o2c91OF+l9NntSa9Kx7I01wWXThxzTDkD1CHKIpFwuM3j4yNeo+qheUFWVhjYUVV954PtHd7Cp25uWrhq7t+eHzC0X8GlsyS3MUROUFBYlH3tZfaBZcGUpJILZsHqNcxhUzZS/DAlfpIRk6Bze2lxv9cXvffFmo+KKs5GcIaPHLvf+FM9JwxQU1Lq1NzStqNqV3NzuyCpnAow8i5r8QgF3ub65p07dre1tIV72CRnyAGhsb5pd3V1U0OTFFBbU797+6762lZQ3ssW8ZcAmhra6+tqa6ubWSiwS7JkeyW2tXXU19TV1zeHZZrV7uoex2u5Irf4m77cutylO/qVDdDAJcDswVQsYt+F0V5vqXS2eCi1ZDl9+8SCPS0rHbLSaQ/f5/g4iIqU1bjw6quvxsqgH9YyAUcQjU3Vny/0w8ah519mGzNGdWCEHjRNYv9Bg12jx+qVg9Btz3n6FbPJS8GgUDiMDrSVRTHL12F7ClTjA0FqWsplV8wyhemw263WD4rJlyjcHc/UmUnLP4f2OnwiSk9Nu+1n1wBJp9Mdq77Jjj4BWop1XGYAC1s2jPz0POA2cKSDNKdtM17fOAV+dWnQCATBNBjnhEF1T+kb2aUMZ40xOhEiJjvnQFwyUZwd0XxQQDYtGdKSFfU1wEAOHtTrt3f87Kkn35n9/nuvzV2Q1tJhMhvftKtg8tjzzp124rS+OuMExMIUjzh3M46ojprKm3KDAia9HRs++Kju9TlD/3ojnHcGDBncuGmd7x//hor+xpgRJlHA4+TjhznVXLJJkHlZlJcFYDKyPALY4cB6VmcfICvNKitMzP9g5esTK0aWYJrSkmNSqc7spfxpWSMzqwFZM2DKicMHVxRnpmfa7LolxRPOq5TijnLiY1dec8b0meMKivNcDoeUwhQm10K58cVXnjzq2LJBg8scTrro0pkjR1cMHTrUYWfCMrIgDkjTZ44tKcusqBwaglHM4nwQN2jClME5hb8tKS6VIKWl77OXgII6DLGjY8uSqkV9cgaUpvUNd32DxAhHnw5BnEAiCtC0EJQkQClDt0mzNnVMIK58xzqtTFXgCqAVFuOOo19h/P3vf//ma+ZIAtdu8PzhOQdk2Y4bSUluLqQu1P1LTEyfNqUFIAAU/HxJ9YbtuZNHYWqCjSIKlPu9tyx2ST/MizMS2XRms3GiMPCP/dpQxoEyEKANa7dyznoVZNtdnKO2F5UqlOI47RpjSiVNsdaOUsayABnh1cOqtq3BYMvIz68AewYQjexIzvaxP126perprBwdAqCnhDVl0EFhgXUr0GiH85YRQjuATb2UkTy2AzgIjJgMl3eiIKn6q8NEDV0aCCS5v395zh1/uWTGinHLPvp0xz9e4nnJ06+/uPe08R5umDIgpeSW9Fj0QyBeNY8jqqNkcAASwp6XO/aJ3+iTJwBAUnHhrJ/dIhYvBYcjWuAFEEIiU7klEAgkLSyxHrYJji7NUa/SgwxosrMoFQOmIMzPRsBce6/xfY59bOk/VlStL8gpZxEXrsgbu139w30uCQmJiYlJlpY6RhI5QKjZ3dDU3JaZmZLgcaVmJKdmJKuCkaytbW2sa83KTnYl2JKSPaNHV4SSMCmJeEpyRsDnM2wOi6hAJE1JwmQpSem+Np/h0jgDxsKCnqYJHmeyCJiSbBjrZRNhqkhVNPcHfZt3bGzxN5/W57gMSI2YqlEPrbuxPM7w57K9yg/Y3WoaH9/y2rLf59u9fccuMFIvOh5GD4+1DRAkTSFCs3blmvn/fNhdmOY6aZJMSIjpHulOsPKQyhbh1vbYz45IrXXaBHY9B4KoKgnxbo+KiBhjVduabrrxNwDaX++5vc/AHOy+Mo2qLE1wdApoSyseAFAo++ISYFHLuuFzLw3NSFsakDyZSl+rPRHaWt7y3FkZ9JFUzcp7PRU9Pn8polygOA3ECP2tLeDzQ5JH2HROLNjRBs3tLCUZbLbwUYSdDCOUciJL7VmV5ImFwrouQyeAIweVjsxK++x/i5rzU4dMGOPnRjuYDmQM+V4gPz6+Y9Wc7+h5MWAcwObx9J46Sb/wLMrJkADSYfCRQ4yrL5ZDBykGoupZtRrmFMxhCEYo1dUjxXvrFd7tlnv51x8gLVOplYxuN6DlwACKlIpIkCDTppROC3i0z1fOrw3UWgRaJIn7vFnWJ1kyVEgkVSrFIrqZkgheeunNX9x217w5y7w+0yQZFKYIJXzspRffvuVHd3zy0RJf0JSShFQUWsbefP2Dq3/ws/femi/8ZrgVj6TG+OdzFt943W/ff2chZxZJU/1PyhXL1t76o9tfe/ljDRmXDLvEujAXzCRR31azePuipJTESUUTneAUYRzJeiREWtUmZtm8gsWzANV+jDyyAdr5+Sr6aRGLrjiu+rYPU7K0rF733Zpx1SWyqBAs/p168E0kXVLHkpXr7rqvT7Nv4A2Xw9ABAZ1LjPoE7z03yZL+OMRYR12xmYx8X3dPJwFKCm8NaZ0NvjEvVCx6XdeHDK0cMnSI3aF3+2kY5rJrEIpI4Q+xptwer28xohIUekkNcGnL2rmta4d/fhnoyaC7gcQMR/lrGTcGL5kU9IiWdOToDfCwHkzMtQq387CeRlQWmlL9zhI4rpu3cMu9D5kLl5rSD96O9a+/ufXRf4vaOrUDEAFRoXWBRdgDzIoqGiDnqO5pKMAEpWwBgo724qr1Wc114G0Phg6eM9xDHQO/9XcvPuI1qoOuG+0HTspOJWOQyAQwPZR5SD8wPZR19kC3GkQI1RnZaVP7TVq3fMOyAQum5J7EBFNiwHsTB6L7FZHAa9mzd54HIRIJaG1pqanZ3d7hlyQZhj5PRWRoaW2prt3e1t6iVA4thWZGAM1NrTW7dzU3t8mIBAMqNeKW1qaG+l2tTW2ozlgJNEgpRUebv66urrGhOXI0kbTNgp4oOekBEVxeu3jV7nWjK8ZmOgvJ6sHrUluKj/jovqTBXPbcSWNCCF7nQSYlkq72yAUCmiKwdLX83YPpW7fn/OTioNstqmqM5CTTqUsWBR09XjWLlKU7603ELFuB7ldqYfGiYH/NraHZm5Pv+dEtFzPOkpJc31WorxFT5Wk+r3H56Pk3AgVBTwIyJ2OhIznzldyb/Zk2DASRCIWkb5BZFDVNCGXOhCRlgttV//iHNVt35JX8zPx85eY7/ll2zFjQDRPDBve823sUoV9Z2TJThs/WnqXgXIaCKR5p7a/4iCOqIzQoFlERoTdAwSDYDDI0kia2eUPJiNNx6BV4VTAOwTRDs508ZPo9y+79ZP2nI7LGJbIkbrXVInYf3K1QTtLa6YikyhEPU07nnn/m1Kkn5hdmOV0GgQi9RyBwuOjicyYce2yffvkulwMiyuUINOucmQP7V1ZU9nEoPlaYNsvECSdO7JVdXDGsPwtvh4a+XdP4mHEV9/z9roLCHKA9/R/CpTJGbd7W/2382KW7R/UZpZq9ZTyexMdBzkCBIOxMAulh1wOKajmZTS2fvzxbe/2Tgn5525+fvX32m84hg/rMOkMvyCKOPeVjvifIkxTwB7duqUKORcV5nKO3Pbhlxy4GrHdxnqbtaTlgJSaBYHBX1e6ATxQUZRmGvue2n9rME2CmZyUyteLK7ypNGTkDWNC4ZvSCm0FzKe8d8wTPsLf0s2FQGfAQmLERDxIh+0ZVsjBmM5YxJkyzaFhl0rUzvnjoqYz/vLb+0Zfz0lP7XniWTEtRHQMsslnBuiwVGOsjGO17Qezq0hinoMcR1fdl7OG+QiGoomI6gE3IwOotVQuXZBb1MsYMadq9q+OdD1P7DeQjKsFtO8QvJQqnuSh5pTZ8bO8RL26cfWLJ0sq8YQ6ZqDYxujOHCXOoQnCqudHb0NiQmJSQnOxUrG/LzVnm5qbn5qbLUIgWDTWtTY0t6Vmp7gRnVpY7K6uskwViZVEA6enuiZMHyvA+hmWXRkRmYpJ77IQBofdIXyThDj0t7gQYOqKkS/7emXczIOaDji93fPlW1Zwr+1041DZc1dAYQ4pnafFxwMEQHcBjlC9Vi2qYIgia159SWuT93axqP5kByQOkOxKkJJ2YoutQDzZzRrcRJQWrdjTceOWf7YnsX4/9PiXNsWljzY9v/ofDjg889IfsTBY1irb24gVwDXB3Td2f/vTIxi/rHnzs5wWFmXvUqawdJMa0yN4hMST8Lm4Avde82iAxYeEtwG0AwWmteTwrZ3afW/zJ7iAE3CYJJkwMb8jjN/60RfULvbomdWy7YmbB8uXNN13vBW30w4+bI/oigbelxRUw0eMUNs4kI69PtvqYywlOPdyajTJOKIiPOKLqHutEfNGJM2w0cOPcufiOv5Bh1aL5tZ98bi/tY3Bih+yAwFShCRXbket85IAxn+/6/J3lbxbm5uRhInWH9sJxXr2kgGVL1zz9xOxpJ0+dNmMM04FCWb0CSZbYTSg3ZK+9+vEH78695IrTRo8dQg5doSWMDdyhvD8S1GM4k4ptSaYiiTKGhiRikbZHIs2q4u0JRsNKBmJr4/q3Pp9d6smv7F9paA5BYagFnRIP8REf+6lSdQEfFmfQYjJqvbKGnne2JedkYRKrOZA6GyR6DLgjopTEGCJx3c4GDMu2O3VNKTjYbDikPFPXEMlUVjeqjoadgugSgXOWX5DmsOmahvs4S6UhZzUpokrl8LvWh7qgac3URbdCsBkMN0j/ND7wdXYqlI0IugEgYA/dPKnkMpCO0GMWHVzdtSTByW4LQL4NGsBmgF8wXd+wenX+mx8nTxoPoyvJ377l/Q/cG3ZmzDyJivK6HHc8tsXH9xxRkbKUooZGNAUmJYHLjpKoqRW9HUZqimkz3AP6jJlx0s47Htzxy3sdQV/F+dMShg4y7ToQHYweDO7jh9HdOwqjK6N3ZtkJZSc8ueSpjA1pV/QpNKSBpKpOe3yMlYcjkqSmpuYv16wfMXqYlKhYsBGnLgwjNgSsqa5Z++X6utpGU5hG572mGNJ2CBgJkhjuerHEpboUlFSXEXVNsKnrZVRZNiGhrPfVzV754qJdS86dfkG/pP46aTKUf4c7pr5e1NlziVU8UVLHjOHTpogJT3deJPFxVE3JWA4hRTbRwoq9jEnDEBDWGle9CKQB9fiCTETt7d41qzfqun1Qee/s7PTbfn4tEKWkOAGoqCj95lsuJKKsTANisVQkWZIAGRkZl19xXsAfyMhIpX0v6NGZhnj0xlCKddeRRBzxi6YvvSIwcekvQj8zXJNbsp3ZvWYnXCL7FQoQAsAWlhhj2EW7syevgtUSxMJHp0SKEVn0iKMeY2AV5sEwqfbV/61dvHr0D8/xPf3h6mdeKKkcxMp6u5yO3be/uGP12j7pqfYt2z797Z/HlFdknD1dYtTdIl6gio/vH6Lau6naBMCOjqZ33mv8bEnp9ONx2sRAVe3u59+0czP9nNMoI9XLefLoioZj+3n+9vsBCSfCuFH+tGSBzHZwFMooIxFj1weLoRWzYSYQ3Hry+N5T39zx/vMfv1WZOq4ytdImnIJEKFHuIrMTdtBAHYaNGfCHv96Yn5+n2SxSJItBHqRo5nj2+SeMGjegrKzU6bSxsM9qmCUWC4bUlpzV58yiQlGInFu7HoCcdWHh7rGEBEPZHeiSt4F3wfYFD66dPaF82JlFZ9vJiSQ1jHZaUQ8EbQwjKkAhpcbDQjJWP3MoagYjnVBIXdEjxtHWUTFJsds5G9UiIksVJXIvWeyjgT2JqDZv3vbL2+5N9GQ/8cJvpTB3VdcwZJ6EBE1D3eCZGSnqy6151kW9M3yoDFOTE2MzGNwzGoV7aLue39EGp2RULUKRjJQs8heNq0ct/QX460BPAAqcESx7DE93l4xsSXN6CDRiWrgZV1oz1wSBFGnsO2Qd3sitkAKZTwlKWXurJkcTwKb+PQigW8QtCZKFFgIDoXH5Krrq8ZzTSh0/via3f/nb/3dv8sPPZfzk2uJBg5v+df28u+7P/seTDV8sH+hl2ddfFczNDiC6yDz0NtL4iCOqox5ORVdncNh9GembPl/MmtpKCns1LVy1/sFnyn59FTndISgjTf/mbdq2GjeMqbUHHes22fr11lyOrzqBUO5VoIr5r4kmA5aTmnPmiNMeevGR5+f8J+P4lGJbHwAuQwEnVhALo3Io2dnpudmZoLbtsAtkCP+BiIoK84sK8y15vaaG1qaG9vT0JGeCHcPGraHo0tTcXr+7MSMrzeWxKUYlSpKc6W2t3urqxqycZIfTLpVsZnirZS9mF5ehtUyA2NC45vWlr5W5884af6rL6RZCRAycD0lYMVqBUAoWUvmV1mgNTZiXBYkJ0Njqq65xJCbJ3BSw1BNUdBYRo9w4fvpugKpY1LRHD/pXusV4cMjLMPS83qlum8c0zd3Vu2/90R3uBNu/HvhLaqpHSZbIyIfhHp+JBxV8jurCVGc2hgiW04JE4MDmNK7yCt/UlX8E4QPDDaJjVOKoF8Q5MGyQTwMjamEfFpHDSDwL5UdRr+hDtEGWyu8Cg6bZ3gGE0uMRyk0+2NqK/gAmekDTGXZWQ1HtO4KEZQsWpp+Y2/+K80RmuuesGXkb11Zv2JReWytTkz1nzCj6aG7VP3/fAp7xf/ozDC0LSqEx/nWev/iII6rvaOAmHQQZRs6osfyqi3Y99Fz9z+9pa2wqqCjLnTjO73ZwAraj9ssXXkur92Y+ecOaz+bZn5xdWJyvDxkANqOnJpGKS4IBcmY7IfcE/zD/vevuyVuScXbledlGbwmCKwLJHgQRlRaD2V3VJzZdFkSh6M8kB+OtNz56+425F1xw+thJ5Q67Fbk4Q/bB/+Y+/ejrl11+3uSTKpmuWQUuAlg0f8VDD7143oWzjj9hiLCCzj6gKieUSDs6ts5e+OIq77IbR/9ogmcCScIeWjDC4A+txnRCYB3LV9f8+5X0049JOW5S81sfb/14QdnMGTwjAQ2DR73bVDGPYVgJjO1RsoqP+NjPI8dYUVH+r359A0fNbged2UtLBjvdltSnVeTV445slnaxys6QA3zeuGr8iv+DjirQPICBc1qLRVbu472vESmpAQC7tCyqY02rInu5BERCVbh6QMbUZCQAwevb9clc2Li91ylTqLS4o6Z263sfJHX4M0+bpqWlGpZYIEUQlUo6+x53jHH8MYHs7IBNdxs44NarO3bvDmSkOYn8GtizUhMAApABWSmhLJgzI4wOEeMhJT7iiAosyxcASnA5J4+yzZvf/u9/Iox0PnO6Nz0NgTQhgxs3degy/wcz7SdPzsnNqvv3yx07dtj79QG7rQczcoMMtccvHTxh0rDjvzTXfLTqC1dS8iV9ruRcZ1JTRvXYhTseyY6VjbtFJaI9ciUKv4epejxU7dq1+ss1NXUNwlSyKZGdx+rqmi/Xrtld1yAEGZpFowrhvN21dWvXrqnaWb9/CpSUEgha/C0vrH1q0ZZF08qnjCs9FqQR7insoWBDkXVMAxZAcPYurE/Qg0++5GwKVr3whj64jJdmWQ2FlqqqCWCToTP0R9x8mFSbg3SUFwbi4xtKt8DQ9F452arXVWZlpv74lgsJRXKKM/rgf+8vkspxIoTSuY2rxq64AwLNoDtBtE+wj3jCOU3vM5ISdZBSRzyw5yL0jC09EnIk09CpuWXn357ibc15F59b//Hcbf940jNtimTMVO3MSo6z08YBGWWVFlue887Qz6UzLd2elo4Uenvw7U+2ffzFoHOvSvxg+aYH/51fOUj27xNEcEikuDhCfMQRVTRDstADmVIGVd0ZBHa0qwYUIJDJeblDLziH8nrJBHfq8GGe5FTdYSMdsUdrHRzCfXr/z953gFlVXd/vc84tr7/pvc/AwNB7EQQREbEgiKIgKtHYYomaptHERBOTf4otiRq7xt6wF7BiAQQE6SAwzAwzTGHq6/ees//fO/e9YUBUiJBfAnfHLx8z8+a+e++8s+/a+6y9FgUl25E7e9Ccrs5/vrzk1TK1YlzFMW5I4YR/05RcooGeYKWT/XrWYBxU4ekzpg3sN6T/gAqnUyfJPhYiTjv5+IL80mEjqhy6Es9G8VAAcPyxIzye1MHD+35HE55AC235aN17T33+wrRek2cOPCuDZFljTIcsc/foLknGParlJX0vOqflBzfVXPT/lBGF5TNOEkXZwBhFJIEoUAaaakrimMo5DRtICLp0ScCy8ZQdB5we4h8YZABMI8VlmXuGJIgNp6S3g+wBf9S2rsPoPG3TPRBrBxqbGK7Iyi16OOVcWpQXVagGFJCy/5TbsfVIQ0TmdFQcd2zn6au3P7zA3xUKLl3Xr7SscPrJmJLKe8jXJ9NgogkvICEfwykRgCaACrR5a/WO392XWpyX8rPL049Z+cg1vx/68JP9fn4Vz0zvdjKzs4odNqKS7lqIkfqGXQ88YVTXZ9x+f9ey1Z1/eiZ9xGgxoCymUKgo4QAxAAWRulxiSD+57x+T09tkD2P6e68ni0xtgiCU9E8bePmESx/75OHfLvr13PCcuZUXujU3ERb7ulswnewLqr4p78XzA+XAy3sVlPcqsJ4SlhILInIQxSU5RSU5srmTkJymchY9Ny8zNy+Dg5mcoCN7FIaBEpQ6w4jNweaHVt3/xvK3pw888YKxFxY5KgWXPoNJtvhBYZj9DiNb4ExJ8u0ZAUJpKDNVcbkAGk1Huel0hBTiBiAx0fj+0vULF48bMYrPOY61dm5+4aWmLbXHzpuHA8qF3Juwk58dB4GqUCpMAZFFgkjonSTGLI6a3gR+7St5HyiB23e8dO22xyHWBswNGHjQOP2syhmewmKhx7OZ9DiOJwKe9JwnB/humJTN20MS3Ysp2tMKbJ9qUzbNSAQQCvNyr78se8XW3X/+TUre8fk3XxPrW0QIsbT1rURmzfFQSaqPBEN6NAZel6nFcwwEQywcUTTnjk8+LxgzKPMHs9mAftC7coxTTV/6Baup0zLTLN+LZGa0M4sdRzGiQklgpMFw8+LPG5auGXjqCd7zzsS+FXU773AtfD+7IB3SMoyOjq7aer/i4GV5BlMi1bsiwa7UvCzwp3By6EZmk6CMyaEhQkhpSq+5o+bHlhpvLH6LG+bp/U7L10sB9WSOl4o8idxxQNdKeli80h4YhyZGDwWLv/m+R+Ng1W5UTuBY/v4gwKTIWBzhYU3HtufWPb147YcTBo+8cMSPchw5kuhEvk8r6OugqudkIlrnvKul9f7nDL9WdesN1Y++1fzKOxlpfl6QzzUmynL1tWt33vt+dp/U2Nbqrlse8VxwEmSncbs5b8dBr8oeFpQJLHV0z4vKq7ckpO7c8dLngeonmj8FHgHVAbHWe7J+8IOc0yAvC6QzqdLtjiUNN7/zlhFZp/bwNEWrzOtxtxP+qLiPTvnXXKgtdT0CnDTvNruCDAC7OiOtTVrUMBTdlE58PUmVnMavqO7Dz3wvveGZcYI+eSILmasf/1fmrp15F11YecKx3onjIDszjsScWuWs6TBpPKb6SGLo+Cj+PNhhI6oeyzW+7imix+epmH9m+jFjoml+Zdigomsv1mIRabBCYpFQzZvvZNd15v54PiXQ9MhTLCvFP/1kSKHi0I/Mkm6Woy4cfTL6nDdm/qvwyusrXjMi4ZOHnlLpGBYFQxVKQh9BvpQexMHJ1+amkk2pfR3Rk3grURFaDhmWtgJQafsHDL/oXPHmp29+WP/RlAGTpw2bmq8VC6ke/b0YEbhva6oHnAJhzVUJ3LF8Zdtna/rMmeY46cQMASuWLhk5uL8rN5crSnqfityLznxz9a3+W/7e0dqW3ju/+OxZRqq7m1RsS8fYcZBBv6EdQo46OCUxDqNw944FP97+BERbgbkAAw93TMmpGHRC4XhISQGrattzd8QB3Snx9a0zy2wr8dvUcija457co/zaVxdHYjhK6c7GXY8/H8RY/5/8ZudnywIvvlHetx9UeTiAKrqrzASWiyFmZKTXfra6tqlxSFkZfLJq2/1PpZw2Abxub2ammYBosjfmdcf/i+dDe7vPDhtRdT+v5YJAt54yfrgXiHC5FESW5k+bMpEZEXR7DOBaqr9PZn71n95RstNDsWD47Y/Kfnqx4naZSQuxw7WeCDLCqtIGOsa4+drYgjVvNASaLhvoL80pI4SCEFJs+bALDSdHjC3dnTj+JEiIUAgTa7es/tPavzbsapwyctKsfnPyHQXA468U5FD0Bb7WT9pn28FXWNj3qkvSRvUSWSn+eaf3GdLXnZ3LCBUIXKFw6ol69UZ2440OqHI88WujV7GpUg8gJ4Tb0jF22PFvB4sDi7tqXr562+PAw6DqEGv+S/4VFyjjoTjfcKr7K1cOdMERurellXw/ThIJyOqvm4Sx5EOLfMPGq7S9wFAo2PDy68afnyv503X+Wad2Fuav/tU9Rb7HXb+9OpKVjpZ9Md1zijGC3sFVaVefv+UvD+380z2hl1cMGVOcfe5sSPELIeSp9VRxsfvddtiI6msNIQZcUFR8KUwqNhFETgk6XcTpIAAqAtcc/pMnh+rqvL982gsB360XKGNHBn1eXboWkMN7dqAQVp5ecf7gH2aS3DeWv3Fzyy/PnDBzXP6xKSwNhKKgJLR/k6vy3r2of6uJhwIIEspQTvTE4VQ8Ve2itQu/eve1j15p7+i44IQ50ypPzdCyCVBO4zeQAZjfY9ePE4hJ22dm0ekBokTK2CT0a4jl9+Gp6s37VoIqJTAK8/Nzc2IgKIv/mCJAxHTtaKmPZ75Afm2bJlA1BChUkiOQgN2it8OOg2tOWYjnrppX32lf93r76jicouG7G0dWDpk0unh8THMBBeX7mUxJvZWebypQmGqXAYyiUzcZQSB6xCQxA5gCDgUpSXSJ9lHIk3MDsWC0kSiFt16WN+tkKMnzz5iahdGa2l1lkaAu/ESK6Fk0BiqH/hBIRNdSZ02rWrkqfN8DLcCPueQXRq9enCmMUEQbQtlhI6pv7wJZz1UBRrCLBsPM4UKfW0GEWIy2toEvBdyOGHDI8Lsqiyk069Cl5+Zxl1MyMpM7YoevPRQPkyEr9pScMWxmmi/1gTX3PrLo0Ya+jRP7TirwFrvQgySpgXB4SJFCJhom7f8pgRDtqttd9+q6l97Z+qGepl9z/I9HFgxLo7nCsvQj3fT17zsKKVn/UhSL0u72fnIWQOZBlfHuvyIF1BUzjoDjP1ZM3vbia80PfjDkRzc0btqx/ZHXBp0whg7oY3Fj7QaVHXb8W/Ud/L3mlau3PQaxNlBUgM57xRnz+0/TisuiTt0EcOL3q1UQ9yJ4SgTHg4Ftz7+2afPm0SdNSzt2NN9VX/2v53ch9D9jhreiULaoSA/rqZ4MLOHxefvNONWpMuL3ohCugtx+F8yNdXbRND+JYzcqksaq2KOTFgyEOjq6fKCZ0MmbmtE0QbGtb+2wEdWBIgYKQnRtrd397KuZpcWuuacxAs2frHC9s8w3/wzat8QBTKzdGF2w0JjYt7M1pL7zWdbowayPgxLl8PY5yJ7UAJRluHNOGnByXkbO21+889zaBSsaVx5XNWli7okZrgxFNqRBHBawQC0bVyRIoaGzYWH960tWf7Y+tP64suMnDZwyMm2EJjRIOrzSJIdU+T56x12hYE0DS/V4M1NRYYGGRt7SmVJSQDxOjnsoUBTB2eOKVQEMIEqJE6Bx5eqN9z3Sb2yJ/uurcz77ou7cX2+4+4Gqm6+PFufqgMxe8XbYcZBxb83rT7eu/LBjA5hBUPGm6vLJvSaM7j1OS8tEylRE9ZDUdHSvxMERiO7wZWVFbr83WNuRlu6rX/Z55y/+XvTrH2qZPjlqvH9jKUQigDGVeLIzOEHBDQqCgeL0+zW/n6KJgKaU6WM98CID0LjY/eQrjUs2Fv3650X3vbLlkZeLBw/UBg8AZhdidtiI6gAaIQSJYMzp9cS6Ahvuf2pATpqnIH/3/Y+FKyo0n04Aos3t655/VdtQXXDzFV2Brg13P9712psVmXMwMy2+CMU3wio8ILz0naiKQWIDn/mU1JEFx+R7ivvUDvhozXvPvfXcmuI1owaNGFI4JBcKABhFxZrjS46w4N4nshfpC6GnKS3pMassWZooJVkQkMYUULbAplWbVizfsGJdzZqivILrjrmuf9HgHGe+zp2SzoU9pnH+3f2+BPUd1K7gtpdeI81Ngy+9AB3q+seezhNO/2VzudchDcSsGWwRvyNIuwcYLe6rvnx1w1fbnHVNpSeMKZpwTPTdT3S3q+TPl+7cshUbdqnF2YjxTMpsic8jM/BrBnq2atR3JKWe1uJ7BIKtod4kHfyemlcv3/YoxNqAOgEDfzSmXjTk5LTiCkx1iaRO5vfhFXXnKUwSozBZNQlV944fNfTyC5p+/oAr0hH6qiZ82rj8uTNjKV7EeIUlbRkEFdYRkMuWNiGEoSV2AcyCXcT6NKCI11Sk21adJD4laCKqhG5+76Ot/3y2/JSx2g/OLq3q99DNv4/+/dGBt/yc5OQA3acPRuAQZHg7bER1ZIXcPge9MK9o+tTVazZsuOXu3NxsVlOfd/n8WEYKQTBbOwrc/uwrL1LGj1WEOSQYCrZ2QiDKM+IrlfXsF+83TZBuvLHPgjvAHER7esDq4CpL7ZXlzR6YX/Vh9btPrn7q3VcXjc0fNa3f9BHlI/0kHQRwU14VEYTsAxzwa4iqx8qXLS5JLJffZNZ7k4DRtXrNF09WP75qx2qSRc+ZOnt87ugq1yhGVSobV2Qvdj79nomEA5D0lF4VFR8//FJId7c5gb+3LOOSy4nPy/c6/x7upAl3NTAJaIq+8r7H+5WUlvzqqs8+XBi+5t5J9/8m5+zT/V0R4nKoKEyQHT970R/hsMF+nB0QqCLf8NPufbB7a167p2XJl13bwQyCokJk1905P/pB3lQtIyOoqE6IJ4Dvrx2QmHxJvrtIEgfiuYgQI9WfecpUsW5r6z1/KIfx5tPXxioKI2C4ACmhHFRFyB45jSfjWDxJyqNJyBSHU4LKKkwk8jEkrLHo3rhbEEKiIlJdP2LaxLTzzsDsDHLKpKm7W7I+/ZLs7oScnB55G75FbHkfz2w7bER1lLWp4qsNhaYoxwwpnzfdvOjiCPj9117EhlSpuqIi1wuzUufPIrpueB0UiW/2GZ5wFPx+q99sscK7O0KIyHouNnJoU6HghFNkHsXfP31wsa90dOa4xWs/WrZtye21fykpLO3fu9+IkqFlWm8P9RGiMVDIHgGXvU/J8iO1irSEErn0uWEgWPwfO0V1def29TVrVm1fs75mS4rqOnPo7Il9jivL7uUFLwNNKm0eevlxAhDRFXrKxBFrV+26/QUtFBp2wwXO4wdzlw6A3SKBltgnl8oXlBBDYsc4TupTnnvGCY33Lih49Dn2z+f9PzwFxo00fCkuX4JnzzBevBIpyceTnqwsYW9jP4btOBqjezjXGoNlQranKPl7zWtXbH0YjA6gDiCRO9pGjxt0cmXBAF33IhAHHrgY3kEsf5JUpZL2fNZkLqomV+t2twO0QdBV16xU9ZOWXVJ1lZJgMNj0xqKUtz9PP32yNv346Na6mkefzTLMtMvOhaICWdUySwpHsZKdbMrvSdQYL4yZBFm9pp/oPG0KT/VxlXICeXNnwCmTIdUvNfLxQKRq7CRix1Gs8AlS9VvudAnDjIVCpiyPeChGTC7LL6G4dHQ5kiP3aPi8xOcl8tGexCpIgHBEq+gxk1RJcjjgn6VwKZAC87PUgYXDizNKhw8cvrL28811m9769M0VK5dUpvUpyi7LzSnK9GX6da9LdTuZTkGR24fdVKdE0SYkSjNBdEEgysMdHR1NHU11DTs3NK/b2VbXCZ0Z/qxTxp80onBYhbc8S8tjQqNADqugEwFwety+osKGUCeHLlduDmg65YIxyhJvK2RqY93JF+NnFM93pgMGn3xS3Xsr1/zm7irIc150Pk/1c+QcqGI1BaXwNZUvx3i6BmJP/tlxdEd3U8VSa2NxoES+6NgUh1M8BKoKxu679bN+OOg0vbjAVKkUc/pPeDklBvE6g1+9+lZwyYbysy6rXfNV+O5HxhQW8aoyTAjyoeZ0p6em1b6+dOuuusEZ3pqPPq9e8EbuhXPA6zERlYSxBUgeevx4TJ66IT0oaA8YB4w4s9JjMpMQQAbC8LmJz8OSZhF7t/HssMNGVF97eCPhCEyYRnjFytpX3sg77uTUosLGd1Z7532ljx5qUqaDSeOFDYs/hgmlIBL+eXKJ8j19nkRuEvG6Kv6lJmWC+SE9W0VI6ymCQAgHQoiW4cod60gfkjm0uaJhffO6z2s/XtK69NWdi5yKK9OVmuVKy0vNz/Rk+pwZKQ6/y+FwUo0BpUiRxwxudMaCrbHOpkhrfdfO5ram3Z1NrUa7YGaeJ69334r+qQMr0/ul+zJ9qk8FhaDCpWEzBXqYEioCqEA6ttfWLFycNqIPa49sX7wkZ8J4p8ddt3mz3hFIr+yFPicwZXdtnbm9NqN/XzUlhSURVQSE6tIjKFTYpYMnqAiPwhhSmpiGVBI1uWmAoipyqwCJiP8V7Y1AO47WsjK+pq0ME4cYdEnXV2M2/gOMMPAwkMifqwdM6nVSSb/hxJ8Wk9YJjNDDAigsX9MeiSVe84VjwTcWfnn7Q+NOGJv288vCn34auGx+Y0WZ64YrICuNIGiCGIrqGznM98s52//8z7pb7jKrGyrPneo644SQ3yPLJSTxJA8GKEY8Uwuv9DaOyl4VBaLGUVe36SCqe6h4csQ52dbq3umzEZUdNqL6xmTCJbk8srWm+r7nSYSk//E6TXO0Bu9i9z7dJzePlxZCvJIhNEHfxj30azl3hgRYDIls3JgCoxRcQDQpx24CGuTQPqkJSbTGEn41xFruRPPoqZ4MX25K0ZDiUR3hjrZwW31L3faGr+pa65fXLQ9HwqYATkABYmmOWzIE8ToMBSeEMup0ODNS00cUjCnOKMxPzUtzZvncPjd4HaqDJK+YEnG4U0k8jTXv3vbQI+vqq0++6VpTxD68+4HjHn/G+bNLO9evb7/tEfcPZrounM1qm9fddkdWeyjztl9EU70KMFPKiTlB3/Hca+11u0b+5vfPPfvCyNsf9N34Uy0zJRpHuYJ8tiq0vS518DBeVShiprppe+fqL319e+PQAcLGVHYcTZVkN41/j8glk62pzq1jVt8CkQagDETHbdkXXl4xRUvP4m6NdNNG99AIDuleueCJzJo8pAoiEu5oqt+Zd85JWefM4P1Lc9M9nbvv2hToLN/ZpGalxPOY9HGIpXozzz1jZCgavuGqjKnz/NOmivxCBkJBpEhMogCiM8KdGhMooixejXqFAkgwJrhm7edRC1YlNVYSZTIhR5V9ox02ovq+oIoKgwfqd2uKOmjeHGXYYG5Gq+adBXc9A3UNtDhPSGM7mhCbTKaQHiuMmHzVW4vcJhYeM0rNTtm9fM3WjRv7jhqtlOaiohzq/THSkxZJE5xKqw5jTubLd/ryXAYnRjR3YLBPV7vZuls0t5ltLZGO1kB7MBIKGYYAgYCqoqhM9Ttdae7UDEdaBkt1Kd4MluNgTsYUj+kBSoBSIMIEkyQa8EAPi5wT9rijxOjoKNacZVddkjp2OFfZlPaAd9kGaG/tPWRoU9abS+9/6piJoxpffCf23vLCq3+I6WmCUJBq7gIU8u7HS59+adzkY+HCOZWZ7q2X3104dCidN5NTJAjBSOyTOx8a0+fzzAd/C827l992Z0uw84Rbf2X7m9px1OS77nUmt8CliG4ck1C6tnP7gHV/BjAg2gQKPaXRc0/6pb7y8YorNUqJCqgmMt9h4l0j4QKoQLantKGAus9ddv7ccoa6x2VS4DkZ/ivmD4zFVIeLCy6ZFioAMqABAk1tnU4Asr1R5dwkVMF4xRjHSkCjgc7Vjz3XXF09Zv5craocdreveOzZhqa2iZdd6izIQILdE0B7M/cJHO0+jnbYiOpg4IkKoDCSOaJ/etUNqssNuoNpWvqUiThiKHrdsh2k0AQfGrHbcz2hDCqLNQczupq7/vK0cmUQRvbfeePvPW5dGztcocAh/ig/9NVljy8T5ZTVYUmwzRUFFEVxupWUTCgoB24C5yCEMLlAizKRsFgmhFLCiMKAKVJLnBKWyJdKkrkOlKHSY4+PHOqCLVkBJr0maGFB5hUXgcMhdE0hJPOMGXDSSUaKR2VK9BcXaNf/v8h51+9esa3f1ad6pk+I+RwIyARQikiwXdMqL78wbfRIMzu99JwzXVpqW1FuetjQ3apJhW9Q1cDTJ2/55aP+0b0jESP21OfD/nkVqygKyi1aO+w4GjKeVRqJOHSSknqSF7kqsH3IF78Eo1VSFQx/tOyuwvm5gwcLt8YQmRAk6aSX4HUf6r0vgkBMwYx9DkkZczrTXVaiUFAgJcSvWV/H0ZI0TdaAkK4APrGg8YlXe006u3VDjXjp9ayCHMjNMQiw+KtQdzlSszOa//4vaAi4br1u98efqdc+OvD357uceowKCnsIVcrXjI/3KSJtZSo7bET1rRCFEM3jAo8r8R1CweGAXIfFi+rx1Lf2vGjCD0pKSgKBIOVVkyc1fbKu9rlXfc++HmppHvqjazEnG6mUGu/Zxf4PXlPiUqQNF+vOfj3/1CJ5ZWKvVLG/fs0+vf1DfzmW0JTciCRC17iuUataFAAuF7hdnAgDIGdIf2//isZ//tWAnLzxY0h6miW+xanVqOeuof0rh/VXHDoS4van5c8+hRIqdIXJDVue4iqccWLLl1/s/tGdHLwF10zLPHlK1KmpmPhT2mHH0ZLzJGlBIfBloHbQql/Hl73RJnf6Oo9jQ14svtJVUBJzUC1htUf2LYK+VYVPJEgFCYmpA4UgHJHDft7I8mNIEp32IBvLGYYQbpgNny7d9ruHssb0Kbnp6vUvv/X+4y8dm5ZeMH8OpvkBBYlXXWre5Il0zcZ19ywY7Lyrfs1Gz3kjs6ZPNvxuhpT2OLSdBuz4nmFj7v2mhp7t7Z4FGenRpQKGEAMqsnMdc6ZHWwOetx4acvZMZczIiFOTpHWrnfx/vEgxcTG4V5DkfzTx3//paUolFxrPvrJ6trposvUWP3ERAxNB7Kyrq9u6LR9SnBDuXL1eRCMqMBUISUpvEZeDuZwxecspQeFxCLdmxnEkMqBRxiIVeeLYfm5Y5YVqZWTfSE56VDao7DVgx9GBphL27gSIRmB9oHbQ8msh0gDhRqDm+M7UxuhPnhtyo7+4lDuo1l1pkINmTO0jLnxYe27RrkCstr7PuCFVF8yFQVXZs6aPnDo5a30dNLdaTFNmae2l+AvnzgyeUNX2wN0lS3fnzZvBK0q6NCS2j4Iddo/qkCYZ8l3flLvpaJhccAUoMApEUOCAHEwvR4UxXltXvauhHaB05ZbsGcKbRgkgJcQEjv+R3HKwF7g/OWncL7Q4zHPS8WrWANCDoTUvvpJSs6vw9ClK/3JYtqn9+YXi+BHe8SOFS3cLYLs7cv7yr6X1bcrKD7R7H1n1yKvj+ww3po9Ct65Iq1MEIielUU0e2olWd5Ga8ip8iGT1dva3t7bBUCe4vHe/6Rg6Si/NiakaS4rT22HHkRxCxEsUyVXa2Lmp34pfAg8BZYBdY9Whbwy5Vs/OUvR4keKQpuRW3jJlz4kdaP9rz0Kih1lv1ZLTdPq9xefMZLOmg9MRY5qnqtL/hxsUIcDpkiQGtBTgFQqKYJ6Q2QIRFRqyAmYkZjg0jfYkn9sdKjvsHtXh7/HItGAiC4YdHSEwTAQhONeDIVdbQAElUF2z6cXXM04YOfTHNy157aPAq2/QzoAA5Ny0794BJWEEcDk9OVmbPvio7vnXwktXLLn3wW0rVrtTUpiqxItIqq1/9/0NL3847IIzld4VJRfOC5dmbH70WdLQ3IP7Twj2tLTo5nyAKTNvpKV93Usv0x2dQ1//c+k9lzV8uqL2xVdEjHNuCnuax46jAVBRAoxtDtaQD8/qu/pW4GGgOK3VE9555RsDb3bmFwqHJsUzBRHYnf0OeqIP9/AkxOEvFylhitMNPp/QJFuAMeFzx1LcQmVW71sQApSKYHjdK6+HVm/tNfeqlsL8bU8u0OuaVIMLFPbyt8PuUf1nMxEACcS2vPiqc9uOnHPPgr69oLl50/MvZ0YiabPO2fD8m1pHpPSiU0ND+vRvbqle8HLZ+MHqwCqhKgoS8V9qi/FfhKRlFseCiaNxzfrGlz9SXluphQJlN12i9S81VTlkZHIzxZfy58tcx47lLsYGV1XeeJWx4SuDokPAPvo4uLcyPCVgSpJG8OPlOz5aOuG6mXzyONbY7Djv423vLCocO0w5dqyJMZXYvX87jvjqmawMVQ9bcqV0Nw8CixaZ5U+UXe6o6st0FQB1npQBTi6hxNhLt+LCAUc0SY7Q9sZah5YFEcdtNL7ATfkk0xAFgSgQE5iTghRGIAYQYorWV99tfGjB0Akj3Dde4Xz3PfOS25v698/64fnhbJdCQUO7P2WHjaj+Y00Ug4PHpab4ty1438sx7WdXdz376raHnnBcdkGaSy2eONZ33BilvMTr9/huui7Y2MTy8xhjkr8uvjslHMXdZovgRQFigEJzZUw6LrJ4tbH4kaGX/BrGjAi73QSIIllRfSeMF4hEV5FQoZL8Ccfw0SNVXUXK9vH92XcgEkG3atne5SNuud5dXmaojGZn9P7ldaH6eigqVLqHJe2w4391He1r2Je0Bk7segOBTcGdA5b+CBSXNLfEIR2+Txpnw6nHO7OzuZKw0xJJIjr5HiciJ/DAETBABSQY1nWKqMeiskVGDAdjhO23niNsj1rygSZnRMpjuhnTBRWaBkxhSNwGh0iE6Dpo8ZJWBTBDodbmJv+MSa6zpkfLigq1aTtuatsUaPOFOlXisjtUdtiI6j9b21ECjJSPGeUYN2rjC4uqGN359KIBg3vljxqOXj19QCVVWPxFhECvUldFSeLftvf9AYNWIckd7Y27grt2Z4O5cfmanPZ2DXISuweEUIduyMEjKxcLTROatm8q7OZ8kT1wyuqBASFq7zJnnzJOpXS6quoVpVp5ifUrKrFXgR1HFMDqqXeiEtgYbhjw2UXx1WN0AREDzbyVmZfgpH6m1HkC7KGI8C28SXIg7xw/QrR19/K7Hgor5oRLL4pmpmuNTYvu/6cB2tQf/Ug4PewbsNG/lTpIKNCx4pUF4U9Wjp59ln/SpN0NDasffiK1rWvApRfq5UU8XrAJ1e0sP/cMIOBwOrsIhfzsgmsvyTVMp8PLkdiIyo5DiRbsW/AdwQVBYaAwcrOM687Pzc8yf38ji/H0y84N9asUupNpqhwmsWboSDecsuMAoBSRRjDoBKTbawKPvJBdmhO48x/1rTvJ3Q+6auqdwnKBAApUQ9AEqihUQAeC+wA6S0ikn5dVsKsUKaE9YTKL42D7r2DHkRcCAJECoZujzWTRSX2XXi1bQAwgWu7qt2L43bGxI6J+nVJjr87W90xcSAFpGATzef05vtCtjyi3/S1ld2vsoaeyfvXk2N79weNm36Coi1zE358ddG2j+tIr88rT/7ms/taHYMW6zseeDt3xZEl+sZ6ZGgMuvVABKcFUD6a4TI04AXQK4HdBqs/wqASFAgl7UDvssHtU/4nHvnw2U4bgCUU6EKMApCvGQhFiGIKpBIAmHKTsm/Vv1NNEAKXh2NL3PzKoGHXOmc4xg51hY8s7HxetWqPV1Tk6A44hA0lGGggRWrOW1jeqo4YraWmC7qlTv7VmTkCrHjpd9t/JjiN4RaFIutHVhpsrP54DVAceBsCqaMq60JzYyLHodMhmrTQLxkP+RCFCVXvPOM21at2S218YoSlrFyzqfeVZvuPGCkxYzu+n34VC2vqRgxIRRkRKafawoeSvly67/TH11js6ancec+GsjNOnGV4PAS49+QgBoqCgCYl4UAgVBJg03iHM3vG341CGXaMfCKKSK7Nld+Ozr4Qbdvuu+41wabuffpnV7ARAE4gsziy5UGI/sP8NUAVIe40c2e+Ga8n40YGMNN8P5hT8vxv1fn2N5Ws3Tbth87+e4Z2Bli3bVvzmr9E7HqddAUFQ7IG73/ano93TmvZfx44jOgSikHtnRDbMt4abyxafDdQhP/uiFylYl/UzfsaJhtdjKOAUPI4vpO4bJYQekqUhGVgaUobEyMkrvPD8htG5sT/+emAd9VxwRiTdF9EZPbSFJyEGkHBqqjZnZu+5p9IFD+SjO2XmtGhxThwtcmYJLFv2GAxAIXEcZaUFpUeTm9rKCXYcsorCjm+NGJAIUx2IjQvfCz/wUv5PzvNeMt+fm7b8rkdGLFiU/cMsTPUBkft9B7wqpRuMbSi3B/SYDjWtX68YIcCF04hFUv3O9FRKWeaMU5avXc9+cn9vodA1q8zaGucdv48U5SEFx34VWL8JEtthx1FSnxBSH20p+mg2KF5gLgDMjWXUdc7FaaMDbpcLuRMoIonRhHL6IV8ewhoHIaAKltLB64G6dciJmlwQpJiUQT/wciv+v29JlUweTqOmg0fbADwdnYrgisAoCMGscT+2J1FgosYidnKw4/CE3aP6rgRBiAKU1NWuX7w4ZVSv3MmTwOfOPH1azvFj8IV3SXOLFEe35IjJvwMohA2qwFJLlwmSUEVVFIVQFgEMFGaNP+/c7KysL3/2q52PPzhy3iy9d5mhWJoUB5ANyR4rMjvsOMLXESEmmtWd9XE4xdyAAgQth/x6/Wcw84ROr5daAbIjBfH/Oyy9GUkljYTDK5941tzQ2mvWFbWtu2peeoN0dZKD1V8XQERPh+f9AUgALRqufv/Dd156pazq1Lat27cv+iDa1SnY3uZSCa142EsHngCxQZUdhzTsHtV3hAOkz3BO7vg7/0oVJmSHXC0vG/rgXaZpmpSyg0kTVgqLSAU9A8AFoFKIQILOwFB24L+zbEu0ZWhPsV+CUt34/0QJIOnnBWgRwWVhSRQkKFAoSIESlNt0ZI+wDe3+XQKCISgIGjHkXVR1JLo04wMCsWMG9T912NYH3/XCAM/AQYbP70VEgdSeALDjKG1DJda8SGYBlDpM1dG2Xh/OiGMp5gZCsgOuncvG8+vPC7m9BkCKBUuk3JS1CwaHB07EgDPD7PjXc83PLjrxp7PD11+m9c8lNz8WGDY85eTJpluVdlPk6w8iUyWCxR9IXIgolcqcDBA4B8KB6QRURGVf8EaIwM7PVrhm3znylAGh267rWvBW559eynbmuC6cjn4X4cykHAkqwIjt3meHjaj+G4JSqhKyD6mZEUKVg757pgRSWhSxrcPhUNDr4ZTobV0QjUCql2u66OEguJ9Uij2rszhIQdiDwBLufOT/rtWUkEAnkglucTqo5ZzafVpf26xDuQdKMH5zGUkoLRNEYhDUTN686IMd739aWHBse12Tc+GHKX36GK50aj0X0E6Odhy9uMpSbzIBgyIUMqO9PpwFis/qe+eL7DpyPv/VcKoxhccYU0TSDP1wQz2FUN4VaKzbmTf/JLx4jurzDDnzzM31Hes2rxs7dRyPF4+Efl1Q1wRqxBOBLjiJhEnEJF43UxTC0YzFHKEo9bpAV79+/pHOzk21tY75IwbOPh36VzETN7a01tdtKWlpZv4SQZEeHNndDjtsRPW/E6Zc3Epb6L0H/lWe5i0+8/SYy7H9kSfakQ+ceybNzvxmj6nETyRjC3uMuCURFZE9q/+7IBY3VgjGBWUUGaMCkfM4OFIU6zSxh6O8xbdgVnNLXi5LcEalk7Ns+cOWrVvvfZR4aP5N1+xcsuSLp14fM3Soeuok06lRW+bYjqMzkgjBygMNxu6i988CqoLikT92qFpWnf/6aP80oJKCTSkVaBIQ5D/hDKAAUq+39yXzVQcDtyPGCO9VmnfLz7J4BBQiE9j+rkkIGs9lxAiHFz79TPrabQPnnaMProq2d3zx0iuO+pZ+55+jlRR+PSm6HM4+J06hUyaB32eA8PevHHzjNRiLipQUglzIWT6b2mKHjaj+y5LYNxgqSwmqb3yy02TPZs/tRkATMMWTleHvuuwe7k5Rw4F1195xwr03atlpSZeGRDv/a+mDm8AMSjQpNSOkkpOQ/R8p/A0C/m9oARZMZABcmMGNm90vva8OGwRTx0HT7vAHn0I45j51cjTDI1tQUqVTIOGCUeSUhShopskEoQKQMcEIpRgjRAAxg11rXnyl4+21g5+/mU07kQ7tvXvrtjU/unXogEqtd1mCvmZ/NO046iKRHwygtbGW8g/OkljKWgqZTezSzHEj2onwCsI4cMoFEE5R+d4zdt+e63qcHBGqqublMGnN7OLCZERkpSoAEQAnjyevr61bBGFaSsqmy1HUp7e46PeBTu7++SV84ac7r/jj4Jvma6mp5tceV0gAdVXPSo8AhABcwJGpIiPdBCnGZTmoE3ufzw4bUf0vI629qknogY7kqxmL46D+yCK41wAAToJJREFUp0ytf/G9tb/9e9CIVl4wzT3zVAORCSkQs38JPMBAjHcFdLcDfC6MmaSti2gq8/lQoRwOy9jOQRTN1hgNpZyxDz/4oPOtd07MTgl9tW3R3+8bdNaMKq878UK5v2cGA+3rNtFINGNAf+5zdX2xyojGUvsNUFL8ltCB1WszDbP30EEjnh4Cxw5HxPyS4lk/vQ4mbzBVJuTOgZ0m7Tg68RQl0BRtjwAv/zAJpwzd4coIkx/B+P4G5xqLwxPLL1wkaATkYPFTzxRnfXlgoEpu+JNuikJiCjpedKEkiu4/vQkLIglCBgwYFvrxD5e89KZw6vULP+01/ZiKuWfHfG4GYt86M0knYMmhP8k4QJogSNgjfXbYiOpICQTESJgQBgkjd4RwmPg8QFhEI5DhC519gnbhjZUQDF/wu1imJwjokxLeVoHF9tSFFg0VQ1u2rX/kqd59Kv1zp3dur2164DnXiEGZM08iXhfKRtF/RlVlH/ISys+QRbQHStPLy8f//Jq3b/hdcN5vwtnOySOHZ150ptCQocYwnuyQoCHM1tVrg7e/7L50ljZpWOvP/qFOHCh6VwIlQuyhW6X4UshJU4SltAPICWFjR7CxIxQ5K0AOrGK2w44jKKVYHWyyM9pa9OFsQB6HU4ggUoJbp7jOnY5+rwkxQsHBOVBFMJLo1iQ4lge4YKS4ixDUMIESVJT47yGSmCmtjxX4puEZsqd+1OOYSoIkypicueFgkm974hiEIwGVA2v2ufQrZ+at/Dz6998q2rBBt/8EKksUMOSl7PuGEktZfsxExE9UaJgkD0iyKdjDvnbYiOp/Mdlhj4xEAGIgYs+8yp26d+wIahITwp0vv+k79SRenK9zE5vb1I+WmgN772gIaAsWpfauwtx0lD6jBEwOFJBSRIEcpboxMErysjHFs+mlNwY5lOCa9TVbto08Yyp16rIcQ2qVb7jXdiGSHsOAe7vHY1JJnByMYbNANAgoIJhVVxIwgShIKBBVAKfE0DQ6avCAOTM6rruExqakXH9hyJlKzZhOhUyI8TSn+lPLJ0/asH7bl088O/TjpaxXVtb0qWpGBnK0zFJVkqRbCYGW5jHK6aT4w0NuedpanXZ8yyP9fyJffOfp497ZRaqMbIu26KYo+mQuMGfCatxRjG1zzIuGG7rGUDBQ4vUHEVI2BJjU8ExCCoRE+8jCRKJH4qIkQXUXJkEDINLU6Fi22un1w9D+4PcarW2wZKXm9cDwfuD2yN9l8lA82TkjVOYBTIod0IQuygH+baSAe+J80MWFz+MOAThdqqQJGMKa7/2uPz/Zuy+193fssOOwh03aO/QZUppqoUpYbOuOd//f31o/XeqMxmLQ0vLVVlAZEmCmWL/ovab3lxdfc0Hxz+dsuuO12Fvva6bgggOi0hEkXREQAgiymKG0d2E4KrjQ0lIGTj/Z53ZvvPDmyP2LR50z0zNmGFUIlXDqP/RIQRTcRMERBQgTTQ6yXdSt4IAowsHwtl3NbvADwXB9IzMRqUbQUr8hBKgBIEqLsmdOxdqu9hfuLj52jNa7LMaohZKsulOxJM4pZVKuwtJKkOOAtr6xHd/8PN3rs0GPrOxC6iJN5YvnFSyeBcwRTzMiDTwVWPUXftLosK7LlzAKlBJKqCLXGpHWlTShlyePI3pUgN11YPLfmLxxLBwOf/rEc4t/+tuOVWtIV2jVq689ed1NjctXgGlizwormfESPaGeaZDEF30P9afvRsPWEVzhcNPb761Zt7nw1EtIh7Hxn48ZDTuRAv+6dt/eh02MG5OkPCCxu1N22IjqCLinhHDpCOG8+ocpQ/ubf3hU/WRtBnSWXPGDSG56/BW725cuXuK/4lznzNPCl5+XffGkj5cuNXc2E6aKYDh2/8s773uM1daISKBj0Xvwx3+S7Ts5pR0aixTlOkYMzIKvSoJpjjGDuEM3k0YrsQSS20sylEhuJk1mPSGdg7t1L6lFWcKDwGJGIMBXrDZ2NhIDwMDO7TvE+s0kagACZ2hSEzra4Z8Lon963vjjjfrkQZsfflldXe0MmhFGeCJlcwWQRsO8pY07gUNhuHknBtsJ8AMccrYbVHYcPR03TIhI0S3hxqKPL4hjJNUHyB0kl/NLcfQdIlUjlHjl1Eu8tvlm7IJAOVAB8ZVoAHCgBCnllAjKAUwCUtqAKYKqKHLKKibOOZu2Bpvvfw7uflS76t7+w4f5pk8X/jQeP44CSDjSGDAer3LiCA4IGPGDIBIRL4oEsIOQL2ZCAaBmqhk2NmzUr7y1aObE6L036H84d+lHX0TveUENmMx+WtlhI6qjMxTGEIUrNWXCice3fLG9GTanQiZ1uYBDDEF0Bc88Z3bvc2Zxl5aiu4fc/ItJl1/EPG4CSBXWnOtd/OqbLc+/Fv5k1Rt3/mN1sBPSUkyCrmhErPwy8tkKpd+M6rzI9udeYS2tBIiJ1qgd7inaLNE/uYcoetaOKJtImAwAjmgmFKEOpD+Foda2z2//x5d3P4B1u6Lrv3rrhlu+eu0tNE2TAkHCBGlp2Llu+aelV00vnn9exuzpHZn62g8XShQFFJFL5Iech9dsrHnyJeeQwswbL65b+Gn487UsFLU/NnbY0TO4JBB8FarfHKzt/enFYEkrRX0uR0k49Xo8YQw3Y1T6We21hHEfFsKe7ydKLESIxMA0BQqDIicIhoGGQYTgBC0qIwdgUyZkXzE7/ORna278i64rQy+e5yzKQ4EUBUHOwSBogBGjXICACBATEGIGxmKEC5MIJAev5kJoJMTf+/CDluknVp0105+Xm33m6b3mTKlraYD6Bmo3nOz473/027fgsHWqmBHuamhpVvMzfDv9EWhuXL7aN2VSMBBoeOZlMxrWqko1CpwCzU0nuZkEBEEUDj1t6qSJm7Z0/vbRWFnuyEx//iXnduZmIJjqzobNLy7I9+ip91we/GBp6B8Lgn2qnKdOiemMAWgInAAmJ3MIoCDUAk4UkhM2GP+XsOSeCAhETiBG0Clkqv2uxg8hJDU7Z9CJJ315+0Mh6mutri0JQ6+pJxoel5Di8iCE7vLlXnFeQUWZyMzAoUrJtRc7OrsgFiSgc0Qai+fxWGeobskqLyhVV5wXHljiveLPnR99offvh8UuE5HZ1Ac77LD6NoRsDu2sXHIFxJpB88sSKW9ncFre8OOCWWkEhYIaA8PaKu9u3H5TlypRbRHgHYHAki9ibkdq/948JUXpCgRWr+2iIqtfX/CnKggMKAdQXQ7fMSMcsKAZPi8+4WRaVhjViMIFBYEkjr14R2fzqg0+3Z3St28sxe1q62z6YrWhKXmDB8U8OgFyEE8X2VwXgIqqjzz9jNSzZ4vszCiAWpzX/5ZfYltHLDNds+VS7LB7VEdnYDzDQezDZV8993rq2ScoJaN2gdb6l385v9gQfGZB3c1/zkeqpaRKyrUwIV7wAXKLaES93pzRw1q6IpHVr5cfM0zt18cEIBzM1mBnUYF24dk4bnTK7Onq/Gk7ugLRYJDLWlYI0+joMqNROelCYjHTaO8iUa4gYUgEgimRViwQNNsDKCRxlWOsq0tvjxggwuSA+lTo1FzTJlWOH9zwxwd3P7N4zNwzYHAVotATUudKalFRwdTjzIpiEwSJCb2pI6WuhXcGTACzY3fHm2/jY685mzv8x47Iu+kyOna405+T8ouLtJPHEF/8GCbZWxjeDjuO1tgSrFvTta1y6VUgYqD5B7Y5s7RydF2ZMeOUriyPLrgurDFb1tOQKglO9reK4j/AGKARiwYXLVn/0z/hm5/o0Vjg0xWNV/4x+NFnwghxMDnhCYJUINz6wefN+SaFfvULPw1s3MRihknRIIygCuBgEax5+90vf3iDePdjZywaWvhJ/Tm3dq1ajwIt3vrB9acEEIFdTsVTWuzIzTYpKsAFgis13VVWBl6vQYT9qbDD7lEd6eDJUmoh1jROvIyyVFtinG9/6TV3Zkb2OTOrl68h1VnG4mXBX9+5c+2m0pMmp10+H1wuDoJKPEQs5RgEIXikI9i1ZqNGNa8Y3bBsdcrmamdOhqmp3t6VU/r1EcIMd3Y58/P63nAtcJPrSlS+qRmMbF7wttPnLTl2NNG17YuXYF1TyUnHO/KzksM3RFDSsHJNbPnawoljnAP6RDZvX/vhR736VPnGDuZMO6CLFag6lfSMtHYwFHBAaqopkAoUFJmke1hbjVIhhsWArF+3ruHGvx73+58XXXJ+/Xsfv/Kr24aOmjBy2oT8kl4EQAhTEOYYPNAVDnZsq4bGFld+nvB6aFcg0tgsFMWRnQkO/Rv4pXa5ascRUXyRbl0lIXvH8Sp3Y6Cm7/KfQLgO1DQgwmtmr6oZR0bNwjyfQTmVA7ZAiNSuI/vahn/zypCvF0pGWtqZp7gXfdLw2PPpTrr8kaezkQ2aONFIz4ghp9Z8iGHEXnu3/l9vFM6aWFGW/+k/Hm156IkhBflaZQUhRMq1oJqTXXnKtGWPvVt/230exVz62FNV+ZmF008RmsoPcn0SIX0/KbWUrAQIZqkeMMVyLUwMNtqL3g4bUR3ZcCqBqARHykxi2aqggtAVDCgzpvQtK4XS0pDb5KCXppXWL3p0GAC5+R4szDKBMyRUAKeWcp2cYgtHzSUrt7/43shfzIuO7rXoxj+ceMmt5onDXeMGh8ePFp2B4GfLxeatOWNHRoYNMIEyoC4TgQpQmNjVVvPL+3J/fiFmpex68LHKAf0cJx/P4xmaW5PUghC3U2l47hW6ak3F1Ze13vOIsXEd/W0ZZ5QeWEddhMO7P/x43cL3el94Ol/z1fr7HyuvKCIlRTFKnPEkKghwDdGyfnZnpE86f179x6tr71uQHeb84xWTS/oV3HilWZJrAGoIlFACPAqKc1f78rsfcby9bOQtV7PTT4i+8e6X1/3JN+v4sisvwtK8bgGcvQnpdnK14389hPUpthADQYMQtjKwHbk5fNXNYAZATwURc7OyTuMcfs0EUzaf3BYhknVr+lpDfAmXTwuk0SR+sgRzraUi4okA9PirCPYryrnurOZf/Mkz483ekEmf+p0YMcwk4DYNmYpItHZn/YNvldPC1PNmk8oiVReB3/yLvPSeenmWmeI3iFDRREI9x4we+tMLPr/p3lGnzypwVKa89LdwbrpQiAsJiacdOFDrdoGExROCS94UKYHFpImOAIKKVJOxe9d22IjqyA9KadQwwttrlM5OpW8v5nIhisj2HZ7W9vRJE0DXhGHq8dyiKpketbUkCNxXu5NUVXKPTuJ5glCZUaWIlQnEaNlWzSePYudNd2anDPzBOeueXYS/eyxn8vKK7GyjruGrv/6N56flTBqtycKOobQlRoIuZ9nsaWLTpl0PPas7oLSqJG3uDMzJEPG3oHI/UXAgmYMGdV15btvfnwrdcnfLztoBl8/xDB0MiorwHTY2FnA0ugK7Xl6kDq4quOwi2LDl+fvv9y9cmD9/XkxxJFlcjCZkFEi8is1OS//pRV/99Pc7bvkTqawquvUqWl4kTFNRaNKghxKCWJrfZ96M2vVbG154I8uMrP/X82q+v3zWKUphnkEYgN3tt+OIDEteHKjc6iZEXxfYMWzlryG4DdRUoGJYMHN3esa21Mtivcopyo00mphA2Udld/9FRo+eDk++AGUvHDU9s3efQElx587VudkjXEMqwwxEHNdYlpoYEKZrzsTighKoLEW3Y8Cp0wK+NOLzS1EoEk97ROESLuWOO8bX/5XOJStL+lW4i/MCVFBggChkgXWgDxgUVvrZH6WegO11bIeNqI6WMlMIg/P6jz/Z9cyC/tddnjVhfPuOmi//dm9hlBf97heqmmpScAALwK66Ta5el1/wxbIv2m65c0pJCQzrB5LQpAhiTR8LQKGy3BMm5ad7aVYqClF6wdz80aNg4Wdbb3u+8Td3uAjJbOvK/9klZq8SANREHI1AHJFhDLijpGDIuJFrHl5kQHXf2f8PinNjlAjp+kdkCWgixDTVf9w45zNv73z5HykTz/KNGGL4vRRNKjvs396Ni+dlwyip6qeMH459K7CiaJgIp0XDEI1SXRdxjESZNeITh0mARBiqIipLfRWFbOU7NG2kWloYBlAYYXL/wRIhVBA4MTLHDtfOP73ujkej82/WmK/84Z+rQweamqIKBNs93o4jLSzkQC0tTrn6YE2geuAXv4JYCzjSgEdA7/Ne1xRfrwmRTJ8AcHHLxJMk9VL2why4x+xFxJe79S0J0xCAk4QxucXUREKNcLh93cbI7mAeDKlurHUs/by4uDDqcMR/l4AJkF9eRioqJBQzAbmeV+g8p8iywAEERgjHeNohsdiuxZ/y5mA6HLN1RX3FqrW0IodSigicHgyRXMh2ffLm9Pg9m+lrx/9Uh8W+Bd+3zCTE7XBU9K1iu7pqbr4Tln3Z8fDT4qkPCkaNAbc/Shkaggo0IWZedrzy4wucv7jItXpj7PbHWEsHIhgEsNVs3rLDqGmhXAHN6S7LMyKh2I4ahqD5/WzUMHHRmfzicfjkXW1PvOc+c5o6emxEc1omWVZ5K+EOMQKdDZu3OojPBWVtW7aL3a0mJDrvCUwUfzmGN1a3t7er/gnBhnbzqxo9bCBBE8S3U8ItFShnbo7/sjnuIQPlWKJSOmuGc/aZptdFQKhCKHE4ZSkFCiRCIEAwFHr9/aaPV4uKk0JftYZf+8ARiWhcNtYkEURIVYUoiCghdGSVUp7hhi3Zx/cmxwwJuHQjfpwecn122HHkICoTUFg7dEu7tr3fumbgqt9ApAkoTN7tPlYbGCn8qW/aybFMn4LgQCkaRUwGUYD9+C8l9THRQG4Aj8UPLqVSAKMEwrLtBJIdIACYacLqNS3/eCKvXyl56VdNJ5aRG59ly9bpAk1CAZieNDWXpAYGwOLYCSCK1OJkEgQTOBGi69NlW258rKqwQnn2+uBxJaFrHlJ31KuGiEg1F0X8G127hEbnfvOP/bmxw0ZURzicsha6NmJo75/8sPWzLW2//FPgry+PnHeK46TjTUUhJmLMiJqGAp4Bc2eJgqz+004cfM3F66Er0FAHFBhAtLNz2e33Nt1xL9vZBELsfv/jj2/5Q+NHnyAB04wRAJUp2emZZjxn6qrXLShVkEjFTukcQYEQqptQu+iTZR9/nnfjGYU3zl2/at2uT5axQFC1MqskzjMgpKa++ukXMDW15JHroSSr+oVXeXUNMUWyxP2OK6WKEnaoJsGO+l3tL78dXbc+xogQPLijJvDOx2LrDiQogHOCMRDENNuXf7HtJ3/PGTWw1x0/1U4ds/SJV8JvLyIGT7Bq45U1EfEkThXTNFZuiO1oFlC0beGG8OerHeEQQ0y4g9lhxxGVOKxmU3z9f9m1bfSXv5u09BKI7QLGQeS/Ejjlw9KbtKJigxGUs7oULQl0C4Dh1/fBZR0jBCAxBY/GCBeCSDkVAGEaaMaowCQBnoi29rqFH9R4lLR5Z6RMPWnMxfO7ItGtH33Md7dbHTBLScryvunGN6SbniW36BSiKG0dq19/K9rfl/PTeb6TJ/efe9rmxtrti97FSERqCf87ilR22PE/Hfau36GpN0GhjtmnD7nzierFz+VBpfe0KSLNqzCFEUCmcI4aZEDfEkNTDKa6f3dVUWen0+MmxESgNNvfryg7cP1dzYW5mccf2/bzO/ILfbkD+sUYcCCeQKR94Wc7nnyz7+jZARdpfvH1lMGD2bAhERU1q+yUFqikM6it2Fwx6VjlB2d2aYriBLZigz5+LFQ4OeWSyBpPz02bNxUEI74Lz+SnTMk2Y1tfeDW4cbOrOI+oetJI5luBFQoqu0/hto7o6b/ddXx56V9+6fa7F9/594w7vhz46o28Vz6XGC5KCGndvevDJf787KoL5oiTJ2Toet2uhs5XFnn69YOK0u78zgm4TKhduarpwVcyy3prV83T//JU6y//6crJ1UYORl2R25F2eWrHv7Mu/ztPTG6eaZ93be2MdkzefB+EasHhH9bkzk3L/YfnbH32iKBTVdFULOumhHYvQVBEvC7az3XxZJ+KdwWaN2zKYE59cN+Yysy2zo7N272aQx1UJSeKKQEwELCsqO+xw83RI2IOnRw/wX0viyAXkZhG9pVR6Sa5qyLh1cyTbnmRaDRn6ADH9EnG8AHx48yY5EoRZkyBsEG9SNEu1+2wEZUdB5Wt4+ABTCKJBVu2d9R3+KAqAti5eYd76JCYBgohmqISXUdQwEBVshBQd6Vke4WU9KRADKez5IyZa7fVNv3tSd9na7owNPjSHykD+0cBVZN3bNy86+GnszJ8mbddq1XXrLztduWJF3pnZZGyPMmRAgZEAEQdesbpUzzpPpKbbipK5ZzZzsZmSHMDcGmvZdG0UCsvTfvJZay0gINInTSmV3EOTU8DTROJFj8RBNgeVCUSbqeY/BJBiadKktmnt3jgx6/84R+++54g2emdz71X+udLybgRAhQFOcTzPhi6njr5mLTjjoGBAygQ/8hBQ266BoJd4HZD0qc5oeuwq3XnC++EdFYxb4Zn0hgK2rq7H4GPl5SUlUB+DoLd7rfjQFYk7j1agf9FuaKbJE4StjKrOreOXPdHaF8Pqh8o9gllPBWa2Kv3RKgqESrRpMymBWiQds/0WVTH/awGmkxGZiTS+voiunQb/OFKdVBVw6JFO557c8TUqTi0ygSuyok5PSO9z9yzBKOm3NljXl/J6SdJLpPAvfpoFp8JrU6V1Q4XKMlf8vvOnJyqs84UDDgKDZGkZQ6aOZtw5IQyaz53L9M9+k3dum/+tjgQR0A77LAR1RGSwhPlIyG0cfemux4MmdFJd1y77cV3Vj3yzPghg+jQSkIVnshMVkPdyonxzMQpVWT3PkqJUVyQMWNa5/3P1mz7IOPiq5RxI5EpDDiPRlp31IVS3YNPnyWOGekszs5pOCPwxUbYslUrK5KynQQRwUSH5nQMq0IQsTjAo+6SIqWkSIAJuMeAnSGml5UCgBzDFizNl5Y2PH4dHNA0kUgxdVmkJh9N+3SsUOZ0ZhA0deaYecqwbdu6fv9AF+hjz5iQOf9Mw6/HQR5SisAoKikpBWPHyBsl4tnY504ZPRQS7NbkuJKVaLlZMXigNvFYx8ihAZ/Pd9q0AalplHNCKRfSKtn+tNlxwIvyv7ldRgBWdW5qiLZP++pR6NoODj+YoXJH/8Xi5IxZEwyPg0kMo3SDrz1X8+2rAK0Os+73Vg4fvvq2N9seeHzAvLOb7n3Ck5PlPWao+f/Z+w74uIrj/5nd967qdOqyJEuyZcm9N4wLPZAADgZCMORHB1N+EBKHXyCEEAIB/oTQE3roGEw34IApBowxYBs3cJV7t2VZstq1tzv/z+17J8kNbHC5k/Ybxch38um9fbuz35md+Q4molgExNBihj1SLor/y4hKXVA5CM31dkyCnXlpVySSVEnuqrLYyXmXDGPORTKXipNFkaMRf8ncjSvFFzruL6PS0NCMqt2Y7mZlPhmNNf73g6zHJ2XdO55fMJaKC0K/v73p3id9D/8Ng4Eo2F6pSkUglRnq8BvnkywAMxKq37hJgCcHemxYuwG2bMXMTAacGe68AX2C/XpAYRGCZEX5pZedF91YFQn43SBVgxkUSPUbNoYWVgb7dObFRSAxMm9+XXVtZq8evDBPIpoUJzRKpUFur1wSXrs+q1uFt2ORJFG1fHls+Zqs/gM8OdkxN0OVTKravAMj4ohAkloSRVU+VtzLFQykSEvLGjIwCuss4Pm9LoaszChFGRhKzMH5N6qVX3NGKdn8r/VGoWr9iEqKcktOJ9Ut2S8JsjIy4k5zfLCYXa2kDaxGKgOVI8ER5tetGLDoX1AzF8wgGOyMqjRXh37/6nh+dnEXwThX4sC036aIBJCh+I7lT2PHDYM7Tuc3PhR6eWlWvigef5bs0ZVAIHFIHO27m8NQyr3xUutAn7T1O9GuC5FKvoQJZqelMxWqsut5gVyO6ibaGhBumdB2YPt7BzrlSqMtQB91/3gT6XhniOFQaDmI3L9c2uPsM6TPU3LU8O43jNue64uEwrvXOcsEObBFaCSAJxyTM2Zvf+RF79iTcu8dX/fRd1tenQTbauNvu1zusuJgeWfp5gIEouEJZmf06OnqWCyUvYuzF2Th7dXzHvrPuhffMKtqQksql9/57zXPvxbeUSMRhTJXyuKhZfBtq1bP//PdK/79NG3ZFlq+bu59j1b+6/lwXZ10cQI0QrHaBUsaFyw1GyMSyVq7KTJ9DtXUkPpd5MT+hToL5Hz95kVvf4gwNK1gxLo3PoHFy1xxq74T99m9QKelZgftIkU7CVaCFFIxP5UzRYKEaCn009NNI5VthSr84Ahz6lb0X3Q/1C0GTxAwBNjpKWPMS12uzyjpHuHK67HrP9j+mWW7/3Eic5zJQFrPUcMDYK6tez/Yt7OvV08nO6G14WrlFu7yUQLQQtawvabx829w1hJoapKMmmprG7+Yg/OXYySqcgjQUdxlOx2zki1U3Lpr+75E7yjRcxT1fqShY1TtNERl/0dKQJ/fW37umaZhxjgnACMno+CK8yORMHJDQkLG2P5xbHVWqEI9RMTXr/n8hQm9Cotyb/tDuLigS6hm5n8/PqKoKO/CswUwYTeZ4MCJq2Qo290FwrgNVkXRmN+tx6BLf7Ph7w/HttZXLVrqBex+1YVmeUlMRZSYk/YggWG3kSPdF2yp/PujpWDWrlibs3lz7xuuNToVC1vKQMolX39d9cLkk669jPcp/eaeRzuEoOgf/8dI2kZbdcqQCNi0cevyP95ZvWRJnzdv5l7363++teLymwY+8FdjQM/9aM2XcMftZC1bDksy5Oo3iVbqzxoaKe23Pr/+4/d2LHhp+1yIbAWT/3VVweCSI4aXHx8sKIkYBhK4hUGsRRZhf5UCHOlOBENE+aZtyyd9IDGv++iTl8xdFPx8hrdwDHnYTkeie5N4UwW4AsyQkFUT3gp/ubjL36/KGNBn1WtvrJ4wZdRVFwW7dbQUVWqpFsGW5Qw7vZLQ3Pqh8BQk9O60PoKGZlTtN0jVnHAqDYMZpgAwSaoMIZKI6PFYijvxHwhok+Hmnc85IzOnQJSWRAzMOWdsnz79PNkZJCJomCbxnc2VsJt/cftUTZ0exnzu9KMG1QzqXnX/hCII4wt3w5F9oy4XA2GQKmRmCEhxuuf3ZZ17Wt9FC6vvfiEKovvd480j+1pel1TBffBg2SnHZjw3ZfljE1xd8uXsJQW3/YlnB5VGoEFK3YpUclP96lWZKzfmXvkbz8+OBKChfxjne2QSLl0KPcvAdO/jIZ36QLv5ji1P5QTtGOCeNHc0NFISEzZ+fP7K/0DTBnD7AEN/DY24ruwXaV17Q35QMDBpdxX0/fTuEIVSRYhbhHC0Zur0pn++U3rT2e7TTnH97pZlT7/ar6LCGD5AoIDW9XfY2jVsWZMcSCD4c7P9Y36+6KuF655+jabPq3/po86/HuUdOTDmdYsEUcLdWN0evU4NDc2oNH7YKbRbe4JTcKd8UXSKY4yEsHGzlZG7mRlC4IQEnOcXdi3oCGjEePyjXKUdOxUXgRDEkbXIRDmSyImoja0jbnevkQaC6TXczKiBtQbIAm5IbkRAdetLJJcCMYEgGHjT3cxtVMEyEwyf2wA3FyqEz4lCnHwdi/NuvvKT39/S7aMJA+96wDx6aKOLuYib6liBO10sMLOiPO2p26C4UPrTgWT56FOx90DICEhu0F5d7D3IEtqebmvnlkMikR70eZ9GKmD3LjCJ6Mz8hlW3rHr1rdpFENkGPu/FC4Kj+/zPMT2O8mXlWx6TOVUjjtYU/thsQYwbHBJIRLJu47bPpkztcvrI/AvPCXfM91xz3rx7HjPf+6DnEb0QiLjR2hyxVmut1aehQcAYcx0zLHv8ObEL/7UB3ikZNqrw3DFWWYltThLuD7UyTT+83jU0NKPS+AFStXMymlPmbChepSrxHONFe/r3To6Qy8kTNZs/jiHYne+cf93Cq3Y2gPaJIIGwqr5dsm1RZflpF2z8dun2yR+U9+zq7tVdtm4sQygQ3FKumjpt9WczBp99WdPM5Ysmf9Bp1CDs3QsNrn4ZZ0r4xkLhhWgsFnWpXoOGo1PlFEQjQ19urszLUxVBBGhgWrrsk06q1SA1M8t9GEDc+6hqe6yRQlSKWr4hmyEtaFjdf+H9UDsPeBoY8q9rulxZemp+96Os/EAIwGMneR+IjOxmZ0sCpAXSB4+7OCszlzoVI1l5Jx43srjIKwFEjHFTJq5aqhN3x+XDXY0SU+Uy4HUHunSM+F1VjZvTi7MxL9Picb8LVQ4o/HACPe7HOEod0NJoC9BpKgfd2u4y0PhjrCXukYjY3whgTeu3rHvmHbMoP/OGK9kNFzW+vaDxhUly41ZAsBI6x8AkR2pYtLTuvgkszef/46Wemy9bvXLrjkcmurbVmBIFoAfNyKYtlfc8VVFUGj3n6iUvvwcffx0gMiFGCJLFv4CBI2cgJUrpVGTHzXn8rz8ir1ZDI3UhHN2ChEaTCt8sbFz1i/l39Fv8b9ixEFx+gLobYiOu63FB/tGjInl+IPJKYkR0QAvceNyzYa68jOKjh7r7diYWNQxpZAZyhg8JDB8C3AdoIkipvDSjOTy8F9sVBYDt1TWfTNtexNJhWO2r39TNXYCxqKViU3wXqakD5aDqoLSGjlFp7NlAILZmVfhTA2F7tOYkVavm2g2bIpFoxflj5ICeBaUFrrWb1lZvL6muCRR1oES3ekABFq1dsdzK9va++FLq2cNV3LmgumrrrAX+DRv9WZkRl+GvqZ/x1AuRtSvH3HFTqLwocv3ts+7/d9d+hYHSTrJZ7gFhj8d6mkhptLs13iwpro7eJCIHXNK4pve398S5FPeAady0vuSk4qN7VByZll0Q83Am49QHW6kF/PSEwVahMpTMlj8gVMK8kixihmAYNxaIwhGW+r4eeVK1VfZGRdPEd2seeTvzsjPLSku/fPzZNU88NyQ/1zOwvzQNRzZmHxLP92EMHZ8MmS7r1dCMSuPwgZS8kwsgp2e34C3X+nMzoi5mFOQV/PaynMZGX0amICFBGCrbi0CaligZNhT69XJnZYPbix5vl4vOgTGneLOzVNkgA2BDh45gRw5h/fuyoL/PzePFqrVpptsO8+96PqDNn0a7B2tOmorTKVjYuL73grugfhm4AgANQyKdb6gY5+9W0ZjpixGY0m7Dqc4F8UAyu+aUTVsgVL1oADCPeitsd9BEpb75Q8fqNktaMf+7mluf75JRmHXayVjRuYiiyy69rab4lQ7FpVCYR07WFx4QVqqYIOkQlYZmVBqHE6opvMo3DaZjRlBCzCDkEkRupic3S8mXE9qC5SofS5oud34+2W1llByfOyuLsjIZMBmz/FJSujf36IExw2xEyRH8Q/uy/r1jpiETClIaGho7ExCHHS0MbTh38SMLRAjqK8HlKtkgnmw4tvjUM13ZFRE3c5Pt1RAymaAOeCDPy5y2xHGeI5XyiAQ0autwymfh3CzX0H61fo+vuhFnzI76XP6hA2MBHyOyG920vgqSxNRH5RcWZk/8e3ZWuqjoEnG78n/180CvCtPllhl+5iQ9Hdj+MI4Wl06n0tCMSuNHB5loT9U2+2VJnfNFCZID2mrsqgs9KoUFhkCWU3XIiNsHd3E3WXUVtFv5WQQGGpwRCCWUHlHiUBzIYoQeIxb/HKdxmGZVGu15uTrdXpx+LokkdIAVTRt7z78N6irBNMFD/eoy3vOeVnDECCooamLSLdCwZcRxj5WB+0vh4otbOoEo4MQUHZGk+sYwVYpLCFGQZEVWzJyzftnSE6+8yDzxmG3vfbjm0ZeLLjrdP+II6bRehj0EnpUqTLBDDhTlkrIecdsSDGYOO0JRQXlwfCv6HpEsDQ3NqDR+GFIJIPzkTARUfUmpuQzbTGSO2q6wqvfjCM2NtVpkBJVKsakqpu1QFkgy/CgwPjEwBjwK0m3PEiKSpD5GQyMJgbvTgwO+XAFBYELjQy235aFNw767r5pi0LAC3J6KDfLF1QNyfnl6QUmfUDDAATySWEtXFkzQhp+gPqWq7Sx1TkYAXnXwSCCjSEKQyU0GYBCE0Yqme7J/flz9J19U//tZJLH2+YlZORlFw4aAyc0Ed9qDogkmWnoq1uVSOrvYUmXckjmm55yGhmZUbXMzaR3owt1qA3evkmbIdtI8tqVKIU6mcOrn86ZNHzB0OB073OP18s++Wvjp9KLhI/xHD44x4UNTD7hGEpOqg8WoSNEpaqUVvjpUVTH3JmhYA8wFnEOj/zXfL/ueNSLSqSDm4iZEkZDHF9qBvDBJgqPhijs3KAGiaDGQJC0X80sOTApClMC8ZAgXM4b27XbF2O9++2C//95a3C/f/+Cl2K0sxsCURJDosPm94nEJ23Jwx1ZDQzMqjTYICcCLizfOmJU+ZU63stLG4rw1f7s/jJD281MinBhyPUQa7XRpJIp3OcCmyLbCebfF/9K4FgwPYGNxtPPXeZfnd+/W5PdLxtNUwV2c89ABroFljCFA7eatW+bPL8/McQ0dGIZIbEd99eyv00xXztEjSHU05wKRm9FAmmtg32iXgGvR9KL8y2Sv7lHDAJIm6Q7kGhoHHrriXcPxOYVq5uoFYGWd+lx43pYlW7a98KZ5873rPpnX84IzjF5lJkeu8xw02iu4KvUwANZGthXOvg7qFkF9JRgm1PD5K8ZMH/KXgj4DY4EME7nPMa1cqfayA0tc7OO4WNRqfOnddefc2Lh4mavB2vLSO6uuvz/n200RRKESJKMMIySM2obwpzMzFtVVlZ22aPGKxo8+9kSiblJq7cQOdHa5hoZmVBoaDqcC1VYZmhgrOuHYnMt+Xn3765vvva/HtWe4Tzwm4je55Jy0/dVojyB16ocMN4erSmeOh6aNYHjBjEIouN07ru/JY4szS6MeDkAMmzOsd0/tOhDETnVHD+Rl9zvt5G8bt62560E2aUrVE68XDe0Gp41iEGOkOpojGuFo9bQZ8175b8llp+Y8+afaPnmbnngFvl0MABFGqgtg0ixneWDlTjU0Dg/0qZ8GtDTUU2hAlhFMj5bnB+G7TGis6lRoZWeEkQUkMWKgz/002uUC2RyrL5g1HtCEyFYwTKMqtmrRiNDFY9ODBTuCvjQig1QBLSBBK3nfA09aEInQbbBjjyy9/iIaf8fa9xYWdissuugs6OA1pVQlv0gEomr75vueDJiu3PPObBzcteKc06rP+3PlxEllXTpHMgMI5E4mB4kAdQRcQzMqjbYDqbScs0HwZcs9D7zJjj559rat6X98ruyI4eYR/WMcmNIN1NBoD6uBVIsnLgEZrIk1dPryCohWq3YvDKKB9dmX5F8zlDICkkEagVIkUXVxjvgtHhTWAQScWTGLTMPKSOt6+ol14/9Uu3VW3q+vMbpWWC6fapuOKElKCfm5nZ64y+33QW6u12V4Th/tXz4sZnJM86WRyjdPGu8IJRgcuduMJVioDoanCChR1+Q0sXUKxTWj0mjn64JUTxuGyOpCnz4/IWtRTdmUPxeFGuaMuXzNi68Vlpawgiypq3w02smCILIQGUCtaMr64krgHohuB2YAhkAU1WVdG+jRHTwu4Iwd2vMqEsR53G4b9Q0fvjSxExh57p6bP/jKe8YC49ijJAInAkTGGXCWUdHFVsxiAOD3+7r4yWmrTMk23LqvX6ruG4k+17ylDKP9PkedR6XR4iaqvssAH81qmLsi867fRIb0CZ98Qu5NV1YuWxH6ehEXOiqv0X48b8kBa0Q4a8YlENkKTRsAGYRdc9b/prbnX739+wuvB5C3atDn5KIf1DUKwASXggmMifDbHwVufI7/31WZb93WROamf03gyzdKxCjGXSNuM6ndmBMm63Br25KKUBWtkiFIICHV92C15+NbHaPSaN4QEG2fo2/5sXf+yVuQE0v3CzRKr7gwd/Rmb04+MmkggU6k0mgH/gWiWRNtyv3yYojVATOBRcDKasq41nVUb/R5JGNcHJ4rCwEzALYvW/HVa293PW5Q16svj6UHXL89+4vHnqOXJnb6y3gh41yQmCJVe4n66KacGgeAB5OqF0Xjk2mLv/hi9s+OG9Cvf7nb3a5JhWZUGju5roxQdC7yQ6FgzLQDV4Ud0grylbKh1OoJGu0BURl1Tz8P0AOxemAIjRT6cmTT5ed48osaPMxDzBSH7doEMCLIz8w97tpr0tKDVkkhSOpyzplFA3r7mInSMnaT89XQODhuR3zHeO2tyXfe8Vy4ifXs1rF3n04ImlFpaCTAEJAzSyXYAoKhOJSSiiYj/qaGRlvysls8CtXdJf6/kBXxTf8NWCHARjAIon5hjoObRqHHiDHmBiTEGI+/gzt9xKG4WALwgyAE2SHgzRvQxGQQuGRAWUFj2GCb5gkW/zGeMmEoO6lZpfWrJldST8vU4VQvvvDu/fc+K2Wm32taltQet3GIbJa9uElJpbSb/uLUqvenbD0eSK0tMSXLNMTm62G464utLliHqQ6tE7j79p9gAGoi2bOMJdJD7XYppLgxa6fkyIHc848kFh+hVCOsRkmAYGSR5f3sXEAXWGFADhGq+6APXHMhdewScZuoMqua2x3LPf+OfRL03Pe0odaPUDr/MP7xFlNdkVV3ZAEgkYhzC4CkkqtCEAc5SVbu//Xv5XNQttLFckYmTm9TaZ+wr18ScPWAbDUyQiYZpsaN0J5viXaes7jbsy3v0unuf96yck396xPfBIoBa+9K/MbB2ZQTSwnVeb5jCuKMSgKjdjPg1Goatp6x0llxTmu9ZGNUu29ObKc3NKM6hL77HrYgteMwm6yTgKj6rzduyOIUIU6nbEbVXiNO32deUKp3mc2qhBozu+8lhkEEPhsLMgIQBmQQM2s2nOa6+fhoZl4IuRnf+Hnr3ULsJUIl941R/WjiosLHxBML05Yb4Cp+jAAxxpp/hTy0W/B+/Rg5u0P8GSj5LucV0erGZerMYWxeb61YB5HLQi7irBdEW/BUmqe2Y15I0qAh3RljOybPsmS9BNvJQ82oNDT2Yr01f0o2A8finMqSUL9DEuNer8frjj8mAYIDl4KF6oBxcLnjXzqf5nu2eCYNe/9r4CLw6Vi1ZUTB7hjO0qOdb6VRBWG/6SdGduyBbBGnZOgZ3BxO3v16UutpkKHkHqQUdryq+QkxSj2fgKn5pEKEzPGdlcZfasprNRt/OyYC9iLAFgJJiDHiMYZ+kCCJEj8ZA3C1W8Oj1RM0NFILiAybdtTfcssdfbofNe6y6zdtiiECR15X2/jgPc/06DbonF9fOHv2PM2lfoCTOI3tIPDJ2SAiIMLx14VJM38p+z1mdu0i/R4CzhOKhUwFlTGhP5kMX8l2Pfv91erAgpjc5fmk4tcuu2sbzXBJ3GjiSJMxjpxDIqEFdIxK45DviqiDPxo/yo4JCeTLCFxwwa+/+HTVxxOW3uOfeOeD58QEfDZtzhP3T/PJ7iecePLAof0FENchqp0GkIgRSmaprbyORxmJrE//R4WmFMFi7u14nXXdoAaT++MbIvMl8tTskIMezp8S69iTR0/SmdqCScGcoI46204dC9kclkCpophkn8kDkmXfEVPhqxRgSLs8OBKRqFW1tSYWs9ICgazsIGPMIiBBDXV122tqA2k+l8fdULd+w4bqaKO5cUPt5g31xR1zXS47goWaUWkcvvmrofGDW5My4AwkY1TRtfTyq8bc/ddn/zvp3bL+3qNHDH/+qfd3VG87+6JTLrhgtNcEi/RU282RIWcLtMjK+excEBHnHWFWf3Fk1q/PtCo6xQzmJ+Jgb/Z2n77mBCw9hj/V4lErr9IZUSfnyw5SqRw3kHbZccquVPvamXQicdCqSClFSHCc08K2bTsee+ylTz+YN2rEiKt+f1bHkmxEWrdp05OPvDp96reXXn1Kl84dX3n1jflztkQj8Mor/62trb7iyrMKC3Kk1IxK4xAadj0GGj92c1JdrUmm+82TfzF40YJVLz7+1n8eeW329FXffL585M/7XT1+bGa21yKBO2dSa0Kq/sCIjBGA9/PfOHRKcDBNuWZs7I8nCZcraoJbSoaqG7FTtoXoNNdAXdn/0x1I57jVSUx3OCoRSYak6BS1mMgUm7yJrHRs3SWbWqoEMLUem0QKBny9e/R6+9k5Ex6cEsz1/uGP59eHGt6b/Nkzj7xWXNC1e0WPLl0LzvufsaefIRh3RWOh7GBGeiC9PSvIHgJGJZvrlSVGCIiQSBK1VA204eMvpLhRdrG4bW4CNIDQIKenFimrrQ2uxvc5is2hFYwpi+xW6Rpkn0AVlBRccvXo6TM/XD+3YcOiaRUDSsZdPaaiazBiCRdnOx1Ytce9u9WuJiOS6pj0NAH5Z1wAsRpAtyqb8y15vWe3P4yDozpwJlGSK+6bt/6ohJnSp/QHFCKR6uwEoliMTAaMTIgpPQgXqhqMVGTthOBSRJEx4mhnaluqb6qZxNct1E7NFZdFu2oPANPS0372i2Gr1qy5+/Yn3nhpWnmXHjn5/hcf/9Kq947+w4hBQ7oTiw4a3EcmKKOKyFG7PfI7JIwKW+g7MgiHoksWb3SZnMjamXpQ2+s4HmNxzsQEsXAUwLt6ztL6rIxGwzBU2TbZgpmkTxI09uqKMIh1LisNZnqJEh1FyJHbUNXmMi87eNSoUY98825OWl5+h/xOnYoAwGTMIVPUfmqZd79NlghMIXGToa+erPQZF4PV6NApM51yboc/50B+WoxiYMUNlC1OIXYObDW7Rzrg91PndIKg2vnMQkoZ38GBJLNkfI4nBGUkilRytiU0Nwlu2csEYEzGzTxTvShaBOOScPEgSHQ8CXLOJ22tBMrOyhg9+hczvvh21kcrHvn389n56ZULK08796Tzzz8TWVQ6ETiSjqfX3hscHYIYVYseVcAXcJHn9j89QczaZXIJLpHaGqOSDFncTMhLTMruWDzhf27f4TJ3GC4uZWv6aOijBI29IC+T3fXgTSOPL0MwmzXelM1jgBQOxaZPW/TGK1PzsvICgcCCLxe/+uL71994PjNVBXe7P1yWABazIpI1NERro+HML8eBVae0pjwgreqhT1QjRAA8obBJ+yQLp+NU+71V0555r+KsZId0rFi0KeZvJF+kCajBktKyJIOUKhyTu2SKcW6EYw1Welh6wvVWkzdmWFImr6I4xleKQ4UkM8j0mpwjB1MCcoCu3TuM+99fL1v8xNwZy1G4Bx3f+4Jxp5aUBCPC4oyrMiuponHa4zhEeVSIYAiA0aN/0bfnEJXxZu0y+MJZbm3qkTglH4AVMuyWoli6wwZGGGO2JVEuMSZSMTU0dofbxSq6F6DqTm2fFiuFaUIUVowWf7f6uSffjmyjE87sNWTIgEcfeOaNVz/u3WvAqWf0cWZeOyJVrUMarHk35xJrt9U99PfnnzjrU/ArU1QvfjftaNMyrp/8mDpYZab98/oI/uCY/p0eUmKMrRYhUjCBjHkb19QYXzz4lsz/HIBMaWepE6bg5IvfNUczFGraGm5qqnr9b89F/G5GYMikvRt0kgTJILIKO/vPOfe0ktI8JGQIksgwjPLy8h69um1atdHLAp06FXUqK1atNRxpVkTQAdxDyKhUMhEQjRjWd8Sw9jvWA/R00/gRq4ekoydt+x7KeEuwaqrDr738/swP5g8aOeD6P12VleNavnLZC//64MH7Hystv7Zf/24CJKf2XAYRd6/Ly0pDtZ4l31bCuR3Ai2DAcX93z4p+q8LmnAEyiTpGfPCwS0pD81ALttMU93n9Mi1t64YqWLc1URaHkDre5m5kiRhDd0G+lLRm8SoClIiSJ+9K5CRdQGhxQaIplBGqiyKgpVINOGLtjoYpH3z0+YfTM/KyUbJPP/xq4OCKSy7+OTNbdyvD1j03UDOqgzfZ7AFXOUVAJKRd4bFTazubINO+NcVKGURZzCDkZAgMAxKTLhE3JWhKoZqyMq2koLF3t1E1wYTmVpCcqZ6Y3IgBiGjYnD1z3usPzOpYnnfZNb/q26dDyGo661dHf/Xpd0vnrvrPI1P+dmdZRhZX7dHaTx5VQtsIWpIyH3notpgEAZYRsaLkIULzo0YnfgembYCEnm0Hb6veOZAjd6NWyJgBgJIBA57Q6Us5Lfjdc76aszrIyUlK8oCxqmNlzU+GCSIkIZXk+5xZlf95+M30YNoJY4YFs8wXH5oy4Yn3yrsUH39Cb4kCd3rI7R2HIkblJNTaSjCMOWWxuMvzbINPxYzzyPjWaIBbHfIZTJmY+Big0zIa21w+vsaBs9Kt6mFbshQQgIUiTTNnzuh7bMFxJx7xyzGDJVguwzNgQP8r/vfsV16eJKiusnLZEcN6SZLtb7haxz5knDcxZgIHL7dXnAHeXQIoekM49DGqXX+Gt6Yi32MQaZ/p9aGm8/h92x/b+/Vjkj0q1rxZI0chZeWydS+/+M7axZtOPfvE3/3+vGikbvXiqg8mffLsM5MGDOyaneWWiDrDsOVxks4eOGiw1H6GBHYNC2teUiQcSokImlFp7B8kAFmW3LBhs8nNjKx0n88TI4nAOLJIJLp58xbGeHq6L5ge1KU3zflnzduXtneHdIPZt+knE5u53GWLd4RmwPHK98lDOMAW9cCtoL1VL7K9TdfD+KRUF3ZRs63umWfeeuCvb3bvU3797ef87PihoabGtyZ9cfOND4UbPPc/fOXJp47wet16njdDK3weVNLPMLG6iRJnEgSInBJl8FrsU2P//WEwDKO0tJhIElhEAoERSEnkcvGS0kICicSxrVV6HJitQg9JsjLfXZ+ORIcBWwCmnamDbN/XSFL5QC3SG3jICNxPB6+ra9y8ZesxY7qffPJJo44aLEB4vd6jjhl4+W9P//SLuZs3b9pR06gZ1U6PT8eoDpJbjIg7doQaGxqQGZmZaS63SSCJMBaO1dbWE1Eg4EsL+IBUQYWGxr5OLdvsCkmkqkltIRKDnH4pEkkCQ04cbEKvoZH0kAllPlv2QyboFRISgFA5pzxVWaKzMqlZOJ1o55XJkvPKLSLLspBMwwSOYJFkgEzV+BFACMCIgMGJcx0H14zqYHIp+0/G2OS35z/9xASMuC+++pcnnDSIjJiw6KOPv3zivvc8fvdlvz3luGOGElkGN/W4afyIPai5h0dC6Ya1dtK1ldNIKepBEsACwdEIQ9whMOLMA1jKSiDbh5TqUCL+fdSJU6EBkoMtbGqvVZa8D0UpVSUqxrh0hNWl8uyEejRMd7uEJGfHbYZa9epb7A/iRx9+8I87nly9qgYZW1656f57nvr4o48DQXfX8pK438L0wavGT+FVYucKKqkzhTRScSYTSYGAAsKhJqith6aQLZwuUrdVmepTqBR5lUJHU0TWNPCGMBIjpbQlkv++COPklpxuDYmYG0Kc63Iipo3NLuC33HKLHoUDCEyApEzP8JYWly5asmb+10siltmjV9HTT7/x4TszBx856PY7b+hSniNI2r1FsFWdvA4uaOzLRNvZdO/ajlbHqDSSJtABP2jWBJBAACFhxZrK96fWfTo7vGFTus+P2RnodImj5O6dTHt5jQiRLBFbvXb9+59VTZsp1m3yZfiNQECiUrFKNN5JYjvDEhZF2Rm0pacQ7UJ2naypGdUho1YxQR0Kcxpj2xfOX7/g6+W14eiH735umt6/3H7JsOFdJURVCpVSTteMSuPH2zuWUNhr+dLTSCMZYMsMJuwa7o2MhBCJUK7atPXPd1Y///YOl2iaNDWwYXPayGFkmFEOjCRLarla2uNLFovTQWv1+sp7Hql//L1wpG7r5I9h7cqsPr0gK0Md1jOWEjK8zhU6O9UemolrKOhTv4M4BQ2DmQaOHXvakUcPFkbk2Udertpac9a5p516ysgIyEQBiJ6PGj+aTjXXD+HOX3pWaSTNHCWlA7b7V4JzgSqyEMJasbJywbr1w+675ZiH/9nvrFNWTZ0RqVwFJpLq+E1JQ512OllvdTu73pwK5xiW3F65fOaSxf3vuHr4k/cOvPD0bY9/CPO/U3lUmAIGBhMhb3Wegq0D4NrQaEZ1iFefRZSZkT5kRL9wbLubZ3iDgYFH9lDJfYRkMrB7/H2PvdHQ0NBIXUbF7C9waFVr6kF2f2oC4iQ5UXZJx9K/3SDGnLQtzUUdMjxBk1sRR0ABUSZNIKc1oyJVF0K7kivnx1S2lJWR12Ho/10jRx8dywtsK87OAR+QqeWd2yR0WvRBXXiWga5Fi5ZO/ehzirk6lHeo3rrplRfeHzSopLgwW2BYEmfAEUiSLWJnE1yh6t71StPQ0EhxnzLxTRRt2iFNYlwpJBBBDElwFCAMMriBed3Lg90rmizLXL56zWdfBbpWGF3LQEo3JlezOJ64FAtIoLSA3ORoOJO6TAIQRFGUHDiZptm/Z2/WS1qy6Zv5W96cknP6AOjVlQAYSXRqATXaCHSM6mAuPOQN9ZHnn3t3+kczy8rLr7j21x3L8qdOmvbUE69aEebIqyAhMoYmoqGFLDQ0NNoWoyJCkkqtk8WpA6dmqhV3IxkCcjC5OlSKAEWBvFu2bH38xerttR3O/7WVnSnjfIsYJUvCDjrK+3ZoSiJwBgZDrm41/n9JtsggR3VfDCDKIEyyaeWq9c+87Ktp6nztxVRWrPS3JBLpMFVbgo5RHUQIgZ9OnT15wjwU/Ld/PP/UM/rX7lj/+NpXnn7ovZHDTj7+xBKuNNPr6yOLFi7LCGRVdO9IKFicWmlupaGhkfKwNZcsEJH1m6NNTR7DcOfkgN9Hqiey2FEXrqpGS2JBrhEIEAj/2vXLn5vQOHla33tuMH42Mqw6ePlo92rWw23bVTTKkLJuy1ba0WB5vYHcPOE1CImThJrGbdVbPcDNnCyWEXQBWqvXb3xqYqxyfb/xV9DRR1gkTOn080Yd1mhLYRRd63fg3TIFRFy0ePXddz+2auGWX1184vjrznZ5jY4FhYuXLl4+b/PaDWuOHNk7EPCtXbdx4sRpf77xbuK+kcP7Awim3Dh96qehoZHyjErFYCRi9eSPv7r38czJ04P56aJzx5CB2BTa+PqbK//5uPXVXOPIAb7M9NDqNTvu+c/X/3hs5K9O8g/oH92yHTwG9/kks+NbSWIUCYBQKj13K7Zqysdrb324acY3+TkZWN4JSVJtXey5V+f8v0etVWsyy0qxIDu6au3ap1+O3Dmx4+gjjZ4Vsc2bOXBMDxAqYQht6tsQdIzqIGJZ5cZAuv/MC0+6/MpTGSNGoqxz7kWXjk5z5xGIZUvXejyeB//19MefbDM9HULSIxC5cw6r15iGhkab4FSKDBX26f3dK2/wd57aHK7LLi+NdCtvnD+37sp7MbKp7MbxseJCGQptnD0v/O/3h0Px5hUrG//xcCwru+jys/OOGRkG4phcGSp2Ua2FsrBTaTgUib7ycFPlJt6vu5mWtm36TDH+j4WwI/2UB9wlBdFQU/VnXyx99PVBgFULv125/DszmFVy9hlZHTvEUCuOa0alsS/rDZGI+g7sUt71ymB6emFBllqABgEce9yIzmU9hBDBoDsqoqbb/N21Y95+dxpYUSXyoTpZxR07vdA0NDRSHYRAQIz3Ku//f1dG31pSNXVWxguT08aNnfX0Sx0jCzIvHu++8qKwyxMV5C/t5HrityZHsmI+wYXHY2ZnopCcJ5PKTEJciwCE4fL37llww8UNY77bOncqPTOxdMTw9c++lgY7Op9yCV14lsjJwsaQr6xzyf+7ijMwhUyT0jS9RsdCINDhqbboQOiUnYO07sgRmFX1tBKdYpUWaTQCtCgaEyJSF7386jvKinveeusFhiGREREyphmVhoZGaiMGAgkYYAwFStj+2pSFF9/RtXFjRnGv79Z9lX/S6LJ/3hjq3dWwE9UZNvdRQiBlASWTwBjDJCqII6ehM6BQXZx5U2PkqQmTr7lrEIggdFoPlXj2L/re9ZdQaQkDC4kbyvAL1SEPEy2fUWlsqRiVNvVtB/pZHjSuikgkJAlKlIcwaBbtF0QCiDiCy5BCSiTLroFhNv3SnouGhkbqQwJJJJVNxSygwAlH9Tj/mAhsiKz7b2fgwfNPi1Z0jhKYBAY4dErEeZi0gCwgCSgZS6osiNaKnlwJj8Z8Pjzj5PxxpwRgdRQ+LYEOnceNpdISCywJyNAO0zm3ZrV030Qknd7R1qBP/Q4mqYKEQsKu73DVjTzuhnH0GIZloGFwbhpxz0UAM/RC09DQSH2YwOPcgYiR6tzHVFJ3nFeABC/EhCByFLkJDIpTDQMBd2tzkkwGEVXlkK2uRYiE8bsyTenmzTQyhEq2SnL7jim+zxpKOkJV90lUTfJ1vmzbg45RHVRGhXsJVjuaJlLS0qXL58xev2NbZOOGqnnz19c3cR731YhAklZO19DQSO0Nhpg6xLOk5SVmTZ666r3pJhSz7qcuAWk9Ncm7sNJDEFEki6kTMfUn2uV0jOJfycU74gRR5YYRWCzOBN2NO1yvT448+elmKDHZsSth++bHXsK5S1xgKgqFlsoBYQScJJLVnCerNdM1o9LYP0qVWC+7uiO2wkI4Grn3gQeuu/qO7+as+vi9GTfeeOeSJRsZMkmWHjwNDY3Uh7StnYubm6u3bLr3GblqZfa4s9Ofvw06F8tpb6x5/V2MUhggJomkRGxpHGElsVG3q/RiiFHANStWLL/j6TyYF7zs7LSJ18tOncQ7z0cefDoWvwkkQgOR2fIPjAEzRKuW+JpPtTFoPapDuRJ3PQBEzgs7dBhx3KAxY4/7xa9GjhzVr6xbccBrEjK7K6VebxoaGqlMqMhmVbwuvOS+hzNeecw/8ISMW8fzAX1khm/HpCmh6RuLehUavbuZlsWkJaZ/vf7hZ0RE+spKBUcDdreayeInoySUZK7bVHPvUzumvVSad2zmC3dQ9/IqHmYfTrbmbff0KvWUl2MobH04bdNjz9W/9j6uWOvJysKcdCYtUl0zUPfK14xK46eRqsRfEDnjHYuKyrsUl3UuLO9cWNapyOdzkfMmag9GQ0MjtaGyuC0pqt5478v7n+6yI7/zbVfisSPCJgZzcxo2bNm8cDat2cpPHO7lfPW0Lzbe+sDGlye5BvTJHj7YYknJqJxezyop3bJWvv3Bppuf9GZ06XT/1WzUcGmSPysT569bvO47K8ayKjqvX7t2/p/uyIiK9DT/hilfRcMNwaF9pWlYyJlmVG0OOjP98C5Ou+DDLsYlWwpPRaZI0ykNDY224UkSibDX7Hn1b8yCbDh+FHebgMDzc3N+fzkNHkgxS+yoqd++feULr3ZiZi74Y5DsKsd2v0JmAWQGc2+5JNirDI47KgZScEwv62Tc9ofMr49J82SHGiOR1auDpYUlN4zHrGDTo0+v/Wx60a9OFn26RwH17qsZlcYBsjGtDvSo1Z/Y/L4eIw0NjZR3GpGQODezjz8qR4zgHm75A4DgBkLDyBjY31VREQUKuJkVCvf430v8DaFPlv2+P4VV2R9LSi4F6hxTaT24Zcdjh8kRQ0yfS3jdXEqODDxu77BBPfv1loK7DVZcViSHHSG6Vhg19W5puF0eCqaD6qBsp6jrIJVmVBoHnmK19sn0CtPQ0GgLYGj7hzwzaFs2oY7LTJuZuEyZnUF2iZ8/PT87O7R0+YZM10BhEe7EYJLIKtrNn9XlSANYMCCBg4gyYEp8CoAkul0+r68eGAiJaR7LZCTE1m/mbP96Qd+fH4tFHVBKxhkgaXuvGZXGgbY5egg0NDTaqKuoVKjQ42Q1NGsGODQiTXEmRhBGiCDjQAKFhUwgRYHcZGcsMUwy3xdtiQdwkTq8Q2a0Sny1Cxbjt6wkE7iboOGrb+oefoaO6IHn/7LBABPArcVxNKPS0NDQ0NDYPxayhwZ22HoHkiBNQkQmuZnZEPMj48g9REgkVUyIJx1RdNxh5xtkre9WkSVkcQ7JzEg0NnXGymcnFJeWZl9+vlnaUYBgJBGZAInAuJ4fbQg6PqKhoaGhcThBACwcjlVWur+Zm7G20Vy2ms1bJOubVKEOpmIwh4gYoohZG7+YteG8W7MmLuyQ7q//9rv10z6HmloDmJ1EpdHGoGNUGhoaGhqHkU6RJaPWpqoPH3qy/r3PDMM1+d1P/KGmkeN/5xncg1R3GkypdCObBUqAxi1bpr39pqxeDuCa9dRLsZBwDSgbdOt1FSNHRoBcUt2TDmu0ISBpoqyhoaGhcfgQhRhriDWt2SRqa0xkEgA8fm9xMeV6UJDZfDKWOqRKAsUAsCnUtH4d21ZHqnM+WABet6usyMzKsgBNUio5TGema0aloaGhoaFxIEAgLQKBLCYFAzQdVXJCQA7AnMykVGJUFGdUFgJaRCHJXQheAAuIEE3FozgBIdnHmnoCtBkYSTwj1Z8UxTiH16eTqQjZ6nuWlFOMdMxdQ+Pwe/aA3CZRjDnaBEQs/iKm7B0BVxV/HMHDGUtU9jHnoI+05mDbnMnJHKNSUdIGE31629OM6qBdnp5aGhrJ5Ug3k5K2dEfY/L3ac3Voqk0iqWM/qvjUJYn0QXNqGhKWjEax7dlsDY024+K36TvC3SyQRhsDS2I6RUqT1mwINUqS+lGlFJ0iIilAEEkp5WG3IZQAAAgQQAJIkvO6LmLW0NA4hBwLUQeoNKM6bNOvtrZJs/pU4VFSSiISJARFGZDKKBWKVEEykCohBKIABgJJgtRBKg0NDQ2Nts+omol89ZY6KTWlShnfS4WnkKTZWGvUb2cInBCIxOG9MGe6I2usMWs2cxllSFwVL4ud8700NDQ0NDR+1F6T/OoJUkrGdPpw6sGeWckW3ibVqFXno2toaGhotDtGpaGhoaGhoaGR5NCuuoaGhoaGhoaGZlQaGhoaGhoaGocb/z8AAP//cSB7KY7WFOQAAAAASUVORK5CYII="
-            }
-         },
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "S_ZjoGBU5upj"
-         },
-         "source": [
-            "### Sieci MLP\n",
-            "\n",
-            "Dla przypomnienia, na wejściu mamy punkty ze zbioru treningowego, czyli $d$-wymiarowe wektory. W klasyfikacji chcemy znaleźć granicę decyzyjną, czyli krzywą, która oddzieli od siebie klasy. W wejściowej przestrzeni może być to trudne, bo chmury punktów z poszczególnych klas mogą być ze sobą dość pomieszane. Pamiętajmy też, że regresja logistyczna jest klasyfikatorem liniowym, czyli w danej przestrzeni potrafi oddzielić punkty tylko linią prostą.\n",
-            "\n",
-            "Sieć MLP składa się z warstw. Każda z nich dokonuje nieliniowego przekształcenia przestrzeni (można o tym myśleć jak o składaniu przestrzeni jakąś prostą/łamaną), tak, aby w finalnej przestrzeni nasze punkty były możliwie liniowo separowalne. Wtedy ostatnia warstwa z sigmoidą będzie potrafiła je rozdzielić od siebie.\n",
-            "\n",
-            "![1_x-3NGQv0pRIab8xDT-f_Hg.png](attachment:1_x-3NGQv0pRIab8xDT-f_Hg.png)\n",
-            "\n",
-            "Poszczególne neurony składają się z iloczynu skalarnego wejść z wagami neuronu, oraz nieliniowej funkcji aktywacji. W PyTorchu są to osobne obiekty - `nn.Linear` oraz np. `nn.Sigmoid`. Funkcja aktywacji przyjmuje wynik iloczynu skalarnego i przekształca go, aby sprawdzić, jak mocno reaguje neuron na dane wejście. Musi być nieliniowa z dwóch powodów. Po pierwsze, tylko nieliniowe przekształcenia są na tyle potężne, żeby umożliwić liniową separację danych w ostatniej warstwie. Po drugie, liniowe przekształcenia zwyczajnie nie działają. Aby zrozumieć czemu, trzeba zobaczyć, co matematycznie oznacza sieć MLP.\n",
-            "\n",
-            "![perceptron](https://www.saedsayad.com/images/Perceptron_bkp_1.png)\n",
-            "\n",
-            "Zapisane matematycznie MLP to:\n",
-            "\n",
-            "$\\large\n",
-            "h_1 = f_1(x) \\\\\n",
-            "h_2 = f_2(h_1) \\\\\n",
-            "h_3 = f_3(h_2) \\\\\n",
-            "... \\\\\n",
-            "h_n = f_n(h_{n-1})\n",
-            "$\n",
-            "\n",
-            "gdzie $x$ to wejście $f_i$ to funkcja aktywacji $i$-tej warstwy, a $h_i$ to wyjście $i$-tej warstwy, nazywane **ukrytą reprezentacją (hidden representation)**, lub *latent representation*. Nazwa bierze się z tego, że w środku sieci wyciągamy cechy i wzorce w danych, które nie są widoczne na pierwszy rzut oka na wejściu.\n",
-            "\n",
-            "Załóżmy, że uczymy się na danych $x$ o jednym wymiarze (dla uproszczenia wzorów) oraz nie mamy funkcji aktywacji, czyli wykorzystujemy tak naprawdę aktywację liniową $f(x) = x$. Zobaczmy jak będą wyglądać dane przechodząc przez kolejne warstwy:\n",
-            "\n",
-            "$\\large\n",
-            "h_1 = f_1(xw_1) = xw_1 \\\\\n",
-            "h_2 = f_2(h_1w_2) = xw_1w_2 \\\\\n",
-            "... \\\\\n",
-            "h_n = f_n(h_{n-1}w_n) = xw_1w_2...w_n\n",
-            "$\n",
-            "\n",
-            "gdzie $w_i$ to jest parametr $i$-tej warstwy sieci, $x$ to są dane (w naszym przypadku jedna liczba) wejściowa, a $h_i$ to wyjście $i$-tej warstwy.\n",
-            "\n",
-            "Jak widać, taka sieć o $n$ warstwach jest równoważna sieci o jednej warstwie z parametrem $w = w_1w_2...w_n$. Wynika to z tego, że złożenie funkcji liniowych jest także funkcją liniową - patrz notatki z algebry :)\n",
-            "\n",
-            "Jeżeli natomiast użyjemy nieliniowej funkcji aktywacji, często oznaczanej jako $\\sigma$, to wszystko będzie działać. Co ważne, ostatnia warstwa, dająca wyjście sieci, ma zwykle inną aktywację od warstw wewnątrz sieci, bo też ma inne zadanie - zwrócić wartość dla klasyfikacji lub regresji. Na wyjściu korzysta się z funkcji liniowej (regresja), sigmoidalnej (klasyfikacja binarna) lub softmax (klasyfikacja wieloklasowa).\n",
-            "\n",
-            "Wewnątrz sieci używano kiedyś sigmoidy oraz tangensa hiperbolicznego `tanh`, ale okazało się to nieefektywne przy uczeniu głębokich sieci o wielu warstwach. Nowoczesne sieci korzystają zwykle z funkcji ReLU (*rectified linear unit*), która jest zaskakująco prosta: $ReLU(x) = \\max(0, x)$. Okazało się, że bardzo dobrze nadaje się do treningu nawet bardzo głębokich sieci neuronowych. Nowsze funkcje aktywacji są głównie modyfikacjami ReLU.\n",
-            "\n",
-            "![relu](https://www.nomidl.com/wp-content/uploads/2022/04/image-10.png)"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "### MLP w PyTorchu\n",
-            "\n",
-            "Warstwę neuronów w MLP nazywa się warstwą gęstą (*dense layer*) lub warstwą w pełni połączoną (*fully-connected layer*), i taki opis oznacza zwykle same neurony oraz funkcję aktywacji. PyTorch, jak już widzieliśmy, definiuje osobno transformację liniową oraz aktywację, a więc jedna warstwa składa się de facto z 2 obiektów, wywoływanych jeden po drugim. Inne frameworki, szczególnie wysokopoziomowe (np. Keras) łączą to często w jeden obiekt.\n",
-            "\n",
-            "MLP składa się zatem z sekwencji obiektów, które potem wywołuje się jeden po drugim, gdzie wyjście poprzedniego to wejście kolejnego. Ale nie można tutaj używać Pythonowych list! Z perspektywy PyTorcha to wtedy niezależne obiekty i nie zostanie wtedy przekazany między nimi gradient. Trzeba tutaj skorzystać z `nn.Sequential`, aby tworzyć taki pipeline.\n",
-            "\n",
-            "Rozmiary wejścia i wyjścia dla każdej warstwy trzeba w PyTorchu podawać explicite. Jest to po pierwsze edukacyjne, a po drugie często ułatwia wnioskowanie o działaniu sieci oraz jej debugowanie - mamy jasno podane, czego oczekujemy. Niektóre frameworki (np. Keras) obliczają to automatycznie.\n",
-            "\n",
-            "Co ważne, ostatnia warstwa zwykle nie ma funkcji aktywacji. Wynika to z tego, że obliczanie wielu funkcji kosztu (np. entropii krzyżowej) na aktywacjach jest często niestabilne numerycznie. Z tego powodu PyTorch oferuje funkcje kosztu zawierające w środku aktywację dla ostatniej warstwy, a ich implementacje są stabilne numerycznie. Przykładowo, `nn.BCELoss` przyjmuje wejście z zaaplikowanymi już aktywacjami, ale może skutkować under/overflow, natomiast `nn.BCEWithLogitsLoss` przyjmuje wejście bez aktywacji, a w środku ma specjalną implementację łączącą binarną entropię krzyżową z aktywacją sigmoidalną. Oczywiście w związku z tym aby dokonać potem predykcji w praktyce, trzeba pamiętać o użyciu funkcji aktywacji. Często korzysta się przy tym z funkcji z modułu `torch.nn.functional`, które są w tym wypadku nieco wygodniejsze od klas wywoływalnych z `torch.nn`.\n",
-            "\n",
-            "Całe sieci w PyTorchu tworzy się jako klasy dziedziczące po `nn.Module`. Co ważne, obiekty, z których tworzymy sieć, np. `nn.Linear`, także dziedziczą po tej klasie. Pozwala to na bardzo modułową budowę kodu, zgodną z zasadami OOP. W konstruktorze najpierw trzeba zawsze wywołać konstruktor rodzica - `super().__init__()`, a później tworzy się potrzebne obiekty i zapisuje jako atrybuty. Każdy atrybut dziedziczący po `nn.Module` lub `nn.Parameter` jest uważany za taki, który zawiera parametry sieci, a więc przy wywołaniu metody `parameters()` - parametry z tych atrybutów pojawią się w liście wszystkich parametrów. Musimy też zdefiniować metodę `forward()`, która przyjmuje tensor `x` i zwraca wynik. Typowo ta metoda po prostu używa obiektów zdefiniowanych w konstruktorze.\n",
-            "\n",
-            "\n",
-            "**UWAGA: nigdy w normalnych warunkach się nie woła metody `forward` ręcznie**"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "J8niDgExAMDO",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 4 (0.5 punktu)\n",
-            "\n",
-            "Uzupełnij implementację 3-warstwowej sieci MLP. Użyj rozmiarów:\n",
-            "* pierwsza warstwa: input_size x 256\n",
-            "* druga warstwa: 256 x 128\n",
-            "* trzecia warstwa: 128 x 1\n",
-            "\n",
-            "Użyj funkcji aktywacji ReLU.\n",
-            "\n",
-            "Przydatne klasy:\n",
-            "- `nn.Sequential`\n",
-            "- `nn.Linear`\n",
-            "- `nn.ReLU`"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "from torch import sigmoid\n",
-            "\n",
-            "\n",
-            "class MLP(nn.Module):\n",
-            "    def __init__(self, input_size: int):\n",
-            "        super().__init__()\n",
-            "\n",
-            "        # implement me!\n",
-            "        # your_code\n",
-            "\n",
-            "    def forward(self, x):\n",
-            "        # implement me!\n",
-            "        # your_code\n",
-            "\n",
-            "    def predict_proba(self, x):\n",
-            "        return sigmoid(self(x))\n",
-            "    \n",
-            "    def predict(self, x, threshold: float = 0.5):\n",
-            "        y_pred_score = self.predict_proba(x)\n",
-            "        return (y_pred_score > threshold).to(torch.int32)\n",
-            "\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "# 43s\n",
-            "learning_rate = 1e-3\n",
-            "model = MLP(input_size=X_train.shape[1])\n",
-            "optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)\n",
-            "\n",
-            "# note that we are using loss function with sigmoid built in\n",
-            "loss_fn = torch.nn.BCEWithLogitsLoss()\n",
-            "num_epochs = 2000\n",
-            "evaluation_steps = 200\n",
-            "\n",
-            "for i in range(num_epochs):\n",
-            "    y_pred = model(X_train)\n",
-            "    loss = loss_fn(y_pred, y_train)\n",
-            "    loss.backward()\n",
-            "\n",
-            "    optimizer.step()\n",
-            "    optimizer.zero_grad()\n",
-            "\n",
-            "    if i % evaluation_steps == 0:\n",
-            "        print(f\"Epoch {i} train loss: {loss.item():.4f}\")\n",
-            "\n",
-            "print(f\"final loss: {loss.item():.4f}\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "colab": {
-               "base_uri": "https://localhost:8080/"
-            },
-            "id": "LP5GSup24dXU",
-            "outputId": "05f332c4-5d94-41f6-f85b-17793d3c4b49",
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "model.eval()\n",
-            "with torch.no_grad():\n",
-            "    # positive class probabilities\n",
-            "    y_pred_valid_score = model.predict_proba(X_valid)\n",
-            "    y_pred_test_score = model.predict_proba(X_test)\n",
-            "\n",
-            "auroc = roc_auc_score(y_test, y_pred_test_score)\n",
-            "print(f\"AUROC: {auroc:.2%}\")\n",
-            "\n",
-            "plot_precision_recall_curve(y_valid, y_pred_valid_score)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == X_train.shape[1] and module.out_features == 256\n",
-            "    for module in model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == 256 and module.out_features == 128\n",
-            "    for module in model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == 128 and module.out_features == 1\n",
-            "    for module in model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(isinstance(module, nn.ReLU) for module in model.modules())\n",
-            "\n",
-            "assert 0.5 < loss.item() < 0.6\n",
-            "assert 0.6 < auroc < 0.9\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "AUROC jest podobne, a precision i recall spadły - wypadamy wręcz gorzej od regresji liniowej! Skoro dodaliśmy więcej warstw, to może pojemność modelu jest teraz za duża i trzeba by go zregularyzować?\n",
-            "\n",
-            "Sieci neuronowe bardzo łatwo przeuczają, bo są bardzo elastycznymi i pojemnymi modelami. Dlatego mają wiele różnych rodzajów regularyzacji, których używa się razem. Co ciekawe, udowodniono eksperymentalnie, że zbyt duże sieci z mocną regularyzacją działają lepiej niż mniejsze sieci, odpowiedniego rozmiaru, za to ze słabszą regularyzacją.\n",
-            "\n",
-            "Pierwszy rodzaj regularyzacji to znana nam już **regularyzacja L2**, czyli penalizacja zbyt dużych wag. W kontekście sieci neuronowych nazywa się też ją czasem *weight decay*. W PyTorchu dodaje się ją jako argument do optymalizatora.\n",
-            "\n",
-            "Regularyzacja specyficzna dla sieci neuronowych to **dropout**. Polega on na losowym wyłączaniu zadanego procenta neuronów podczas treningu. Pomimo prostoty okazała się niesamowicie skuteczna, szczególnie w treningu bardzo głębokich sieci. Co ważne, jest to mechanizm używany tylko podczas treningu - w trakcie predykcji za pomocą sieci wyłącza się ten mechanizm i dokonuje normalnie predykcji całą siecią. Podejście to można potraktować jak ensemble learning, podobny do lasów losowych - wyłączając losowe części sieci, w każdej iteracji trenujemy nieco inną sieć, co odpowiada uśrednianiu predykcji różnych algorytmów. Typowo stosuje się dość mocny dropout, rzędu 25-50%. W PyTorchu implementuje go warstwa `nn.Dropout`, aplikowana zazwyczaj po funkcji aktywacji.\n",
-            "\n",
-            "Ostatni, a być może najważniejszy rodzaj regularyzacji to **wczesny stop (early stopping)**. W każdym kroku mocniej dostosowujemy terenową sieć do zbioru treningowego, a więc zbyt długi trening będzie skutkował przeuczeniem. W metodzie wczesnego stopu używamy wydzielonego zbioru walidacyjnego (pojedynczego, metoda holdout), sprawdzając co określoną liczbę epok wynik na tym zbiorze. Jeżeli nie uzyskamy wyniku lepszego od najlepszego dotychczas uzyskanego przez określoną liczbę epok, to przerywamy trening. Okres, przez który czekamy na uzyskanie lepszego wyniku, to cierpliwość (*patience*). Im mniejsze, tym mocniejszy jest ten rodzaj regularyzacji, ale trzeba z tym uważać, bo łatwo jest przesadzić i zbyt szybko przerywać trening. Niektóre implementacje uwzględniają tzw. *grace period*, czyli gwarantowaną minimalną liczbę epok, przez którą będziemy trenować sieć, niezależnie od wybranej cierpliwości.\n",
-            "\n",
-            "Dodatkowo ryzyko przeuczenia można zmniejszyć, używając mniejszej stałej uczącej."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 5 (1.5 punktu)\n",
-            "\n",
-            "Zaimplementuj funkcję `evaluate_model()`, obliczającą metryki na zbiorze testowym:\n",
-            "- wartość funkcji kosztu (loss)\n",
-            "- AUROC\n",
-            "- optymalny próg\n",
-            "- F1-score przy optymalnym progu\n",
-            "- precyzję oraz recall dla optymalnego progu\n",
-            "\n",
-            "Jeżeli podana jest wartość argumentu `threshold`, to użyj jej do zamiany prawdopodobieństw na twarde predykcje. W przeciwnym razie użyj funkcji `get_optimal_threshold` i oblicz optymalną wartość progu.\n",
-            "\n",
-            "Pamiętaj o przełączeniu modelu w tryb ewaluacji oraz o wyłączeniu obliczania gradientów."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "from typing import Optional\n",
-            "\n",
-            "from sklearn.metrics import precision_score, recall_score, f1_score\n",
-            "from torch import sigmoid\n",
-            "\n",
-            "\n",
-            "def evaluate_model(\n",
-            "    model: nn.Module, \n",
-            "    X: torch.Tensor, \n",
-            "    y: torch.Tensor, \n",
-            "    loss_fn: nn.Module,\n",
-            "    threshold: Optional[float] = None\n",
-            ") -> Dict[str, float]:\n",
-            "    # implement me!\n",
-            "    # your_code\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "eval_result = evaluate_model(model, X_train, y_train, loss_fn)\n",
-            "\n",
-            "assert 0.5 < eval_result[\"loss\"] < 0.6\n",
-            "assert 0.6 < eval_result[\"AUROC\"] < 0.9\n",
-            "assert 0.3 < eval_result[\"precision\"] < 0.6\n",
-            "assert 0.6 < eval_result[\"recall\"] < 0.9\n",
-            "assert 0.4 < eval_result[\"F1-score\"] < 0.7\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 6 (0.5 punktu)\n",
-            "\n",
-            "Zaimplementuj 3-warstwową sieć MLP z dropout (50%). Rozmiary warstw ukrytych mają wynosić 256 i 128."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "class RegularizedMLP(nn.Module):\n",
-            "    def __init__(self, input_size: int, dropout_p: float = 0.5):\n",
-            "        super().__init__()\n",
-            "\n",
-            "        # implement me!\n",
-            "        # your_code\n",
-            "    \n",
-            "    def forward(self, x):\n",
-            "        # implement me!\n",
-            "        # your_code\n",
-            "\n",
-            "    def predict_proba(self, x):\n",
-            "        return sigmoid(self(x))\n",
-            "    \n",
-            "    def predict(self, x, threshold: float = 0.5):\n",
-            "        y_pred_score = self.predict_proba(x)\n",
-            "        return (y_pred_score > threshold).to(torch.int32)\n",
-            "\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "verification_input_size = 143\n",
-            "verification_dropout_p = 0.125\n",
-            "verification_model = RegularizedMLP(\n",
-            "    input_size=verification_input_size,\n",
-            "    dropout_p=verification_dropout_p,\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == verification_input_size and module.out_features == 256\n",
-            "    for module in verification_model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == 256 and module.out_features == 128\n",
-            "    for module in verification_model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == 128 and module.out_features == 1\n",
-            "    for module in verification_model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(isinstance(module, nn.Dropout) and module.p == verification_dropout_p for module in verification_model.modules())\n",
-            "assert any(isinstance(module, nn.ReLU) for module in verification_model.modules())\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "id": "rEk9azaULAsz"
-         },
-         "source": [
-            "Opisaliśmy wcześniej podstawowy optymalizator w sieciach neuronowych - spadek wzdłuż gradientu. Jednak wymaga on użycia całego zbioru danych, aby obliczyć gradient, co jest często niewykonalne przez rozmiar zbioru. Dlatego wymyślono **stochastyczny spadek wzdłuż gradientu (stochastic gradient descent, SGD)**, w którym używamy 1 przykładu naraz, liczymy gradient tylko po nim i aktualizujemy parametry. Jest to oczywiście dość grube przybliżenie gradientu, ale pozwala robić szybko dużo małych kroków. Kompromisem, którego używa się w praktyce, jest **minibatch gradient descent**, czyli używanie batchy np. 32, 64 czy 128 przykładów.\n",
-            "\n",
-            "Rzadko wspominanym, a ważnym faktem jest także to, że stochastyczność metody optymalizacji jest sama w sobie też [metodą regularyzacji](https://arxiv.org/abs/2101.12176), a więc `batch_size` to także hiperparametr.\n",
-            "\n",
-            "Obecnie najpopularniejszą odmianą SGD jest [Adam](https://arxiv.org/abs/1412.6980), gdyż uczy on szybko sieć oraz daje bardzo dobre wyniki nawet przy niekoniecznie idealnie dobranych hiperparametrach. W PyTorchu najlepiej korzystać z jego implementacji `AdamW`, która jest nieco lepsza niż implementacja `Adam`. Jest to zasadniczo zawsze wybór domyślny przy treningu współczesnych sieci neuronowych.\n",
-            "\n",
-            "Na razie użyjemy jednak minibatch SGD."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "Poniżej znajduje się implementacja prostej klasy dziedziczącej po `Dataset` - tak w PyTorchu implementuje się własne zbiory danych. Użycie takich klas umożliwia użycie klas ładujących dane (`DataLoader`), które z kolei pozwalają łatwo ładować batche danych. Trzeba w takiej klasie zaimplementować metody:\n",
-            "- `__len__` - zwraca ilość punktów w zbiorze\n",
-            "- `__getitem__` - zwraca przykład ze zbioru pod danym indeksem oraz jego klasę\n"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "from torch.utils.data import Dataset\n",
-            "\n",
-            "\n",
-            "class MyDataset(Dataset):\n",
-            "    def __init__(self, data, y):\n",
-            "        super().__init__()\n",
-            "        \n",
-            "        self.data = data\n",
-            "        self.y = y\n",
-            "    \n",
-            "    def __len__(self):\n",
-            "        return self.data.shape[0]\n",
-            "    \n",
-            "    def __getitem__(self, idx):\n",
-            "        return self.data[idx], self.y[idx]\n",
-            "\n"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 7 (1.5 punktu)\n",
-            "\n",
-            "Zaimplementuj pętlę treningowo-walidacyjną dla sieci neuronowej. Wykorzystaj podane wartości hiperparametrów do treningu (stała ucząca, prawdopodobieństwo dropoutu, regularyzacja L2, rozmiar batcha, maksymalna liczba epok). Użyj optymalizatora SGD.\n",
-            "\n",
-            "Dodatkowo zaimplementuj regularyzację przez early stopping. Sprawdzaj co epokę wynik na zbiorze walidacyjnym. Użyj podanej wartości patience, a jako metryki po prostu wartości funkcji kosztu. Może się tutaj przydać zaimplementowana funkcja `evaluate_model()`.\n",
-            "\n",
-            "Pamiętaj o tym, aby przechowywać najlepszy dotychczasowy wynik walidacyjny oraz najlepszy dotychczasowy model. Zapamiętaj też optymalny próg do klasyfikacji dla najlepszego modelu."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "from copy import deepcopy\n",
-            "\n",
-            "from torch.utils.data import DataLoader\n",
-            "\n",
-            "\n",
-            "learning_rate = 1e-3\n",
-            "dropout_p = 0.5\n",
-            "l2_reg = 1e-4\n",
-            "batch_size = 128\n",
-            "max_epochs = 300\n",
-            "\n",
-            "early_stopping_patience = 4"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "lines_to_next_cell": 2,
-            "scrolled": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "# 1m\n",
-            "model = RegularizedMLP(\n",
-            "    input_size=X_train.shape[1], \n",
-            "    dropout_p=dropout_p\n",
-            ")\n",
-            "optimizer = torch.optim.SGD(\n",
-            "    model.parameters(), \n",
-            "    lr=learning_rate, \n",
-            "    weight_decay=l2_reg\n",
-            ")\n",
-            "loss_fn = torch.nn.BCEWithLogitsLoss()\n",
-            "\n",
-            "train_dataset = MyDataset(X_train, y_train)\n",
-            "train_dataloader = DataLoader(train_dataset, batch_size=batch_size)\n",
-            "\n",
-            "steps_without_improvement = 0\n",
-            "\n",
-            "best_val_loss = np.inf\n",
-            "best_model = None\n",
-            "best_threshold = None\n",
-            "\n",
-            "for epoch_num in range(max_epochs):\n",
-            "    model.train()\n",
-            "    \n",
-            "    # note that we are using DataLoader to get batches\n",
-            "    for X_batch, y_batch in train_dataloader:\n",
-            "        # model training\n",
-            "        # implement me!\n",
-            "        # your_code\n",
-            "    \n",
-            "    # model evaluation, early stopping\n",
-            "    # implement me!\n",
-            "    # your_code\n",
-            "    \n",
-            "    print(f\"Epoch {epoch_num} train loss: {loss.item():.4f}, eval loss {valid_metrics['loss']:.4f}\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "test_metrics = evaluate_model(best_model, X_test, y_test, loss_fn, best_threshold)\n",
-            "\n",
-            "print(f\"AUROC: {test_metrics['AUROC']:.2%}\")\n",
-            "print(f\"F1: {test_metrics['F1-score']:.2%}\")\n",
-            "print(f\"Precision: {test_metrics['precision']:.2%}\")\n",
-            "print(f\"Recall: {test_metrics['recall']:.2%}\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "assert test_metrics[\"AUROC\"] > 0.8\n",
-            "assert test_metrics[\"F1-score\"] > 0.6\n",
-            "assert test_metrics[\"precision\"] > 0.5\n",
-            "assert test_metrics[\"recall\"] > 0.6\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "Wyniki wyglądają już dużo lepiej.\n",
-            "\n",
-            "Na koniec laboratorium dołożymy do naszego modelu jeszcze 3 powrzechnie używane techniki, które są bardzo proste, a pozwalają często ulepszyć wynik modelu.\n",
-            "\n",
-            "Pierwszą z nich są **warstwy normalizacji (normalization layers)**. Powstały one początkowo z założeniem, że przez przekształcenia przestrzeni dokonywane przez sieć zmienia się rozkład prawdopodobieństw pomiędzy warstwami, czyli tzw. *internal covariate shift*. Później okazało się, że zastosowanie takiej normalizacji wygładza powierzchnię funkcji kosztu, co ułatwia i przyspiesza optymalizację. Najpowszechniej używaną normalizacją jest **batch normalization (batch norm)**.\n",
-            "\n",
-            "Drugim ulepszeniem jest dodanie **wag klas (class weights)**. Mamy do czynienia z problemem klasyfikacji niezbalansowanej, więc klasa mniejszościowa, ważniejsza dla nas, powinna dostać większą wagę. Implementuje się to trywialnie prosto - po prostu mnożymy wartość funkcji kosztu dla danego przykładu przez wagę dla prawdziwej klasy tego przykładu. Praktycznie każdy klasyfikator operujący na jakiejś ważonej funkcji może działać w ten sposób, nie tylko sieci neuronowe.\n",
-            "\n",
-            "Ostatnim ulepszeniem jest zamiana SGD na optymalizator Adam, a konkretnie na optymalizator `AdamW`. Jest to przykład **optymalizatora adaptacyjnego (adaptive optimizer)**, który potrafi zaadaptować stałą uczącą dla każdego parametru z osobna w trakcie treningu. Wykorzystuje do tego gradienty - w uproszczeniu, im większa wariancja gradientu, tym mniejsze kroki w tym kierunku robimy."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "### Zadanie 8 (0.5 punktu)\n",
-            "\n",
-            "Zaimplementuj model `NormalizingMLP`, o takiej samej strukturze jak `RegularizedMLP`, ale dodatkowo z warstwami `BatchNorm1d` pomiędzy warstwami `Linear` oraz `ReLU`.\n",
-            "\n",
-            "Za pomocą funkcji `compute_class_weight()` oblicz wagi dla poszczególnych klas. Użyj opcji `\"balanced\"`. Przekaż do funkcji kosztu wagę klasy pozytywnej (pamiętaj, aby zamienić ją na tensor).\n",
-            "\n",
-            "Zamień używany optymalizator na `AdamW`.\n",
-            "\n",
-            "Na koniec skopiuj resztę kodu do treningu z poprzedniego zadania, wytrenuj sieć i oblicz wyniki na zbiorze testowym."
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "class NormalizingMLP(nn.Module):\n",
-            "    def __init__(self, input_size: int, dropout_p: float = 0.5):\n",
-            "        super().__init__()\n",
-            "\n",
-            "        # implement me!\n",
-            "        # your_code\n",
-            "    \n",
-            "    def forward(self, x):\n",
-            "        return self.mlp(x)\n",
-            "\n",
-            "    def predict_proba(self, x):\n",
-            "        return sigmoid(self(x))\n",
-            "    \n",
-            "    def predict(self, x, threshold: float = 0.5):\n",
-            "        y_pred_score = self.predict_proba(x)\n",
-            "        return (y_pred_score > threshold).to(torch.int32)\n",
-            "\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "# define all the hyperparameters\n",
-            "# your_code\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "lines_to_next_cell": 2,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "# training loop\n",
-            "# your_code\n"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "editable": true,
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "test_metrics = evaluate_model(best_model, X_test, y_test, loss_fn, best_threshold)\n",
-            "\n",
-            "print(f\"AUROC: {test_metrics['AUROC']:.2%}\")\n",
-            "print(f\"F1: {test_metrics['F1-score']:.2%}\")\n",
-            "print(f\"Precision: {test_metrics['precision']:.2%}\")\n",
-            "print(f\"Recall: {test_metrics['recall']:.2%}\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": [
-            "verification_input_size = 143\n",
-            "verification_dropout_p = 0.125\n",
-            "verification_model = NormalizingMLP(\n",
-            "    input_size=verification_input_size,\n",
-            "    dropout_p=verification_dropout_p,\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == verification_input_size and module.out_features == 256\n",
-            "    for module in verification_model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == 256 and module.out_features == 128\n",
-            "    for module in verification_model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(\n",
-            "    isinstance(module, nn.Linear) and module.in_features == 128 and module.out_features == 1\n",
-            "    for module in verification_model.modules()\n",
-            ")\n",
-            "\n",
-            "assert any(isinstance(module, nn.Dropout) and module.p == verification_dropout_p for module in verification_model.modules())\n",
-            "assert any(isinstance(module, nn.ReLU) for module in verification_model.modules())\n",
-            "\n",
-            "assert any(isinstance(module, nn.BatchNorm1d) for module in verification_model.modules())\n",
-            "\n",
-            "assert test_metrics[\"AUROC\"] > 0.8\n",
-            "assert test_metrics[\"F1-score\"] > 0.6\n",
-            "assert test_metrics[\"precision\"] > 0.5\n",
-            "assert test_metrics[\"recall\"] > 0.6\n",
-            "\n",
-            "print(\"Solution is correct!\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "editable": true,
-            "id": "XyoRnHT4GFR9",
-            "slideshow": {
-               "slide_type": ""
-            },
-            "tags": []
-         },
-         "source": [
-            "## Akceleracja sprzętowa (dla zainteresowanych)"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "Jak wcześniej wspominaliśmy, użycie akceleracji sprzętowej, czyli po prostu GPU do obliczeń, jest bardzo efektywne w przypadku sieci neuronowych. Karty graficzne bardzo efektywnie mnożą macierze, a sieci neuronowe to, jak można było się przekonać, dużo mnożenia macierzy.\n",
-            "\n",
-            "W PyTorchu jest to dosyć łatwe, ale trzeba robić to explicite. Służy do tego metoda `.to()`, która przenosi tensory między CPU i GPU. Poniżej przykład, jak to się robi (oczywiście trzeba mieć skonfigurowane GPU, żeby działało):"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "import time \n",
-            "\n",
-            "\n",
-            "class CudaMLP(nn.Module):\n",
-            "    def __init__(self, input_size: int, dropout_p: float = 0.5):\n",
-            "        super().__init__()\n",
-            "\n",
-            "        self.mlp = nn.Sequential(\n",
-            "            nn.Linear(input_size, 512),\n",
-            "            nn.BatchNorm1d(512),\n",
-            "            nn.ReLU(),\n",
-            "            nn.Dropout(dropout_p),\n",
-            "            nn.Linear(512, 256),\n",
-            "            nn.BatchNorm1d(256),\n",
-            "            nn.ReLU(),\n",
-            "            nn.Dropout(dropout_p),\n",
-            "            nn.Linear(256, 256),\n",
-            "            nn.BatchNorm1d(256),\n",
-            "            nn.ReLU(),\n",
-            "            nn.Dropout(dropout_p),\n",
-            "            nn.Linear(256, 128),\n",
-            "            nn.BatchNorm1d(128),\n",
-            "            nn.ReLU(),\n",
-            "            nn.Dropout(dropout_p),\n",
-            "            nn.Linear(128, 1),\n",
-            "        )\n",
-            "    \n",
-            "    def forward(self, x):\n",
-            "        return self.mlp(x)\n",
-            "\n",
-            "    def predict_proba(self, x):\n",
-            "        return sigmoid(self(x))\n",
-            "    \n",
-            "    def predict(self, x, threshold: float = 0.5):\n",
-            "        y_pred_score = self.predict_proba(x)\n",
-            "        return (y_pred_score > threshold).to(torch.int32)\n",
-            "\n",
-            "\n",
-            "model = CudaMLP(X_train.shape[1]).to('cuda')\n",
-            "\n",
-            "optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)\n",
-            "\n",
-            "# note that we are using loss function with sigmoid built in\n",
-            "loss_fn = torch.nn.BCEWithLogitsLoss(pos_weight=torch.from_numpy(weights)[1].to('cuda'))\n",
-            "\n",
-            "step_counter = 0\n",
-            "time_from_eval = time.time()\n",
-            "for epoch_id in range(30):\n",
-            "    for batch_x, batch_y in train_dataloader:\n",
-            "        batch_x = batch_x.to('cuda')\n",
-            "        batch_y = batch_y.to('cuda')\n",
-            "        \n",
-            "        loss = loss_fn(model(batch_x), batch_y)\n",
-            "        loss.backward()\n",
-            "\n",
-            "        optimizer.step()\n",
-            "        optimizer.zero_grad()\n",
-            "        \n",
-            "        if step_counter % evaluation_steps == 0:\n",
-            "            print(f\"Epoch {epoch_id} train loss: {loss.item():.4f}, time: {time.time() - time_from_eval}\")\n",
-            "            time_from_eval = time.time()\n",
-            "\n",
-            "        step_counter += 1\n",
-            "\n",
-            "test_res = evaluate_model(model.to('cpu'), X_test, y_test, loss_fn.to('cpu'), threshold=0.5)\n",
-            "\n",
-            "print(f\"AUROC: {test_res['AUROC']:.2%}\")\n",
-            "print(f\"F1: {test_res['F1-score']:.2%}\")\n",
-            "print(test_res)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {},
-         "source": [
-            "Co prawda ten model nie będzie tak dobry jak ten z laboratorium, ale zwróć uwagę, o ile jest większy, a przy tym szybszy.\n",
-            "\n",
-            "Dla zainteresowanych polecamy [tę serie artykułów](https://medium.com/@adi.fu7/ai-accelerators-part-i-intro-822c2cdb4ca4)"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "## Zadanie dla chętnych"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "markdown",
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "source": [
-            "Jak widzieliśmy, sieci neuronowe mają bardzo dużo hiperparametrów. Przeszukiwanie ich grid search'em jest więc niewykonalne, a chociaż random search by działał, to potrzebowałby wielu iteracji, co też jest kosztowne obliczeniowo.\n",
-            "\n",
-            "Zaimplementuj inteligentne przeszukiwanie przestrzeni hiperparametrów za pomocą biblioteki [Optuna](https://optuna.org/). Implementuje ona między innymi algorytm Tree Parzen Estimator (TPE), należący do grupy algorytmów typu Bayesian search. Typowo osiągają one bardzo dobre wyniki, a właściwie zawsze lepsze od przeszukiwania losowego. Do tego wystarcza im często niewielka liczba kroków.\n",
-            "\n",
-            "Zaimplementuj 3-warstwową sieć MLP, gdzie pierwsza warstwa ma rozmiar ukryty N, a druga N // 2. Ucz ją optymalizatorem Adam przez maksymalnie 300 epok z cierpliwością 10.\n",
-            "\n",
-            "Przeszukaj wybrane zakresy dla hiperparametrów:\n",
-            "- rozmiar warstw ukrytych (N)\n",
-            "- stała ucząca\n",
-            "- batch size\n",
-            "- siła regularyzacji L2\n",
-            "- prawdopodobieństwo dropoutu\n",
-            "\n",
-            "Wykorzystaj przynajmniej 30 iteracji. Następnie przełącz algorytm na losowy (Optuna także jego implementuje), wykonaj 30 iteracji i porównaj jakość wyników.\n",
-            "\n",
-            "Przydatne materiały:\n",
-            "- [Optuna code examples - PyTorch](https://optuna.org/#code_examples)\n",
-            "- [Auto-Tuning Hyperparameters with Optuna and PyTorch](https://www.youtube.com/watch?v=P6NwZVl8ttc)\n",
-            "- [Hyperparameter Tuning of Neural Networks with Optuna and PyTorch](https://towardsdatascience.com/hyperparameter-tuning-of-neural-networks-with-optuna-and-pytorch-22e179efc837)\n",
-            "- [Using Optuna to Optimize PyTorch Hyperparameters](https://medium.com/pytorch/using-optuna-to-optimize-pytorch-hyperparameters-990607385e36)"
-         ],
-         "outputs": []
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {
-            "tags": [
-               "ex"
-            ]
-         },
-         "outputs": [],
-         "source": []
-      }
-   ],
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sieci neuronowe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wstęp\n",
+    "\n",
+    "Celem laboratorium jest zapoznanie się z podstawami sieci neuronowych oraz uczeniem głębokim (*deep learning*). Zapoznasz się na nim z następującymi tematami:\n",
+    "- treningiem prostych sieci neuronowych, w szczególności z:\n",
+    "  - regresją liniową w sieciach neuronowych\n",
+    "  - optymalizacją funkcji kosztu\n",
+    "  - algorytmem spadku wzdłuż gradientu\n",
+    "  - siecią typu Multilayer Perceptron (MLP)\n",
+    "- frameworkiem PyTorch, w szczególności z:\n",
+    "  - ładowaniem danych\n",
+    "  - preprocessingiem danych\n",
+    "  - pisaniem pętli treningowej i walidacyjnej\n",
+    "  - walidacją modeli\n",
+    "- architekturą i hiperaprametrami sieci MLP, w szczególności z:\n",
+    "  - warstwami gęstymi (w pełni połączonymi)\n",
+    "  - funkcjami aktywacji\n",
+    "  - regularyzacją: L2, dropout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wykorzystywane biblioteki\n",
+    "\n",
+    "Zaczniemy od pisania ręcznie prostych sieci w bibliotece Numpy, służącej do obliczeń numerycznych na CPU. Później przejdziemy do wykorzystywania frameworka PyTorch, służącego do obliczeń numerycznych na CPU, GPU oraz automatycznego różniczkowania, wykorzystywanego głównie do treningu sieci neuronowych.\n",
+    "\n",
+    "Wykorzystamy PyTorcha ze względu na popularność, łatwość instalacji i użycia, oraz dużą kontrolę nad niskopoziomowymi aspektami budowy i treningu sieci neuronowych. Framework ten został stworzony do zastosowań badawczych i naukowych, ale ze względu na wygodę użycia stał się bardzo popularny także w przemyśle. W szczególności całkowicie zdominował przetwarzanie języka naturalnego (NLP) oraz uczenie na grafach.\n",
+    "\n",
+    "Pierwszy duży framework do deep learningu, oraz obecnie najpopularniejszy, to TensorFlow, wraz z wysokopoziomową nakładką Keras. Są jednak szanse, że Google (autorzy) będzie go powoli porzucać na rzecz ich nowego frameworka JAX ([dyskusja](https://www.reddit.com/r/MachineLearning/comments/vfl57t/d_google_quietly_moving_its_products_from/), [artykuł Business Insidera](https://www.businessinsider.com/facebook-pytorch-beat-google-tensorflow-jax-meta-ai-2022-6?IR=T)), który jest bardzo świeżym, ale ciekawym narzędziem.\n",
+    "\n",
+    "Trzecia, ale znacznie mniej popularna od powyższych opcja to Apache MXNet."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Konfiguracja własnego komputera\n",
+    "\n",
+    "Jeżeli korzystasz z własnego komputera, to musisz zainstalować trochę więcej bibliotek (Google Colab ma je już zainstalowane).\n",
+    "\n",
+    "Jeżeli nie masz GPU lub nie chcesz z niego korzystać, to wystarczy znaleźć odpowiednią komendę CPU [na stronie PyTorcha](https://pytorch.org/get-started/locally/). Dla Anacondy odpowiednia komenda została podana poniżej, dla pip'a znajdź ją na stronie.\n",
+    "\n",
+    "Jeżeli chcesz korzystać ze wsparcia GPU (na tym laboratorium nie będzie potrzebne, na kolejnych może przyspieszyć nieco obliczenia), to musi być to odpowiednio nowa karta NVidii, mająca CUDA compatibility ([lista](https://developer.nvidia.com/cuda-gpus)). Poza PyTorchem będzie potrzebne narzędzie NVidia CUDA w wersji 11.6 lub 11.7. Instalacja na Windowsie jest bardzo prosta (wystarczy ściągnąć plik EXE i zainstalować jak każdy inny program). Instalacja na Linuxie jest trudna i można względnie łatwo zepsuć sobie system, ale jeżeli chcesz spróbować, to [ten tutorial](https://www.youtube.com/results?search_query=nvidia+cuda+install+ubuntu+20.04) jest bardzo dobry."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
-      "colab": {
-         "collapsed_sections": [],
-         "provenance": []
-      },
-      "jupytext": {
-         "formats": "ipynb,py:percent"
-      },
-      "kernelspec": {
-         "display_name": "Python 3 (ipykernel)",
-         "language": "python",
-         "name": "python3"
-      },
-      "language_info": {
-         "codemirror_mode": {
-            "name": "ipython",
-            "version": 3
-         },
-         "file_extension": ".py",
-         "mimetype": "text/x-python",
-         "name": "python",
-         "nbconvert_exporter": "python",
-         "pygments_lexer": "ipython3",
-         "version": "3.11.5"
-      },
-      "vscode": {
-         "interpreter": {
-            "hash": "a5d7af91182035c53be6efb3f9b18ffc3e259c9c524705249407647c970de949"
-         }
-      }
+    "id": "Othm3C2lLAsj"
    },
-   "nbformat": 4,
-   "nbformat_minor": 4
+   "source": [
+    "## Wprowadzenie\n",
+    "\n",
+    "Zanim zaczniemy naszą przygodę z sieciami neuronowymi, przyjrzyjmy się prostemu przykładowi regresji liniowej na syntetycznych danych:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rnJsfxbnLAsj"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 282
+    },
+    "id": "EaYpEXzBLAsl",
+    "outputId": "2f8d2922-72f0-4d38-8548-d1262adf522e"
+   },
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)\n",
+    "\n",
+    "x = np.linspace(0, 1, 100)\n",
+    "y = x + np.random.normal(scale=0.1, size=x.shape)\n",
+    "\n",
+    "plt.scatter(x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "PEM_-yKELAsl",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "W przeciwieństwie do laboratorium 1, tym razem będziemy chcieli rozwiązać ten problem własnoręcznie, bez użycia wysokopoziomowego interfejsu Scikit-learn'a. W tym celu musimy sobie przypomnieć sformułowanie naszego **problemu optymalizacyjnego (optimization problem)**.\n",
+    "\n",
+    "W przypadku prostej regresji liniowej (1 zmienna) mamy model postaci $\\hat{y} = \\alpha x + \\beta$, z dwoma parametrami, których będziemy się uczyć. Miarą niedopasowania modelu o danych parametrach jest **funkcja kosztu (cost function)**, nazywana też funkcją celu. Najczęściej używa się **błędu średniokwadratowego (mean squared error, MSE)**:\n",
+    "$$\\large\n",
+    "MSE = \\frac{1}{N} \\sum_{i}^{N} (y - \\hat{y})^2\n",
+    "$$\n",
+    "\n",
+    "Od jakich $\\alpha$ i $\\beta$ zacząć? W najprostszym wypadku wystarczy po prostu je wylosować jako niewielkie liczby zmiennoprzecinkowe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "PEM_-yKELAsl",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 1 (0.5 punkt)\n",
+    "\n",
+    "Uzupełnij kod funkcji `mse`, obliczającej błąd średniokwadratowy. Wykorzystaj Numpy'a w celu wektoryzacji obliczeń dla wydajności."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "RaA7Q46TLAsm",
+    "outputId": "5c57fe58-1934-4d21-9a7b-d14e9a23140b",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def mse(y: np.ndarray, y_hat: np.ndarray) -> float:\n",
+    "    # implement me!\n",
+    "    # your_code\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 282
+    },
+    "editable": true,
+    "id": "qSGfamGbLAsm",
+    "outputId": "733ce15f-ae75-466b-e7ee-eb3c9d9d534c",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "a = np.random.rand()\n",
+    "b = np.random.rand()\n",
+    "print(f\"MSE: {mse(y, a * x + b):.3f}\")\n",
+    "\n",
+    "plt.scatter(x, y)\n",
+    "plt.plot(x, a * x + b, color=\"g\", linewidth=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Y--E9Mp9LAsn"
+   },
+   "source": [
+    "Losowe parametry radzą sobie nie najlepiej. Jak lepiej dopasować naszą prostą do danych? Zawsze możemy starać się wyprowadzić rozwiązanie analitycznie, i w tym wypadku nawet nam się uda. Jest to jednak szczególny i dość rzadki przypadek, a w szczególności nie będzie to możliwe w większych sieciach neuronowych.\n",
+    "\n",
+    "Potrzebna nam będzie **metoda optymalizacji (optimization method)**, dającą wartości parametrów minimalizujące dowolną różniczkowalną funkcję kosztu. Zdecydowanie najpopularniejszy jest tutaj **spadek wzdłuż gradientu (gradient descent)**.\n",
+    "\n",
+    "Metoda ta wywodzi się z prostych obserwacji, które tutaj przedstawimy. Bardziej szczegółowe rozwinięcie dla zainteresowanych: [sekcja 4.3 \"Deep Learning Book\"](https://www.deeplearningbook.org/contents/numerical.html), [ten praktyczny kurs](https://cs231n.github.io/optimization-1/), [analiza oryginalnej publikacji Cauchy'ego](https://www.math.uni-bielefeld.de/documenta/vol-ismp/40_lemarechal-claude.pdf) (oryginał w języku francuskim).\n",
+    "\n",
+    "Pochodna jest dokładnie równa granicy funkcji. Dla małego $\\epsilon$ można ją przybliżyć jako:\n",
+    "$$\\large\n",
+    "\\frac{f(x)}{dx} \\approx \\frac{f(x+\\epsilon) - f(x)}{\\epsilon}\n",
+    "$$\n",
+    "\n",
+    "Przyglądając się temu równaniu widzimy, że: \n",
+    "* dla funkcji rosnącej ($f(x+\\epsilon) > f(x)$) wyrażenie $\\frac{f(x)}{dx}$ będzie miało znak dodatni \n",
+    "* dla funkcji malejącej ($f(x+\\epsilon) < f(x)$) wyrażenie $\\frac{f(x)}{dx}$ będzie miało znak ujemny \n",
+    "\n",
+    "Widzimy więc, że potrafimy wskazać kierunek zmniejszenia wartości funkcji, patrząc na znak pochodnej. Zaobserwowano także, że amplituda wartości w $\\frac{f(x)}{dx}$ jest tym większa, im dalej jesteśmy od minimum (maximum). Pochodna wyznacza więc, w jakim kierunku funkcja najszybciej rośnie, zaś przeciwny zwrot to ten, w którym funkcja najszybciej spada.\n",
+    "\n",
+    "Stosując powyższe do optymalizacji, mamy:\n",
+    "$$\\large\n",
+    "x_{t+1} = x_{t} -  \\alpha * \\frac{f(x)}{dx}\n",
+    "$$\n",
+    "\n",
+    "$\\alpha$ to niewielka wartość (rzędu zwykle $10^{-5}$ - $10^{-2}$), wprowadzona, aby trzymać się założenia o małej zmianie parametrów ($\\epsilon$). Nazywa się ją **stałą uczącą (learning rate)** i jest zwykle najważniejszym hiperparametrem podczas nauki sieci.\n",
+    "\n",
+    "Metoda ta zakłada, że używamy całego zbioru danych do aktualizacji parametrów w każdym kroku, co nazywa się po prostu GD (od *gradient descent*) albo *full batch GD*. Wtedy każdy krok optymalizacji nazywa się **epoką (epoch)**.\n",
+    "\n",
+    "Im większa stała ucząca, tym większe nasze kroki podczas minimalizacji. Możemy więc uczyć szybciej, ale istnieje ryzyko, że będziemy \"przeskakiwać\" minima. Mniejsza stała ucząca to wolniejszy, ale dokładniejszy trening. Jednak nie zawsze ona pozwala osiągnąć lepsze wyniki, bo może okazać się, że utkniemy w minimum lokalnym. Można także zmieniać stałą uczącą podczas treningu, co nazywa się **learning rate scheduling (LR scheduling)**. Obrazowo:\n",
+    "\n",
+    "![learning_rate](http://www.bdhammel.com/assets/learning-rate/lr-types.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "496qEjkVLAso"
+   },
+   "source": [
+    "![interactive LR](http://cdn-images-1.medium.com/max/640/1*eeIvlwkMNG1wSmj3FR6M2g.gif)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RYkyAHKzLAsp"
+   },
+   "source": [
+    "Policzmy więc pochodną dla naszej funkcji kosztu MSE. Pochodną liczymy po parametrach naszego modelu, bo to właśnie ich chcemy dopasować tak, żeby koszt był jak najmniejszy:\n",
+    "\n",
+    "$$\\large\n",
+    "MSE = \\frac{1}{N} \\sum_{i}^{N} (y_i - \\hat{y_i})^2\n",
+    "$$\n",
+    "\n",
+    "W powyższym wzorze tylko $y_i$ jest zależny od $a$ oraz $b$. Możemy wykorzystać tu regułę łańcuchową (*chain rule*) i policzyć pochodne po naszych parametrach w sposób następujący:\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} MSE}{\\text{d} a} = \\frac{1}{N} \\sum_{i}^{N} \\frac{\\text{d} (y_i - \\hat{y_i})^2}{\\text{d} \\hat{y_i}} \\frac{\\text{d} \\hat{y_i}}{\\text{d} a}\n",
+    "$$\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} MSE}{\\text{d} b} = \\frac{1}{N} \\sum_{i}^{N} \\frac{\\text{d} (y_i - \\hat{y_i})^2}{\\text{d} \\hat{y_i}} \\frac{\\text{d} \\hat{y_i}}{\\text{d} b}\n",
+    "$$\n",
+    "\n",
+    "Policzmy te pochodne po kolei:\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} (y_i - \\hat{y_i})^2}{\\text{d} \\hat{y_i}} = -2 \\cdot (y_i - \\hat{y_i})\n",
+    "$$\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} \\hat{y_i}}{\\text{d} a} = x_i\n",
+    "$$\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} \\hat{y_i}}{\\text{d} b} = 1\n",
+    "$$\n",
+    "\n",
+    "Łącząc powyższe wyniki dostaniemy:\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} MSE}{\\text{d} a} = \\frac{-2}{N} \\sum_{i}^{N} (y_i - \\hat{y_i}) \\cdot {x_i}\n",
+    "$$\n",
+    "\n",
+    "$$\\large\n",
+    "\\frac{\\text{d} MSE}{\\text{d} b} = \\frac{-2}{N} \\sum_{i}^{N} (y_i - \\hat{y_i})\n",
+    "$$\n",
+    "\n",
+    "Aktualizacja parametrów wygląda tak:\n",
+    "\n",
+    "$$\\large\n",
+    "a' = a - \\alpha * \\left( \\frac{-2}{N} \\sum_{i=1}^N (y_i - \\hat{y}_i) \\cdot x_i \\right)\n",
+    "$$\n",
+    "$$\\large\n",
+    "b' = b - \\alpha * \\left( \\frac{-2}{N} \\sum_{i=1}^N (y_i - \\hat{y}_i) \\right)\n",
+    "$$\n",
+    "\n",
+    "Liczymy więc pochodną funkcji kosztu, a potem za pomocą reguły łańcuchowej \"cofamy się\", dochodząc do tego, jak każdy z parametrów wpływa na błąd i w jaki sposób powinniśmy go zmienić. Nazywa się to **propagacją wsteczną (backpropagation)** i jest podstawowym mechanizmem umożliwiającym naukę sieci neuronowych za pomocą spadku wzdłuż gradientu. Więcej możesz o tym przeczytać [tutaj](https://cs231n.github.io/optimization-2/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 2 (1.0 punkt)\n",
+    "\n",
+    "Zaimplementuj funkcję realizującą jedną epokę treningową. Zauważ, że `x` oraz `y` są wektorami. Oblicz predykcję przy aktualnych parametrach oraz zaktualizuj je zgodnie z powyższymi wzorami."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "4qbdWOSULAsp",
+    "outputId": "055607ae-87aa-470a-e6da-25682c82d470",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def optimize(\n",
+    "    x: np.ndarray, y: np.ndarray, a: float, b: float, learning_rate: float = 0.1\n",
+    "):\n",
+    "    y_hat = a * x + b\n",
+    "    errors = y - y_hat\n",
+    "    # implement me!\n",
+    "    # your_code\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "for i in range(1000):\n",
+    "    loss = mse(y, a * x + b)\n",
+    "    a, b = optimize(x, y, a, b)\n",
+    "    if i % 100 == 0:\n",
+    "        print(f\"step {i} loss: \", loss)\n",
+    "\n",
+    "print(\"final loss:\", loss)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert 0.0 < loss < 2.0\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 282
+    },
+    "editable": true,
+    "id": "xOgRcPC1LAsq",
+    "outputId": "85b0b3e4-aa0d-467a-d8ff-5f01be17b243",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "plt.scatter(x, y)\n",
+    "plt.plot(x, a * x + b, color=\"g\", linewidth=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vOr2fWYpLAsq"
+   },
+   "source": [
+    "Udało ci się wytrenować swoją pierwszą sieć neuronową. Czemu? Otóż neuron to po prostu wektor parametrów, a zwykle robimy iloczyn skalarny tych parametrów z wejściem. Dodatkowo na wyjście nakłada się **funkcję aktywacji (activation function)**, która przekształca wyjście. Tutaj takiej nie było, a właściwie była to po prostu funkcja identyczności.\n",
+    "\n",
+    "Oczywiście w praktyce korzystamy z odpowiedniego frameworka, który w szczególności:\n",
+    "- ułatwia budowanie sieci, np. ma gotowe klasy dla warstw neuronów\n",
+    "- ma zaimplementowane funkcje kosztu oraz ich pochodne\n",
+    "- sam różniczkuje ze względu na odpowiednie parametry i aktualizuje je odpowiednio podczas treningu\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NJBYJabuLAsr"
+   },
+   "source": [
+    "## Wprowadzenie do PyTorcha"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EB-99XqhLAsr"
+   },
+   "source": [
+    "PyTorch to w gruncie rzeczy narzędzie do algebry liniowej z [automatycznym rożniczkowaniem](https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html), z możliwością przyspieszenia obliczeń z pomocą GPU. Na tych fundamentach zbudowany jest pełny framework do uczenia głębokiego. Można spotkać się ze stwierdzenie, że PyTorch to NumPy + GPU + opcjonalne różniczkowanie, co jest całkiem celne. Plus można łatwo debugować printem :)\n",
+    "\n",
+    "PyTorch używa dynamicznego grafu obliczeń, który sami definiujemy w kodzie. Takie podejście jest bardzo wygodne, elastyczne i pozwala na łatwe eksperymentowanie. Odbywa się to potencjalnie kosztem wydajności, ponieważ pozostawia kwestię optymalizacji programiście. Więcej na ten temat dla zainteresowanych na końcu laboratorium.\n",
+    "\n",
+    "Samo API PyTorcha bardzo przypomina Numpy'a, a podstawowym obiektem jest `Tensor`, klasa reprezentująca tensory dowolnego wymiaru. Dodatkowo niektóre tensory będą miały automatycznie obliczony gradient. Co ważne, tensor jest na pewnym urządzeniu, CPU lub GPU, a przenosić między nimi trzeba explicite.\n",
+    "\n",
+    "Najważniejsze moduły:\n",
+    "- `torch` - podstawowe klasy oraz funkcje, np. `Tensor`, `from_numpy()`\n",
+    "- `torch.nn` - klasy związane z sieciami neuronowymi, np. `Linear`, `Sigmoid`\n",
+    "- `torch.optim` - wszystko związane z optymalizacją, głównie spadkiem wzdłuż gradientu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "FwuIt8S-LAss"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "bfCiUFXULAss",
+    "outputId": "83f6231d-ecc4-461a-b758-fdc4bc2a88a4",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ones = torch.ones(10)\n",
+    "noise = torch.ones(10) * torch.rand(10)\n",
+    "\n",
+    "# elementwise sum\n",
+    "print(ones + noise)\n",
+    "\n",
+    "# elementwise multiplication\n",
+    "print(ones * noise)\n",
+    "\n",
+    "# dot product\n",
+    "print(ones @ noise)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "type(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "id": "ynNd_kD0LAst",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# beware - shares memory with original Numpy array!\n",
+    "# very fast, but modifications are visible to original variable\n",
+    "x = torch.from_numpy(x)\n",
+    "y = torch.from_numpy(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "W9kkxczELAsu",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Jeżeli dla stworzonych przez nas tensorów chcemy śledzić operacje i obliczać gradient, to musimy oznaczyć `requires_grad=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "8HtZL-KfLAsu",
+    "outputId": "47c6d930-5678-452a-95bc-227935138b40",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "a = torch.rand(1, requires_grad=True)\n",
+    "b = torch.rand(1, requires_grad=True)\n",
+    "a, b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "Nl1guWZ_LAsv",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "PyTorch zawiera większość powszechnie używanych funkcji kosztu, np. MSE. Mogą być one używane na 2 sposoby, z czego pierwszy jest popularniejszy:\n",
+    "- jako klasy wywoływalne z modułu `torch.nn`\n",
+    "- jako funkcje z modułu `torch.nn.functional`\n",
+    "\n",
+    "Po wykonaniu poniższego kodu widzimy, że zwraca on nam tensor z dodatkowymi atrybutami. Co ważne, jest to skalar (0-wymiarowy tensor), bo potrzebujemy zwyczajnej liczby do obliczania propagacji wstecznych (pochodnych czątkowych)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "mse = nn.MSELoss()\n",
+    "mse(y, a * x + b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "vS35r49nLAsw",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Atrybutu `grad_fn` nie używamy wprost, bo korzysta z niego w środku PyTorch, ale widać, że tensor jest \"świadomy\", że liczy się na nim pochodną. Możemy natomiast skorzystać z atrybutu `grad`, który zawiera faktyczny gradient. Zanim go jednak dostaniemy, to trzeba powiedzieć PyTorchowi, żeby policzył gradient. Służy do tego metoda `.backward()`, wywoływana na obiekcie zwracanym przez funkcję kosztu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "id": "Qb7l6Xg1LAsx",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "loss = mse(y, a * x + b)\n",
+    "loss.backward()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "6LfQbLVoLAsx",
+    "outputId": "d5b87fb7-d284-423c-f467-b677384b2f67",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(a.grad)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "Kdf1iweELAsy",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Ważne jest, że PyTorch nie liczy za każdym razem nowego gradientu, tylko dodaje go do istniejącego, czyli go akumuluje. Jest to przydatne w niektórych sieciach neuronowych, ale zazwyczaj trzeba go zerować. Jeżeli tego nie zrobimy, to dostaniemy coraz większe gradienty.\n",
+    "\n",
+    "Do zerowania służy metoda `.zero_()`. W PyTorchu wszystkie metody modyfikujące tensor w miejscu mają `_` na końcu nazwy. Jest to dość niskopoziomowa operacja dla pojedynczych tensorów - zobaczymy za chwilę, jak to robić łatwiej dla całej sieci."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "DiCQZKJsLAsy",
+    "outputId": "2f779622-480d-43fc-b9d0-a0e36ff4b28b",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "loss = mse(y, a * x + b)\n",
+    "loss.backward()\n",
+    "a.grad"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "xNC3Ag8uLAsz",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Zobaczmy, jak wyglądałaby regresja liniowa, ale napisana w PyTorchu. Jest to oczywiście bardzo niskopoziomowa implementacja - za chwilę zobaczymy, jak to wygląda w praktyce."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "AKnxyeboLAsz",
+    "outputId": "2f939474-901a-4773-9704-686a40ae6e8e",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "learning_rate = 0.1\n",
+    "for i in range(1000):\n",
+    "    loss = mse(y, a * x + b)\n",
+    "\n",
+    "    # compute gradients\n",
+    "    loss.backward()\n",
+    "\n",
+    "    # update parameters\n",
+    "    a.data -= learning_rate * a.grad\n",
+    "    b.data -= learning_rate * b.grad\n",
+    "\n",
+    "    # zero gradients\n",
+    "    a.grad.data.zero_()\n",
+    "    b.grad.data.zero_()\n",
+    "\n",
+    "    if i % 100 == 0:\n",
+    "        print(f\"step {i} loss: \", loss)\n",
+    "\n",
+    "print(\"final loss:\", loss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "2DXNVhshmmI-",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Trening modeli w PyTorchu jest dosyć schematyczny i najczęściej rozdziela się go na kilka bloków, dających razem **pętlę uczącą (training loop)**, powtarzaną w każdej epoce:\n",
+    "1. Forward pass - obliczenie predykcji sieci\n",
+    "2. Loss calculation\n",
+    "3. Backpropagation - obliczenie pochodnych oraz zerowanie gradientów\n",
+    "4. Optimalization - aktualizacja wag\n",
+    "5. Other - ewaluacja na zbiorze walidacyjnym, logging etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "2etpw7TNLAs0",
+    "outputId": "8ac35c12-6c70-41ec-bf57-414456fc3c96",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# initialization\n",
+    "learning_rate = 0.1\n",
+    "a = torch.rand(1, requires_grad=True)\n",
+    "b = torch.rand(1, requires_grad=True)\n",
+    "optimizer = torch.optim.SGD([a, b], lr=learning_rate)\n",
+    "best_loss = float(\"inf\")\n",
+    "\n",
+    "# training loop in each epoch\n",
+    "for i in range(1000):\n",
+    "    # forward pass\n",
+    "    y_hat = a * x + b\n",
+    "\n",
+    "    # loss calculation\n",
+    "    loss = mse(y, y_hat)\n",
+    "\n",
+    "    # backpropagation\n",
+    "    loss.backward()\n",
+    "\n",
+    "    # optimization\n",
+    "    optimizer.step()\n",
+    "    optimizer.zero_grad()  # zeroes all gradients - very convenient!\n",
+    "\n",
+    "    if i % 100 == 0:\n",
+    "        if loss < best_loss:\n",
+    "            best_model = (a.clone(), b.clone())\n",
+    "            best_loss = loss\n",
+    "        print(f\"step {i} loss: {loss.item():.4f}\")\n",
+    "\n",
+    "print(\"final loss:\", loss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Przejdziemy teraz do budowy sieci neuronowej do klasyfikacji. Typowo implementuje się ją po prostu jako sieć dla regresji, ale zwracającą tyle wyników, ile mamy klas, a potem aplikuje się na tym funkcję sigmoidalną (2 klasy) lub softmax (>2 klasy). W przypadku klasyfikacji binarnej zwraca się czasem tylko 1 wartość, przepuszczaną przez sigmoidę - wtedy wyjście z sieci to prawdopodobieństwo klasy pozytywnej.\n",
+    "\n",
+    "Funkcją kosztu zwykle jest **entropia krzyżowa (cross-entropy)**, stosowana też w klasycznej regresji logistycznej. Co ważne, sieci neuronowe, nawet tak proste, uczą się szybciej i stabilniej, gdy dane na wejściu (a przynajmniej zmienne numeryczne) są **ustandaryzowane (standardized)**. Operacja ta polega na odjęciu średniej i podzieleniu przez odchylenie standardowe (tzw. *Z-score transformation*).\n",
+    "\n",
+    "**Uwaga - PyTorch wymaga tensora klas będącego liczbami zmiennoprzecinkowymi!**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Zbiór danych"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Na tym laboratorium wykorzystamy zbiór [Adult Census](https://archive.ics.uci.edu/ml/datasets/adult). Dotyczy on przewidywania na podstawie danych demograficznych, czy dany człowiek zarabia powyżej 50 tysięcy dolarów rocznie, czy też mniej. Jest to cenna informacja np. przy planowaniu kampanii marketingowych. Jak możesz się domyślić, zbiór pochodzi z czasów, kiedy inflacja była dużo niższa :)\n",
+    "\n",
+    "Poniżej znajduje się kod do ściągnięcia i preprocessingu zbioru. Nie musisz go dokładnie analizować."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "4DNsaZAnLAs0",
+    "outputId": "70822008-530d-4173-deb9-8149a9fe5b41",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "columns = [\n",
+    "    \"age\",\n",
+    "    \"workclass\",\n",
+    "    \"fnlwgt\",\n",
+    "    \"education\",\n",
+    "    \"education-num\",\n",
+    "    \"marital-status\",\n",
+    "    \"occupation\",\n",
+    "    \"relationship\",\n",
+    "    \"race\",\n",
+    "    \"sex\",\n",
+    "    \"capital-gain\",\n",
+    "    \"capital-loss\",\n",
+    "    \"hours-per-week\",\n",
+    "    \"native-country\",\n",
+    "    \"wage\"\n",
+    "]\n",
+    "\n",
+    "\"\"\"\n",
+    "age: continuous.\n",
+    "workclass: Private, Self-emp-not-inc, Self-emp-inc, Federal-gov, Local-gov, State-gov, Without-pay, Never-worked.\n",
+    "fnlwgt: continuous.\n",
+    "education: Bachelors, Some-college, 11th, HS-grad, Prof-school, Assoc-acdm, Assoc-voc, 9th, 7th-8th, 12th, Masters, 1st-4th, 10th, Doctorate, 5th-6th, Preschool.\n",
+    "education-num: continuous.\n",
+    "marital-status: Married-civ-spouse, Divorced, Never-married, Separated, Widowed, Married-spouse-absent, Married-AF-spouse.\n",
+    "occupation: Tech-support, Craft-repair, Other-service, Sales, Exec-managerial, Prof-specialty, Handlers-cleaners, Machine-op-inspct, Adm-clerical, Farming-fishing, Transport-moving, Priv-house-serv, Protective-serv, Armed-Forces.\n",
+    "relationship: Wife, Own-child, Husband, Not-in-family, Other-relative, Unmarried.\n",
+    "race: White, Asian-Pac-Islander, Amer-Indian-Eskimo, Other, Black.\n",
+    "sex: Female, Male.\n",
+    "capital-gain: continuous.\n",
+    "capital-loss: continuous.\n",
+    "hours-per-week: continuous.\n",
+    "native-country: United-States, Cambodia, England, Puerto-Rico, Canada, Germany, Outlying-US(Guam-USVI-etc), India, Japan, Greece, South, China, Cuba, Iran, Honduras, Philippines, Italy, Poland, Jamaica, Vietnam, Mexico, Portugal, Ireland, France, Dominican-Republic, Laos, Ecuador, Taiwan, Haiti, Columbia, Hungary, Guatemala, Nicaragua, Scotland, Thailand, Yugoslavia, El-Salvador, Trinadad&Tobago, Peru, Hong, Holand-Netherlands.\n",
+    "\"\"\"\n",
+    "\n",
+    "df = pd.read_csv(\"adult.data\", header=None, names=columns)\n",
+    "df.wage.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# attribution: https://www.kaggle.com/code/royshih23/topic7-classification-in-python\n",
+    "df['education'].replace('Preschool', 'dropout',inplace=True)\n",
+    "df['education'].replace('10th', 'dropout',inplace=True)\n",
+    "df['education'].replace('11th', 'dropout',inplace=True)\n",
+    "df['education'].replace('12th', 'dropout',inplace=True)\n",
+    "df['education'].replace('1st-4th', 'dropout',inplace=True)\n",
+    "df['education'].replace('5th-6th', 'dropout',inplace=True)\n",
+    "df['education'].replace('7th-8th', 'dropout',inplace=True)\n",
+    "df['education'].replace('9th', 'dropout',inplace=True)\n",
+    "df['education'].replace('HS-Grad', 'HighGrad',inplace=True)\n",
+    "df['education'].replace('HS-grad', 'HighGrad',inplace=True)\n",
+    "df['education'].replace('Some-college', 'CommunityCollege',inplace=True)\n",
+    "df['education'].replace('Assoc-acdm', 'CommunityCollege',inplace=True)\n",
+    "df['education'].replace('Assoc-voc', 'CommunityCollege',inplace=True)\n",
+    "df['education'].replace('Bachelors', 'Bachelors',inplace=True)\n",
+    "df['education'].replace('Masters', 'Masters',inplace=True)\n",
+    "df['education'].replace('Prof-school', 'Masters',inplace=True)\n",
+    "df['education'].replace('Doctorate', 'Doctorate',inplace=True)\n",
+    "\n",
+    "df['marital-status'].replace('Never-married', 'NotMarried',inplace=True)\n",
+    "df['marital-status'].replace(['Married-AF-spouse'], 'Married',inplace=True)\n",
+    "df['marital-status'].replace(['Married-civ-spouse'], 'Married',inplace=True)\n",
+    "df['marital-status'].replace(['Married-spouse-absent'], 'NotMarried',inplace=True)\n",
+    "df['marital-status'].replace(['Separated'], 'Separated',inplace=True)\n",
+    "df['marital-status'].replace(['Divorced'], 'Separated',inplace=True)\n",
+    "df['marital-status'].replace(['Widowed'], 'Widowed',inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "editable": true,
+    "id": "LiOxs_6mLAs1",
+    "outputId": "c95418cf-2632-41d0-de0a-9caf109de113",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import MinMaxScaler, OneHotEncoder, StandardScaler\n",
+    "\n",
+    "\n",
+    "X = df.copy()\n",
+    "y = (X.pop(\"wage\") == ' >50K').astype(int).values\n",
+    "\n",
+    "train_valid_size = 0.2\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, \n",
+    "    test_size=train_valid_size, \n",
+    "    random_state=0, \n",
+    "    shuffle=True, \n",
+    "    stratify=y\n",
+    ")\n",
+    "X_train, X_valid, y_train, y_valid = train_test_split(\n",
+    "    X_train, y_train, \n",
+    "    test_size=train_valid_size, \n",
+    "    random_state=0, \n",
+    "    shuffle=True, \n",
+    "    stratify=y_train\n",
+    ")\n",
+    "\n",
+    "continuous_cols = ['age', 'fnlwgt', 'education-num', 'capital-gain', 'capital-loss', 'hours-per-week']\n",
+    "continuous_X_train = X_train[continuous_cols]\n",
+    "categorical_X_train = X_train.loc[:, ~X_train.columns.isin(continuous_cols)]\n",
+    "\n",
+    "continuous_X_valid = X_valid[continuous_cols]\n",
+    "categorical_X_valid = X_valid.loc[:, ~X_valid.columns.isin(continuous_cols)]\n",
+    "\n",
+    "continuous_X_test = X_test[continuous_cols]\n",
+    "categorical_X_test = X_test.loc[:, ~X_test.columns.isin(continuous_cols)]\n",
+    "\n",
+    "categorical_encoder = OneHotEncoder(sparse_output=False, handle_unknown='ignore')\n",
+    "continuous_scaler = StandardScaler() #MinMaxScaler(feature_range=(-1, 1))\n",
+    "\n",
+    "categorical_encoder.fit(categorical_X_train)\n",
+    "continuous_scaler.fit(continuous_X_train)\n",
+    "\n",
+    "continuous_X_train = continuous_scaler.transform(continuous_X_train)\n",
+    "continuous_X_valid = continuous_scaler.transform(continuous_X_valid)\n",
+    "continuous_X_test = continuous_scaler.transform(continuous_X_test)\n",
+    "\n",
+    "categorical_X_train = categorical_encoder.transform(categorical_X_train)\n",
+    "categorical_X_valid = categorical_encoder.transform(categorical_X_valid)\n",
+    "categorical_X_test = categorical_encoder.transform(categorical_X_test)\n",
+    "\n",
+    "X_train = np.concatenate([continuous_X_train, categorical_X_train], axis=1)\n",
+    "X_valid = np.concatenate([continuous_X_valid, categorical_X_valid], axis=1)\n",
+    "X_test = np.concatenate([continuous_X_test, categorical_X_test], axis=1)\n",
+    "\n",
+    "X_train.shape, y_train.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Uwaga co do typów - PyTorchu wszystko w sieci neuronowej musi być typu `float32`. W szczególności trzeba uważać na konwersje z Numpy'a, który używa domyślnie typu `float64`. Może ci się przydać metoda `.float()`.\n",
+    "\n",
+    "Uwaga co do kształtów wyjścia - wejścia do `nn.BCELoss` muszą być tego samego kształtu. Może ci się przydać metoda `.squeeze()` lub `.unsqueeze()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qfRA3xEoLAs1"
+   },
+   "outputs": [],
+   "source": [
+    "X_train = torch.from_numpy(X_train).float()\n",
+    "y_train = torch.from_numpy(y_train).float().unsqueeze(-1)\n",
+    "\n",
+    "X_valid = torch.from_numpy(X_valid).float()\n",
+    "y_valid = torch.from_numpy(y_valid).float().unsqueeze(-1)\n",
+    "\n",
+    "X_test = torch.from_numpy(X_test).float()\n",
+    "y_test = torch.from_numpy(y_test).float().unsqueeze(-1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Podobnie jak w laboratorium 2, mamy tu do czynienia z klasyfikacją niezbalansowaną:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "y_pos_perc = 100 * y_train.sum().item() / len(y_train)\n",
+    "y_neg_perc = 100 - y_pos_perc\n",
+    "\n",
+    "plt.title(\"Class percentages\")\n",
+    "plt.bar([\"<50k\", \">=50k\"], [y_neg_perc, y_pos_perc])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "W związku z powyższym będziemy używać odpowiednich metryk, czyli AUROC, precyzji i czułości."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XLexWff-LAs0",
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 3 (1.0 punkt)\n",
+    "\n",
+    "Zaimplementuj regresję logistyczną dla tego zbioru danych, używając PyTorcha. Dane wejściowe zostały dla ciebie przygotowane w komórkach poniżej.\n",
+    "\n",
+    "Sama sieć składa się z 2 elementów:\n",
+    "- warstwa liniowa `nn.Linear`, przekształcająca wektor wejściowy na 1 wyjście - logit\n",
+    "- aktywacja sigmoidalna `nn.Sigmoid`, przekształcająca logit na prawdopodobieństwo klasy pozytywnej\n",
+    "\n",
+    "Użyj binarnej entropii krzyżowej `nn.BCELoss` jako funkcji kosztu. Użyj optymalizatora SGD ze stałą uczącą `1e-3`. Trenuj przez 3000 epok. Pamiętaj, aby przekazać do optymalizatora `torch.optim.SGD` parametry sieci (metoda `.parameters()`). Dopisz logowanie kosztu raz na 100 epok."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "NbABKz5-LAs2",
+    "outputId": "086dc0f3-0184-4072-9fd3-275b60dee2e4",
+    "scrolled": true,
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "learning_rate = 1e-3\n",
+    "\n",
+    "model = ...\n",
+    "activation = ...\n",
+    "optimizer = ...\n",
+    "loss_fn = ...\n",
+    "\n",
+    "# implement me!\n",
+    "# your_code\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "Teraz trzeba sprawdzić, jak poszło naszej sieci. W PyTorchu sieć pracuje zawsze w jednym z dwóch trybów: treningowym lub ewaluacyjnym (predykcyjnym). Ten drugi wyłącza niektóre mechanizmy, które są używane tylko podczas treningu, w szczególności regularyzację dropout. Do przełączania służą metody modelu `.train()` i `.eval()`.\n",
+    "\n",
+    "Dodatkowo podczas liczenia predykcji dobrze jest wyłączyć liczenie gradientów, bo nie będą potrzebne, a oszczędza to czas i pamięć. Używa się do tego menadżera kontekstu `with torch.no_grad():`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "zH37zDX4LAs2",
+    "outputId": "b1f93309-6f04-4ffc-b0ca-08d0a32120a0",
+    "scrolled": true,
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import precision_recall_curve, precision_recall_fscore_support, roc_auc_score\n",
+    "\n",
+    "\n",
+    "model.eval()\n",
+    "with torch.no_grad():\n",
+    "    y_score = activation(model(X_test))\n",
+    "\n",
+    "auroc = roc_auc_score(y_test, y_score)\n",
+    "print(f\"AUROC: {auroc:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert isinstance(model, nn.Linear)\n",
+    "assert isinstance(activation, nn.Sigmoid)\n",
+    "assert isinstance(optimizer, torch.optim.SGD)\n",
+    "assert isinstance(loss_fn, torch.nn.BCELoss)\n",
+    "\n",
+    "assert model.out_features == 1\n",
+    "assert optimizer.param_groups[0][\"lr\"] == 1e-3\n",
+    "\n",
+    "assert 0.0 < loss.item() < 0.5\n",
+    "assert 0.8 < auroc < 0.9\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Jest to całkiem dobry wynik, a może być jeszcze lepszy. Sprawdźmy dla pewności jeszcze inne metryki: precyzję, recall oraz F1-score. Dodatkowo narysujemy krzywą precision-recall, czyli jak zmieniają się te metryki w zależności od przyjętego progu (threshold) prawdopodobieństwa, powyżej którego przyjmujemy klasę pozytywną. Taką krzywą należy rysować na zbiorze walidacyjnym, bo później chcemy wykorzystać tę informację do doboru progu, a nie chcemy mieć wycieku danych testowych (data leakage).\n",
+    "\n",
+    "Poniżej zaimplementowano także funkcję `get_optimal_threshold()`, która sprawdza, dla którego progu uzyskujemy maksymalny F1-score, i zwraca indeks oraz wartość optymalnego progu. Przyda ci się ona w dalszej części laboratorium."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import PrecisionRecallDisplay\n",
+    "\n",
+    "\n",
+    "def get_optimal_threshold(\n",
+    "    precisions: np.array, \n",
+    "    recalls: np.array, \n",
+    "    thresholds: np.array\n",
+    ") -> tuple[int, float]:\n",
+    "    \n",
+    "    numerator = 2 * precisions * recalls\n",
+    "    denominator = precisions + recalls\n",
+    "    f1_scores = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator != 0)\n",
+    "    \n",
+    "    optimal_idx = np.argmax(f1_scores)\n",
+    "    optimal_threshold = thresholds[optimal_idx]\n",
+    "    \n",
+    "    return optimal_idx, optimal_threshold\n",
+    "\n",
+    "\n",
+    "def plot_precision_recall_curve(y_true, y_pred_score) -> None:\n",
+    "    precisions, recalls, thresholds = precision_recall_curve(y_true, y_pred_score)\n",
+    "    optimal_idx, optimal_threshold = get_optimal_threshold(precisions, recalls, thresholds)\n",
+    "\n",
+    "    disp = PrecisionRecallDisplay(precisions, recalls)\n",
+    "    disp.plot()\n",
+    "    plt.title(f\"Precision-recall curve (opt. thresh.: {optimal_threshold:.4f})\")\n",
+    "    plt.axvline(recalls[optimal_idx], color=\"green\", linestyle=\"-.\")\n",
+    "    plt.axhline(precisions[optimal_idx], color=\"green\", linestyle=\"-.\")\n",
+    "    plt.show()\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.eval()\n",
+    "with torch.no_grad():\n",
+    "    y_pred_valid_score = activation(model(X_valid))\n",
+    "\n",
+    "plot_precision_recall_curve(y_valid, y_pred_valid_score)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vfQPIUQ_LAs2"
+   },
+   "source": [
+    "Jak widać, chociaż AUROC jest wysokie, to dla optymalnego F1-score recall nie jest zbyt wysoki, a precyzja jest już dość niska. Być może wynik uda się poprawić, używając modelu o większej pojemności - pełnej, głębokiej sieci neuronowej."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sieci neuronowe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YP298w6Cq7T6"
+   },
+   "source": [
+    "Wszystko zaczęło się od inspirowanych biologią [sztucznych neuronów](https://en.wikipedia.org/wiki/Artificial_neuron), których próbowano użyć do symulacji mózgu. Naukowcy szybko odeszli od tego podejścia (sam problem modelowania okazał się też znacznie trudniejszy, niż sądzono), zamiast tego używając neuronów jako jednostek reprezentującą dowolną funkcję parametryczną $f(x, \\Theta)$. Każdy neuron jest zatem bardzo elastyczny, bo jedyne wymagania to funkcja różniczkowalna, a mamy do tego wektor parametrów $\\Theta$.\n",
+    "\n",
+    "W praktyce najczęściej można spotkać się z kilkoma rodzinami sieci neuronowych:\n",
+    "1. Perceptrony wielowarstwowe (*MultiLayer Perceptron*, MLP) - najbardziej podobne do powyższego opisu, niezbędne do klasyfikacji i regresji\n",
+    "2. Konwolucyjne (*Convolutional Neural Networks*, CNNs) - do przetwarzania danych z zależnościami przestrzennymi, np. obrazów czy dźwięku\n",
+    "3. Rekurencyjne (*Recurrent Neural Networks*, RNNs) - do przetwarzania danych z zależnościami sekwencyjnymi, np. szeregi czasowe, oraz kiedyś do języka naturalnego\n",
+    "4. Transformacyjne (*Transformers*), oparte o mechanizm atencji (*attention*) - do przetwarzania języka naturalnego (NLP), z którego wyparły RNNs, a coraz częściej także do wszelkich innych danych, np. obrazów, dźwięku\n",
+    "5. Grafowe (*Graph Neural Networks*, GNNS) - do przetwarzania grafów\n",
+    "\n",
+    "Na tym laboratorium skupimy się na najprostszej architekturze, czyli MLP. Jest ona powszechnie łączona z wszelkimi innymi architekturami, bo pozwala dokonywać klasyfikacji i regresji. Przykładowo, klasyfikacja obrazów to zwykle CNN + MLP, klasyfikacja tekstów to transformer + MLP, a regresja na grafach to GNN + MLP.\n",
+    "\n",
+    "Dodatkowo, pomimo prostoty MLP są bardzo potężne - udowodniono, że perceptrony (ich powszechna nazwa) są [uniwersalnym aproksymatorem](https://www.sciencedirect.com/science/article/abs/pii/0893608089900208), będącym w stanie przybliżyć dowolną funkcję z odpowiednio małym błędem, zakładając wystarczającą wielkość warstw sieci. Szczególne ich wersje potrafią nawet [reprezentować drzewa decyzyjne](https://www.youtube.com/watch?v=_okxGdHM5b8).\n",
+    "\n",
+    "Dla zainteresowanych polecamy [doskonałą książkę \"Dive into Deep Learning\", z implementacjami w PyTorchu](https://d2l.ai/chapter_multilayer-perceptrons/index.html), [klasyczną książkę \"Deep Learning Book\"](https://www.deeplearningbook.org/contents/mlp.html), oraz [ten filmik](https://www.youtube.com/watch?v=BFHrIxKcLjA), jeśli zastanawiałeś/-aś się, czemu używamy deep learning, a nie naprzykład (wide?) learning. (aka. czemu staramy się budować głębokie sieci, a nie płytkie za to szerokie)"
+   ]
+  },
+  {
+   "attachments": {
+    "1_x-3NGQv0pRIab8xDT-f_Hg.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxsAAAEuCAIAAABplJipAACAAElEQVR42uydB3wU1fbHz7l3ZmvqpjfSSCBASELvVZogIkWl6FOsWN+z69+CT33F8uy9UBQVKRaQ3qtKEQgECC0hpPe22TJz7/+zM5sQBFSaAt6vfGKyOzM7O3Pn3N8999xzJM45CAQCgUAgEAjOASIugUAgEAgEAoFQVAKBQCAQCARCUQkEAoFAIBAIRSUQCAQCgUAgFJVAIBAIBAKBQCgqgUAgEAgEAqGoBAKBQCAQCISiEggEAoFAIBCKSiAQCAQCgUAgFJVAIBAIBAKBUFQCgUAgEAgElzCSuAQCgeAvSlNRUxTXQiAQCEUlEAgEZ6SjGsvDIyAHjkJPCQQCoagEAoHg7BUVQc64R1gJUSUQCM4ZEUclEAj+UnIKgKNHTRFSV1vndilizk8gEAhFJRAIBGckpzgAAwDkWFRY8903y7Zu2cMY1yKquLg+AoFAKCqBQCD4faIKwK0q2dk5/33hy6cfn7Z81Q5VVQFU7R0mro9AIDhrRByVQCD4a3HkcP4zU/9VlOuLxOpWgAnnlEAgOB8IH5VAIPjLwEFVsaKqIjQi6KU3H7aFGRlvEFZQIBCcF4SPSiAQXF6qiTMA5JwjAiJpfJE3LfHr0rVDRocMkwEV5gSOwJFzhiI8XSAQXJqKSjdt2GTsUNgzgUBwPtBVFCKw43mnvEYGEQkBN7hkA9jdBg4uze4QDkwYIIFAcLErKu/QkGj/HZdTzRWV/qcwaAKB4BytjednRXllbW2twWCyBQcajKRRZqHKlIKCAq5S/yBfX18zpYDESZFRggzF1J9AILjoFRUA7Nt3MDs718fXv3Ontv7+Vk1lMUSaV1CSlXmQcZae3iosNIgQYdMEAsHZCyrggAS378ie++V8oxw0+fZr26a2oJLussKtP2XPmDZDlnxvv3NiXGKES3FyVVZcUF/rsPhRTqDRUa6v+BPmSCAQnBkX3Gog4t59R6Y++uH1I59eu36/2w2cMw5MZfjp7IXXjnzuxZe+yy+qFndCIBCci5zSBmqMcx4WHZa5/+D7781fsGiTy+lC7a2GBuf0d5fO+nDTkf0VhJiXLt0058slrnrTwazir2Z/X15s5xwYa1JUIo2CQCC4+BQVB56W3q5H33SHo+bb+duKimsRCUHpQG7lqpVbuFsdPLhHTItw4aASCATnOnzjyBhr3zpuyPDBvkHBixauLC+rY5wh8szd2bt27bVZw8dOGBIa4VtYdPTgwcMjRnVLaBWQm3PI6XAT0hR4gCIIQSAQnAV/wKyfGhcbNnhYp527sudNWzhwUNKYMT1lA5375ZLMjcdSerXsf0V7/0CjqFcqEAjOYeSGXIvOJEgA2PAh/TetzVq3ZMPsL7bcff9AVcX532zMOXSsa6+eg4Z39wkw3TT5eq7qg0pGODEbjJxD4/oYYYgEAsHZQP4AUydRSE1LSE6OZeD6/vvVxWVVOXl5W3/62V7luuKKbrFxNhlFCQiBQHBuaMkSAJGBkpwU2717RkhExGfTvikorTh4MH/HT3tr6mpHjxthC/IBCkaTwWQxm6wmq9lksZgIJfpKwEarKFzmAoHgjPkDfFSEcx4TE925a9r6dXt+WLtjz66ikvJjB7NyI1vEXDGwU1CAD4rsCQKB4DxoKq5FTUm+PqR37zarlkRu27x/xcpd9mrn/t1HUzsk9xuSSGQVNaNEtHEcR8KBaVHpQkUJBIJzkzt/wGdwDgbZ0LNP18RWQeXHqhd888PCRdtycwqGjurbKrkFpQSBCk+7QCA4JznV+ENzVUHHDq1bp8ZbDHTeZyu++3Z9VVHD9RNHhoYZ9TLJHgmFnGi/azsKH7lAIDhXpAs/agR9EU3r5MhuPdtkbi5YtfDHerXOHGgdcVVaqM2KXIuhEtELAoHgnOSUN6hcszk8wN9vQL9eKxev2bvlqOJUohOS+g3oCFxGzrEp+Fz7n/BOCQSC88IfEEeFBJGhajTisBH9kjLCSoqOVRVVDx7aJyUlQqKAelY+IacEAsF5NT0DhnSKbW1zOB12V22/4RlRMcGSBLQp3up45JRY3CcQCC4JRQWoJ0R3cZaR2qb/gJ6ylZoMPiNG9PMLCtTKRHgGiSI0XSAQnDejg56RWqjNPHTYQKMvBsUE9x3Y2mwmWuSUsDQCgeBSVVSNugq5UZYDAwOQKJ0GJLVLiTUZqFZ+BpsXphEIBIJzQa98hYgKh5LSakedo0uPNhnt42WZckBRwE8gEFwg/oC1ft4SfgYgx4rLt2/dwxXSv39qWKivhEA85g0ZET53gUBwntmzp3jj+h2gqAP6dg0LCyYS0ZKhi6gpgUBwiSoq9CoqBFyxfM2PazKTktt06Zrq72/VU3o2r5ksEAgE52EYxzkAW/T9qv1ZBS1axfTu09Zoljm6NItDhLURCAQXggs+XGPc848AOXy4aM7sBQfytnbuEZ+YGC5JyIBz5Aw54yK0QSAQnAd7A6ACcEQ8cODwhtVL6iqOjZvULTrWD1DlXOJcEh4qgUBwgcALLWY4B+4ZFeKerKNz5nzfUMvGjB3evkOM0UDY8bIPwhEvEAjOi6JinBMEUlZWkZV51O2S2nSMDAr206rUSNjMLS+yCgsEgktMUXlMHOeA4FTcdbUOQPD1sUoGCpwzzaihUFQCgeD8KiqGCgdVVQGJbPCM7FTPyI4iABWKSiAQXIqKinOulYVgngEiIiDRAqcYb8pCJXxUAoHg/Jkc7R/RzQvzmB6VImn+PkFhbAQCwQXhwkamH6/ljsBQT0zFEDgC4SJbgkAgON8mx5sLHfVxGnImNWZo0SSWcEsJBIILxgUfrnEERjQNBfjifz+4bvTDWbvyUWSfEggEF9r4AEgEKALz/Mo0sSUcVAKB4EIh/ZEflpeX//PWvQ0NDm0syUTxB4FAcMHUFCdAli/f5FSV3r07+1qNTW+IdC0CgeBSVVRNugkpR8q8L6Jer5QL4yYQCC6EogKAjz78sqS0Lq1dO3+rQU+OJyyOQCC4dBUVFzVmBALBn0J1dXVFhV1lwv4IBIILjogqEAgElycctAUxVPikBH+F1l787YTYln3f+NmpigGEUFQCgUBwPtEC0UUhdsFlx85XhrQccN+6kmq1+atq3dGjVXsqHX9eCRK2/r9/6+bnY/UQEvPI14crVaGoBAKB4HKycWIJjOCyQq0vzS2tdZ0wmY0Qft3yutyjj3cxSn9Ka3ev/deEG94pm7x0S35JcXFx1gsFM77YtLfo4tBUlXvW/N+V7Se+vqz2wn6OJBqnQCAQCASX0jjhFPW+iWS2/lk9OoO933745XLLjbP7tG0dYEUAn4mfzGZUluhFMq5ijuqyeqdKLvj4TSAQCAQCwSUMh6I5IzA49cWtDoUDFL3dM6jn2zth0YOIRqPR5Bcy4KPC41u7aqqmDzdqyMFt+76U2fROw9HMDweg/pYxbdQTy+q9xz/202fje1xx03Pvf3NvKypj98nrc5r7n7jCAffmHXHaFf0FajDK9Ljw2/Hy0LRg/ag4cmZBpVN/uXrakOhO//sJlj9DqUV7N+PVQ8edb6qbzb1e38sQEJPy9Bbvh9UUbnwgpWXqE7N3TE2jErbqf++COgCw52x/p7/35A0dxj69wg7ACrZOvy+h3eDXNhcteHxkoBF7/3PJrirPUepWvnp9RoDB+117/eenAzWNl+f7e3pJk9768Z07BiZbjEbrQ6sLqplQVAKBQCAQ/CU0FXOB2qB4e37VUf3DfYNxcSfO7LVVux4xrb27/T1rdL1QW/3ZuOB7D/59rbPeXnz0i35lj4y7cV41B7Dn7fzimbEb766y2+2Oot0bR2X/+8HJb+3xSjYqb14185/vzo59udylbPyoVyxtpiRSuvRPT7PMuOOOaT9lVzPGTojm2vHygBEPl0/edLiioaFw+i1b/tbthS2ldap+WPfuh/vi465t9RV2u/PrSVmPtO706mHPW8zNv55omLDilsVOu72ibMlE83Mjrvq03JtSju07tPu/j91W8WCZW9m78vURPvVHts569qYd91V7Tr5w59orM597+M53s0hExxvf2P/zovu6RV75/Pxih7L2qSGp/pA1/e5hVzwA9y45UGu3251bX4v5rOuo137URRVXUYqZ9ffu/3U/uDynxl77Yr9IfyIUlUAgEAgEf0GYkfW46+Cb4wGpwdji4Vdvd5VtzS4E4Hb7rjdfWBZ0/6z/dgOJBoR1efzdu+pWTv1gE4AlJm3ytP3Tx/hTSiEwLGjItf12Z63euN8r2VzAW44ac9udVwUgJeTEUuOYcOvMj964cVDBE31TbDbjlJm7ChtUzjlwqFzy+itrU9/69NqYKCshtvGvvzoKXnl9Rn29Wxd4bj5o9rpn2plMlMKVH6+8STn02YLdAIq6982n5qhTvnlnAFBq9U177JNHjVvuf2M1eNebEGPb/o8/f2Og52QIgjW+023Tdn1wjZ/n5G3hoYPH9dmxe93m/YgEPBsgJ4RKSAkCVm+cPWsZPr74yTHdYg2e7VOn/OuuYfyzd9fllqja8dUqUO9498mu0aFGeqo5VqGoBAKBQCD4a2CBti0TvXKHQFKrFPgx6xCAwrK//fpwxPWD0x0absYi45Mrag4cqtZkE2eK0/O600GpHBPfyqV6J/e46jZHJHfo0NnndJ8Yf8uMpUdr1z11ZWvzR7ekR1punZtZBmhfs2R9Ud++fYxGon+iNSrZCNkHD6iaolIMbNKVIySpMQQsoW2q++e58w8BPfTdV/ukm4d10/dyKUp0Qtsa5779FVoxdE6N4d36DfRrfgKcNZ28LEkxCa3cTD2FGMLarZu372wITfTzP/5dohLaRRSsWrCnvBSAoOKsjp0wLMUv4MziwERkukAgEAgEfxmQ2qHwrSus7zWKDUL9kjt3NCBw7izaPe9f7Sd+YDDoIkrx6zb+zESFT4+pCzZNzZ5z3fU3Tb9p6shus/oaTEFBG5/s2PqZps+TLdZWvoYmJ9cv8z0gSBLxbKeAMuMq66wmz49kjWs51tRMIzXfkXNHwY45z3e88ZPGk1f9ek2ip8wlgZy5E1tEWX2OfzdDdLR/cEDz2Up25pdW+Kj+IBRFVRSVi6w4AoFAIPgTIeAPkfdtcDbRYC/dufal6/3cFfvnT20/ce0Dq6u014t2zLw9pKROPYtPSL7u6ZsHx9kPHLQ7nJRVlvd+MetYXdPn1VXWbXupS4DZmyuO8WbihatuH0hNjgdANAGdvPz4eTrrK/bv/ODmQOCnEDuust1znup447bH1uonX7j148kh5Q2n8lEBUoPBmH0kt65GaXrNkXO4vLzOIJ1TRuA/QVExr0REvOxzxGgthXHW4FQOHiref6i4ts7NGNeAi0pdeUsFNVYM0ia/RVJEwWX2OAoEl1F7RsSz6UIpT8zoACXbtuU0rsrj3FlXVevkam3dgeUrIaN7/85mT1ftrK2qrFN+n8JQHXXVtXZ3k9JxV2VlFhS17dzKLEckpEb45u3YVlzu9j6Dir2qusHt7QJRhZ93ba2q10/GXb9j2z5H//Q04O6WaV1A3bI1q75J9rjqKmscp3YdqVU12cvXYteuvTtqJ++oraq2K8QrcRCBIiiKoh/Kp1PPLp38S7KKyqq9CebdDdl7fy5JGH5NalAowFmXrSJ/vJzifx37xjzCpK7BPmfeigce/s+zz39w4HAhY+yS6G9E9yO4/BQVb0z4KRBc0m2Zg7uhsqyspKxUp7zOBZyzZlqAs18M27m39yW+pivvf7FN9rO97ltS4dn16N6db93a8b6lNdTf0qpTF1qb+fP20tLS3O3rZ/39njll/ibS9KlaqPkpOTDrwV5/u2fhD/vLPKdUduTzZ15ZfHDg3x/tFOIDyROeuq/V6uuvff/nPUc979YufbTT1W9uqGzQypZTyXjw82FXPLG+oKC0tH72hJGLE255enISoAGH3v9O/7IXMiZ/U+k5Zv6RIx/e0urm70q1R1g7mWbKh1pNrTt1gqo92snnbF392QP3zy33lYm2iX9gSNv4sH0b1684UlpR53Bb0/sOHeh+4+EZa9YdLC8tLc3/6h/3v7sr/NY7e0YHawf3Oj7OFBFHdQFRCNRUuz748Nt33prvrHb7R9bX1F68SfnxxGIdotcRCASCixFDcFIf8w/39u/mUvUBuinqsXk/X2+OaRtJA/XwJOrfMjY+uCnuGtHgnxifHmzUtvZp9fC2vKTbWt6W9LULUIpqO+nVvdMGGgAg6YbXVheOHj+m9WuqIfWqG+7cNH3PU6vMsucIksEnomOSK8B8yr6h9S3vL/J/9N7be91a6DklYgq67dNdjw+I8dXUzhXPf7cmfuItE/q/VckYmMMfnb/lgS4WSRvnKOj824dFfRb36JhR5XIb/O797sj/eusOHxI1ZdWxxHvi/taytQtADowZ/vrhecN9ABihxuDuiYmhvsdPxhrV9m+vrigad+OY1v9T5fTRk6es/XjPvzeaZO1Q0WlDH3p29w333Nf5jdQHF/5vyqAe97w9P2bqg0+N73G7mwGVW46fsXPqkBaB+uWyhLRITYywnHH2eeQXePJJnz5Cz0969/1PL/nup8+/fKNr12TOFcTLuT4E56y8vO6dD2e9+epM6gomaAyMCHrnw//r1S1aW4qJuifyoqK590xE2AkuZfTxOB069Oaikvpvvnk3rkUA0/xTomELBBcPVZ8MbHVL5FT7zCnmy0EJCPNyIbSUR6TW1tVMfWbO61O/jQ5ObZOahgqXCEdQG0cMF52c4h59DaTxn5j1EwgEAsEFBbmqAuPcrVwWX0fM+l0QRYWI1VXV2VlbElJtd04ZBar/o9vXGtFGVH3ojBf0o89OTjk1fa15SD26zw1gAKDidgoEAoHgwkBsbTqkBwYTRKGoBKcW3Yic8+jomH8+90itvaZnn+TFC3YhdQJnBAHPU8vhjVk8EPX4J8RmC/ROnEw9fXCUZxeOoO3KORDkHJjngPor2iao7ykCqwQCgeCviEN1HWkotMl+YcbA83tk32veWXbN5XOhhKK6IIpK/3+3Xgm6bHEycAOxU6IQ/D0eKt7oyMJmiojhCTqJcc44I8Ap5wzQiZKJcYUA06LWCEdJU0HacRjyJlGEJ6gsxjlXEalSXaMcPCCFBZHQMLtZxqo6diRH8Q+k0dFOA1BAGageZSXmiQUCgeAvJaem5y+b8vODYVGjtrd7ONIULK7J6RD94wXEpahu5ubAPaKmUW41ahne7N9pJBU/aQtvNjTtaFqVIo7UVWOvP5hrysvXRRcvraTZOXJZBR5P04AMkWnnwLQjqBwU1HxRCIRSRqEs/9iqx/65+dkXXQVFVgfL/nbBqpvuz9u6lVFQL+Q0pUAgEAguZjk1LX/plMxnwSe5uGTdDfveE9fkVxA+qguIgdJTRNtxdlJQ+i/1iu6Lakq0oOdCJZqgUoGrnt+RcKZqLqjqvIL9H85IAAh/8kFZNu3/fB77eU+b8aOkvt2BGvWCklxlHn1GUZ/jU4FzVdW8aUgAnKBGtk7ufuWIbS+86275raF9u5KXP+neul1oz54cmAwyCvUtEAgEfyWczJ1Vm7O1JvuuzGfBGAayj+Tbeoh/srgyQlH9SejL507h4Dmes+J0YVW8MZdB8/1d6JFTknd/lDkgcFNsdECb5KOPvO3bu6e5vKr0f59aR/dREuLAaCCgx0MxlnPMfiSfxkcaYyLcBoM7P9+RfcAnMlqKa6EYDBSoKhPz+JFROQdyPv4usmhei7QAnwducoeFcEroqeYcBQKBQHAZy6lpx5ZN2fUEyAFgsAE1vtxi7INxY8SVEYrqT1JTnAPX9AyeOK+HwIATr8eHn05OeYWUyy073MxkUGSKAFQFqcFNKDCTrCJIno9gFj/flCsH5W3bXfzfD2q2FcX3TWwxfhyLb8EavUociT2/YNkL/4toldDlwbshNPDQtFlF8xal/uuJ0NhoPbKdATNGhaf26f3D28vyYVe7jk9AuxSnRBgQA4iKNAKBQPCXwMXc26qz99QfnZL5NJiiQfZr5ZtwR1DHf8SOFhdHKKo/DURUKSBI2vI+CkCQAwIhRNZiqbjm9Pm1ijSEM0dufs3qLdg6xr9DO6fZrO7JdW09YE2JljukOE1APLKLOAB4TLRpwtXko37VAAGT/66kp7gkYtbSSqnA7YD+GWktBnRzPP0xhsVUhfqUPjOn//j+cucMMErImItoAVhVVUU/7/QL8POtapezeVvE/gOYngpaBXAEryzkF19WUoFAIBCcLzk1LX/ZnTufADkIjOFATS/Fjn1IuKaEovqz0KsBEUI45zU1jpLSatlAyorLKSFMVQoLyw4eMksUoqNCJNmjmvR48V+qMc21xRDtDsfPCxezbx2DHv8Hj4/e/d679qyjbf/5QKiBEG0Trt/C2jp+KMcJ7Y1QCXuPkrIKGhnW6OjiBNx2X3OXG8cf2HMk9625vKIudkg7+vBtaoCNAyEABAhxuY99s2TngpWD777GHBW44NW3lU+/iouMIBHhnGtTk95gdk60rNPIuYIeUUi0rA0IoHqTLHh/IvNGvmsThkCOvyMQCASCiws3VzdV7j5sL7oz8xkwx4DqAGp8OX6CmOkTiuqi0FWIuPmHrM9mzkVC8o9WQQOUF5VN+/iref5mWwB58eWnLXJjcgNvyqfjqaSAAwGuEgxIiE3/27VHHvlv9asfG3u2V5Zu6vDA5ICu7VXCiUfEeFSTgWHdzt35H82JeHh4YFbRsf/MD2+VGDDmSu5r1XJLKQZQFM4gNjK6f9fM2SsSYX/wgCkQF2WXJALcwLkMpCK/uObzhUmtWxvHX6MmhYaU5rneXVA7ZGBgeJiiMkmiWo1Z1KcwFc45Y5yirLuuPN8WVO6NoEeOWsp1fjyy3qOoxIJBgUAguBhRuDo9f+ntO54A2QaGMJAsA4O7D/NvLeSUUFR/PojecPTaSldubr7brUrgm9ohnXGporImv7QkNJgwojumGIBKG++CW/tpAOAUVM4p44rVJPfuGHnjoINT32s7/5u2t00yjLvKbjJwYEZOmBbWXpVzaO+ns/xK6iNvHE/KKg/UvVw37esOLWJo7wyQiTa/KMtIaupqajJ3+YGpEmx1P/3YYkQ/8E9kwLVZPNaAbvOk4dFtWpO4cJeBptwwvjwuxhEQ4DlBShjnBNB5pMilKOZIm2IxK5T4VtWUVVT5WX0NIX4qggzUmwWUcQ7opiB7JBbjDHTlCGLGUCAQCC46OcWm5S+5feczYI4GtQGo8T8txj0aP05cGaGoLg451biQr1fvjpFRT6mcIzdxxjgQLqHC3RaDYjDobhvOtXnCZlqDM23KT18DyIHJFkNAdFQ+oAtKA4MCFV+r0xuExQkQWVXspRX1gYEdn7idJcdhq8TW991av247q60jLhdIZu2YRKp3Z8/7tvDb9QMfGGunbOPrcyLaf2+650Z3oK8CBLk7Oi4O4hK1+s4cQDXHxyfEJzIg4GJIPd+II6/dsHXz8lVdRvS1XTUYXK6a92dl5hxpN3lSYGhbUJh6rKiqoCA4LBTi40BVHUdza8orbZFRGB523PcmEAgEgosDDnxp6ZZiV/XtO6eCMQyo6eqQ3j19Ex4WcupCKyqvRuAnLPnySoemHOHCBdGkq7SfUVFyVFTSiVexKWW5qjY4iOJEk6wSwgmiixnsdpAkl49Zj21iAJLb5dyfnfv1spDWbR2xg7YvWduqZ5ppyFBFIhwVChRAju7UNbprVwCoAWZgasTokTB6JHDuQCZpoUwqZc7MLNebc2N6drbcekNdkKVNcUXVM59ae6cbe3RRjCZzub2ipMQc4mMIsFFi4IePuTnHqEg0GlUDkfUIKoDwtLbKrDkVU16NCrSVVJbnPnZ3xn3PWBNiFSCUqXWZ+7c/9Fx6z86hL/4fb2g49uSrFUWlXZ56QIoM51oed1EiUCAQCC4eOTXt2NJbdj4Jki/IfkAM/4od93j8deLK/BGKSl+epuspgqhyjggEvUkfGedCTJ0M0zIoaPnN9Uyfqh5T5AKJqKzhwLH6LdsiEuNJv+5QZ6/dccC592Bo5wyeHq97rxiAWlxy9KtvSwor+j98mxIfvvehZ8qmz4tOSqatElQAormqFM/hVVdFOdQ4pYgQbpHUqtqaikqzrw8G+XNKCUA1Mv+JQxJ7dGfxkUEmOfi2CYdS4hXkNqYgcKiuy571VXRYSPTY0ZW11eWvfhSQ0dZw/UjJYGSNYloFUNvG9//HLUcefK74jU9qjpS4R08IumuiKyiAMoXJ1Ng1I+HaoTnTFvh0XMgBKpdsSXh2sqFTMtOSZumnKhAIBII/nYUlmyvddbfsmgrGcCDy+LDeqeYoIacuuKJijDU4nSVFNbIkh4TaDAbOGlfQqyqUldXV2+v9/X38Ay2o6a2/fLfJOG/yRHlUJwWk3uvsUUmKNsWn5S8nikvJm7OoCqTUmDBWr2S/Nd3tUkK7d+XaOjnKEbhaW1jEDxe0nHA1GT5AsdKkW8e7Fq4qzT4QkhjnlqimZ5lKEDgrz8mtnLsiafQwKb1N+dpNuVt/Thw2SA5or1IicRLQrk1o2xTmY1WAq6Aae3WKT09BYCBLLgAIsgUEh5RM+zbK6HN4d6Z97c+xVw1Fo6zFeBE3EuRAgDUgt/Xo0DC0R8Er/4wHY/Qrc5RWcU7gFkSJo93mHzHuKvu+7NJ7XpEhMPquPpFXD1F8LJJWDKcpoen5C1A/fflngUAguKQ6jl9Wtz8hA+B5NnEz8pfdtPNpkKxgCAakz8Vd+2TCeHEPLrCi0jNlc5afX/ryy18aGBl73dX9BiZxvUAvkoKCsrf+N7feWTNq3JV9+7XRoo+P1+P9y+FN18S0tW/IkFEgAKTW4aouLmtwuiiVAoL8/P38VAQrY4Agp8Qnjxy4+e5/R7/0hjsoDNdtS3jrUUiJZgCEA3IuITFERUU/fJ8lLlIJ9mOEhIwfVdstnfj4AiID6kYGoEocOAX/IFvZjqxSxR1aXFL7+TehIUF+gTaQZQWAIsgN9mO7siSbNaR1kmQyV+7Zpx4rCOrUgVgtBg5uX3PLCWP2Z2YeefKdqNID6sx3Sd8uTqNsAoacKWCQPJ/ipkR2Ox0NFdUUgtzgdOQVh7oZlxGZR9o5JJDiYkjXDHnuNBmM7s43NMRENgC1acYCtQWBnq+F58VCcKGoBALB5dJ56PmYL7ii+qZ4Yz1z3LTrn2AMBaUOEP8Zf72QU3+cjwoAfK1WpjZ89NH3x45Vt0l/LCTIrIBSU+uY9cW3/3vto1FX9wsP85GQMBDxx3reJsYQKNKS0rJvl2T+sHlr7t5ch8NOiBwYE5aRkXLFsK49UxMZgMtsDpw4NqKipPSpxzgkxDxzR9iVAxzopiAR9EasB0RGuCIjODClphZ37XOFBdnS04Cz6kO5cnm1JbklC/DVhCzxjYuzPTDJ/vc3y1792DR2cOBtY9WkGAJg4NyBxCSZDm352bFgVb8pNzl8jFvemtamY2fM6MABJS3ICX2sgaEhxaVFQSBZYuM9e3A9xJ4bAVSgHMBSXrPtrffUaWvT3vrvgYMHSm97JpxYTRPHOowSAPo6Xe71W92zV/C+Exli1Sdfx7ZqA906OwlS7vkUIAh4PFnoOdmKU04yC2UlEAguPTnV5Ljnx//0dqf6Wyd7sM6GcZkvzS1YCCiDHABUXpD6L1/J3NeWJu7BH6eoKNLAQN8rr+y9ZlnW3syc5St+nHjdAAaYe7R03tzFMf4tu/fs3jIp6qw6NDwxzh1P7fa5hJ4M74o9pCjl5Ve8++4ny+ZtC7cFZ3Rv7x8a4HAoB3ceXPTR/APbtyp//1vP7ulEK7incm7wSBbCVRVUlXEkIGnfnCDqU4ja8KWhoXD5ysP1db0mjQeJbp35WYRPQLsWLRgS0Jw/jFAaGIgEHXDUbJDBbGASUuDEoz64K8A3Y/Sokp/2FX88j9XUtEyIajFmlGoLVBAo4RKQ4h+3Fm3JbHnLuEMrtykfzOgcFiwnRauIKvcchAFXkVau3ZD5/bJBD1xtHHtVeFmJ5bMt275eGNctw9Smtco5O5y389Ovgp0Y9Mq97toa16hHdn35TUpUDGsRwfUjeM6EUA76LKCei+tsVzNoQX2o5+1iiKKIs0AguLiUkraImzfKJdRXaJ/G4KHWfXBtrTfX1BM2Cit+kvvqrOXUIpD8QKkDIq9u/1Q/W7q4S3+0okJEoyyltk/q2L3N0rmbv1+4etAVvawW9cfNuzO3HerbfVinLh2MsqwFquMZ6qnGRnbZOKg8jR8RsLqq8pNp82fMXHNjeER0hKVf94Sg3t1UWT7y2YJ5hw/vmJP5b/d7z730dIf4kLp1G/M/X5Ay9GZ7kG/F56utA3tb+vVsAI/EQe+zx2UtrB39fAPat6WvfVJW/SkaZTlrX9gDt3N/XxVA1oWJvaFq6QY5LtCWOqX8SL7fuu3W0Cg1wA8BLSrWUEVKimsxauCO+1+Jr9wScv8caBvnkmQVmBuJT9ahHR/OiAqL8LvzhoBBXYuv/7+ahCjr/be4AwKAUpN2s9wA3BaQcf+UgG6d3WEhvoF+lg8fdtjrJEoJZ7JbdWZlK4xF3DeBd88g1dVRj40rP5wv7T2itoj06DZK0COqFAkoQ2SI0jnZCK7FyhPkTMv6LhAIBBeX68kzZEamew44A0T59GGk2Lh0HvVqsNpw2jMI1TrWc+olJ+15TeHq3MLFIPkCZ0s6vmgixr629uIe/YGKije6ATgCgbBwW78BXRZ9vXrP9mObNu3r2jVhzfLdJvBP7RqV1jFG8TQWOHV4zEkNiAAoCA0AbiTkN2Ku8FK8mgbAH7cd+OqLhT0HDptwXZef333HOu2L8G7twcmqZs8bkxTad2j6xNfnfZm2Kvna3jvfnZnsNvm9/iTNy99+4Pni92b0T2pljArmAE4Eg1elaQMYs8WvX++OR/NLHnhNtfp3fX6y1L+PwyxLwDwjG5Xn79xdsmJd6i3jA7t3znvtzQ3z5mS0Tgju1lmlhKPbyNAIrC6vkFQ6C4D4Zx821DnRLAEyAgRkmjxqRGhSsqttQnBKXNhsWTUaVC5x/Ra4HKSsyiybeOeO8V06Wt0cjhUzX1/3kB6xQKwGCyDh4Kad0ju1TbZGhbtkA/UPDLrj5uCKCgwKcQMn5TVk9xFiM2NSi3qTZKm100OHwOWG5CQI8Ds7+QpAGHBC6PZteRs2bxpwRc82yZFEqCuBQHAxDLA9QggpentYhioAg1PII9Rn+rRQU0AkumuCMbdnf0LPsSu8fs//Zucv8vxGrcCVNR3+I7TUn+ejaryPFouhe882LdtFFmfXrF7xAwPHjs37E1rGDxjcxc9HcnFOtTVujY4n3mxXPLmZSUgkAOV8Lvu6KEYkqudqoqLADxv3OOzqbVNGpqRHBRdcUXHLqzWfzS0qK3VvzO7xxQR71/S4lYfWL1l7OMLs7xvY7pnrITnBGGJLuuuGmm9Xw487pNGD3LoPWF8+yQkg9zyOFrMcEqTCYbU+yuzr02C1MK4Sj6ICriomladPGh0woBfERCXcMNZnww9mBqgwkCSGipFL2Ws3FMxf1uGeqyudvdcvWNytfXvTVb3QZPSMjWIj46LD0WByUEYNxHLNMFVVESkQdIPqcDp3zZ5nLaxq8djdskHOnv5lZXVFhxsmOuODoKLm2Nof/YN9w9u34eEhNZk7S388HNutN1jNDdERhuhwN6iecVZ13c5vFtcU5/W852Zjj04VP/647/1pIV06JSe35Cd6N/mJol6bHMRmGh+1KoFayyEUOaxctf6t1+dt37q3RVxccmK4TIgIphIIBBdBj8AVxnMO5M+bszAmJvL6CVcT6XR18Ym2qt4zPszcmb1k8YrU1LRefTqYfQyN1vFsusobsl6zq+75RcuAmsFdA0Ra3+GlXrZUcWv+DEWFTfLIc0Mpp7ExtjFj+774xDeb1mTm5pSUF1cNv653717tGQD1bEM4AOOq57fGe+/dv/FPXYfTBrV8y97KygJwu4FTwKbib+cn+O5PVFQeUcWd9Vwq2LQtlRD/oqLK1YesgGXJ/u7H3vCBSvn5R5RBvYh/4OAeHb7/9ktnVEj6fx+EkFBgnJosod27BcYmQmyMAxjYHc6aGrT4GH2sCuFu5AbGlX0H9yxeGdBzBEGatXBlYueOxnYpoIWPo2wITG9L0tqA1cIY88no6JOcwmUZDAaPHAMj5pcUL1yJnVP8brmOGQl95f3K71dGdU6RYiMZoGqQqRYIb+DIgHOZUplyziUAiREwmKKjorM+/jYsJAjCQis/nht1z0TJ5mcAQhqUhg2biw9mh999W4M1IPuld1LatsMe/YCDkat6dCUSzsP8/bqn1k5dUTJtth9zl38211jmCOncCXwsJ4cVNBdVjVPDje8gY6hyLhEg9vq6r+dt+vi9z44dcrjtSFTGQNQOFAgEF4ePClBlSm5O6WczFnfqlHrVqJG+/sC0Pu+Um+tzfjmHC776fGndKFOHzmlmH8KxeVjMGdi2SXtenVW4FLgKxARq/Zoub0hIegYKOfXn+qi8t9Dz08/HMnhwzw/fXHl4/8Hiw5VBMf6Dhg3wsRoVLTZYy7LEKdEzJAHTKqno4pppuxOvE5S4Kx0bZnzTgEUmh5OBDOi+5CLQTyuqVGYER7VsyT/iRk4Wv/1lp4pdgQ0un+xcAvkmAGOgPzObCMEQWyBX3BhiMyfEM2AKR1SVo9kH3T9kBl87Bt1ux5LVBZl7o8ZfY0xOVLWH0F1Wvn/2vGO1da0eudPpdP30+nuOWXM6/P0uHhHCGUNCiK+V61PxnHOTCU0m/c4h1+IhZbnt4IE0PERJSrAYDV3uutV4rBAtZsr1qG4OjVHi5Lg7UZvKR64YDVH9elRnZ9c9O8sZHRDWLzVy2EC3r9XEOQQGRAzoXbtmXcE7M4y+tgCFBw/qp5pkjlxi3jJ+MnDVag3v00WeMPzQB/NSdh0GVYm7a0Jgh3TW2GCawbSay6SxYLRHcUvcmyuBIXiuFeOEQnlF1dx58xNbJmZkxC1asJAS5JdNSxIIBJe8jwqoJCWntHji6buCggPMFmD8V8qKaOYWWGpaq4cenxIbH2vxNWoRN2fDhD2vflG4DFAGxQ7MtbHL2z0C24k7cjEoquPKiiAmxsdec8PAd1/8WHbbUju2vGJIuyb/EiGcM9i/7+C6VVvSMlK7dm+rck68MzXeVBt61Ro/k6n3lf3TYiXuciOXOCqglwy+DJwLHCXmqjf5bJu1Jmtz5tCrhsda2po3ba3cs8kBSMG/dOGKtj26qultsvbvoxYfk8UKTEGuNlDZRGikT0DevPXFB4p9Hhqzb9rsFjFJvqFBoLi5JCMH7lDiwqPC+/S29u5mVJSesmw9VgQNzubFf7Dp2Wz2JwFknLtt/r59OrtkyU2IkaOc2pKnxIDRDL8eeaRN4LoBIcSGPdJM9VNhv8LuvcodHuIkxE8Ft9nk2yk9bcyozAdeSYbwtE//wTqnObSZN8kbHsApB4VwJSwER/RXF6+wbPo6YvidUp9eTj8rMi6fOOun/UZ1S8I0CUX0F7QFLxSAav9pSUmDHn74lvDwqNWrDixarDIGQlEJBIKLxkcFBCE8MnDENX2pRIjE8VcTHBMCjKsxsSGhEf1RIpJMUI9iBvb7P/SGrNfy3XWrSzcBSuCq3ND1HQmlroFtxO24uBSVtg6BBQQYx47p+eW0+b4y7d23bYjN6AYVkWiL0ujB7LznHv/kYHbuA49Gdu2OTCVaz4dEC35xN07+2YMMgQM7hnWMV5gWI3S8ueCl/vwgggPAgiTewedlZe3wCW43KHXXuh02SJOhoQaKpcVznald6grZunU/teuY1iI+tMEjEiQL52gyBKa3ke8YvuiJt8Z9k+13RZDpppG1AT4yBzPjHJkcFmC5YRyzmsFopMAjhg6g9Q1gNeMvMsGdPAZCoBy5TJlsNoE3oTuXZS7LcHxpL57mBiBwMHBOCwrZnMXlbftYTRbXt+uMA68giTEOmXBgFo6O8honlFeALaiihridgEZKqZsAZVrdaAQZ0VLfgDv28U1HD0MEPZgTu2e3MTZYoUSbWmx22nbHnkWL2erNqVcOI4P6EgLFc74uWrM58eqRxa3bNnALuqlZdkVFWi0WY6euqQbJtH7DAe658Ew8zAKB4OKBIBKJyj7mX+3hGhcfMUSQCAWLWeJaXLIWo84a02b/dv84ac9rswqXe4bAigOYsr77+2Ka72L1UWldq6pATZnT1WBPSmvRvUdnPXIYgSHQ3XsOPjf11czNxX42f0WBZpnTf1nOzSGhyyC7zSbl8vIoIHgEpFvLZdBjQNf4BRtf+2S6T04bXs3bv/n3wk/nu36yJg/vtGr5TxvXZznr7TfdOC7AamGACgfCmcqZ6m+x9OtpDp1WlbswPnmq1LJFDYCMBLUFItxodBvNCJwypiJyk4GbDBR+V8oKfSOi1QHkTdFJHJuFe59aUXGOKjBQlJxla6tWb09/+h/o679/ynO53y6Ium2Sy+YvNbjyftx2ZM36HnfeUUfM6xcs6pDeytKrO9OWrTBQtcPL3OUu27U394t5kcPSo6++8uiHXxR89W1CmwTaMoExfoKiMpr8QsIObNixb1du66gopbJ856vvJyYkF1XV/eeV1w/nVqv1JDk+4Jln742OsRFZW43K1RMXQwgEAsFF0Sk0VXfQK0Y0WeNTGGk8nupTH5836yB/I3v2zXveyHSVbavYAUjAWb2+20dmaujo3+qCfjt+5imThKJqfsdpTXX17BlLfSRj564pCfGRKucECQJjoHBQ2rVvmZHWeeOa3Vx1IoCkR+d4uzqUvKVIwKRwk8oNAEZPX9o87u6S1lfelmXwCEiekhhz310THnvstbdfOtp3UIfk8IR8a0BDbENOcvrnu1ZkF+bd+ujE4UPbNVSVV+3LiQwIVlvHoMpJg1KzaRfJdUDYVcX7DkfsPezbs4Pmw0PGCQeQG5843XtMOfz+TCW/2BC1fCdNT+npDuPWF/VW2csqqqMnj7UM7acg2h6fVFlSEFlazmxBWFBQPW8pTY413XOjS3GyJ7LccxfRjDbE148B5YSoWlked3FF7twVrvKGhEf+5hrax2Kvyn/6E2Pq0qjbbsRAvxMsB4XIbp0st4/f+cJHfq9/ZC8uja7G+HtuqYyO7Ko6k1vWMTePCvX3MRmBg8rdFKn2aBPG9XA9gUAguEjQY160PEQe40R/zTbjybVo9L2YlpFQOp2t/1vW6zMLl2ur52VwFK3t/rFY0HfxKyp0uZTtP+5e/NWaxIywHr2SA3wNWu4yb4No2TL+tjsmbv8pc9OGbVwLo2HIqbdR6FmtNC8Oawru0aaI8bKpd3uCMKQSGTiw03vvPPby/2Z9tWXDioNbI4+W0HrlwLwFUYSlhbhv9iVWleV9uiBr2/bIO293AkVFqdyybcf0L7veeqU8dvChl95umPlVSkqC4u+jEK1QsecienPuUtSz8R4f3Zz5uR4fAf3Kznr8ErWaU0ZfZTabWKAfAkRfNzKiulYODjQDkEC/mOuuSggOgKREi6p2evohU4ObG4zoctO8HCCSFBbisMg+qrt1aCC/71Y6oDf4+YWOGm6KjKK2QACuItPaCdN/cFDcRhp0/aiQouKG56cByHHvPOlKSzJZLeNGDQWuVRAkxGq2MMZN1AJAjcZAghaLj8EsS3ptb29yVE5AeK4EAsHvgDHWFFOqjVv16bYmG8K08SwnjapIZYw2bq9yb9TUSXKKe1UUAuNMm9j79UEw0fvG5va5cf7jFHtNznpzhT0/r2afx9657aDWr+8+/fzJKc656tF0ekotLZW7viDRe6H0kB0U49gzVFS6c6+qvObj97+oBWeH9I6du6SgNzunfu/RaCT+AVYqMYU7vSVHuEoJPWtdcukqK32W02KWe/RMe6NlzM97y35an7l34ZKaqsqb/+/uoR3ic955P2vmzJZWenTW962H9cb42HoAn8qqqh9+atmuZehDd/FInx7jryn+fFH51q22QQMbEIy88cBNGvbs3K3YPE8Y/uYVp7r3zWKwxkcf3zk4mAYFAYABAAL8/Hp3QUKBosTBt1NHUBnIEqutObB48e4tO6+8607SNT1r97aGdetb3XMrBAYQ4HJMdEhoGAfkBsrQo7P1J1UL20SmhZ1XBlgscNAJRDHJRJI4of6+Zv3zVX3sxnHb1gOFBWVbfsx2K+51a/aVlhT26t01MsKGFKhQUgKB4HdrB0TcvWfftJnzBw/u3a9PN6P8S+nDOeOAB3IrXn75lf79eo+5ZmhuzpHnn39/0NA+1429ErXl7r8wy4rKso/kTpsxOzEu6fZbxhBknP9KghdyYj+IzdIQ0VPKqWmFy4ArgBI4Ctb2mG6Tfdr5xJ/P3gy5XgUfEDjRkiJq01K6ogRCVDEtcKaKSteknHOrn88Dj99278M8JiYiMNAMwAiQxmBglYNKCFJqNqCvRE0EtOJ0nHneQtqkuBlpPrd30kzU5YPnu1BKwiJtg0KD+3aOPbL1+4bs4vRhadZQm/W+m5UPNmXf+1rMsLQWY4byEF8bMBLo3/JvEyRKISiIA5ivGxkzpB+3WpBxE6KqVSaQ/qxLdIpo90Y1RsjxIjCeB596/nkUpdWvU+eg5Rurp30VWFnjePMzS2pL37RkRkEGRErBQjXpxGXOVfSYI8rBRZAhykBg7nLzK4vt/cap+UX03x9aO6WrKUkKZdTTrvRnmCOSr+YtXLJgeU2d2a3yzz/7RnXnvP32a+HDukunHdQJBALBKbo5QsjWn7bM+vA7A1q6dko3+vs0TsM1bsM4Y/yHzZnT359dWy317d1n05btsz5e4HSbBw3qH+xv5vyXgStOp/vg3txZH3zdqVu30SNHhYacN5M0ec+b04pXaH2vHdzVq3vM6B3YDs+ryWOe7y+pFRV5X33t3JHd5tpr4Iruam5e7szZrNaReON10C6JnhQnLfjtun56g7OYDZ27tgdETweqz+N5e1VOgDjdvKi4qiC/xtHASopq8vOrbDZfyeyNbjnRh3nZ+aV+5UEFToji60MDucNYW2GlKnAl2N+nFqQSKLEaCBgNyF0ABmY0GMJDFY4qUyUicasP8bEyQMbYJZn2VJICWrduN3rU0Rc/ali8PbR9VMSkcSwkiDeNaTxDNQYcCRKuFQdVgXGUTYB5O7cffPvjCJs14en71MOHd97+ovTO9NR/3EWTIpinsXlapKrVXZ44aeygK/orqlnLnMWIWte+bYosY2PtHn7ZNzCBQHA+xoweK9GzV6+np1rSO6VYzCbwJhjmTd0XQUII9O6R8ewLT6Smt7fZTD26dH/6hSfT01N8fUyn7N7MJmP71DZPPftweFhYYCABYOceyn1r1lsf1+yHhnzgDBz5a7pNizQFtbRGnXdlg7qc9LGYY2OLPpyX41LiokKrN/2U99WixBvHQUSoCxQDpyhM7BkpquMNDpl2z4g30o7oxf/17h7LSqs/eHvW8kU7KvOVmflfHzm27447xrdNjbqk06CfD6jnqVSdCldduluv3r577nwTFCZOubFo6YbSNWuC4q9v0HSGgROqAOFNdwQVAqiVVcHTxDRetCgAtX4+clJiDdDoo0tDBzzkatcaJJk1Jh3VTBQwh6Mmr5QYDXKoH6Oyu7LcmVfgXrPJ3yS1+MdY0jlDTmnl/3RR9aYDUlYOjQnmRgoc3IQzBAZKcpuo5FaRwDTnHWcEUaJ6wlLWqNrE4y4QCH67g+Ocx8VG33RruCwbJJk22pDj6aC0VVSkRYzflCnXyrJBphAbFXrP3VcbTbKRwskOKr3bjIkJufHGEYRQLcjzXGs6eORU4VKPllLt4K5Y1X1Gb1sqwQsy84bAKXA0GkM7pynXDst5a7axrqGmrCI8o33k8Cu4v1U0m7NXVNBUEaSxNjYyPfBXm7kBEmgLmHTj6OHDh6oq5YxZAgwR0YF61Br/NQfVZY6Rc2SMA3GhpMiUOFnZhvVZM2d3fvMenxGjKnzZ5s+/vKFda0v37sC4R6tSpnlbqR5TRLTHmMAvMnheAsgAQeUVFRs2+DfYWb8b1v68t/vSn6TB/RgFlXDqNU/InM7clcvkrTkp996MAabDr3ykutTIiSPjRo1yBlgVq5FazMl3TVYmNRB/X9VAVE3PG0CSvYUUVSSEEqbl/kQ9e3+jHRRaSiAQnIGoohKVJQr6KvXjq9Abq2A1BhT5+1p1M4OU+Pub+enXqSMiIdxqMWnTOuq52KPb9739YcUOcJZ7/nAWrur2caIlMtoUcoHklPf0tfSFSkiQ77VXBe/LITNfDUy52vzkuIZWiUiJWeXNiswJzlRR/SJMr9l95AAmkym5VQLTS2sDR/Rm18DGrBp4fNtLDH7C+f9yGcaJFwhPlvmInKkcKTKkwCGAkYm3TsYJV4HFkva3SclR0VBarc2jIqI2c40nTlfxSzL0j7lcudu2H1q4pMfkkYbRV4fd/8+CaV/FJcRCSkLzsRz19UtMS89/d6nju2UH1erqLXsy7rzJ2qqly9/CCJEY9VwVm40EKEAJEiJzdCDajxU01NRbI8LM/j5IUK2qKS4qtPr7+4aEEioJLSUQ/LU5wWHUVEnid3mqtL0bx7NNC4Eaey7mHbXp3RpvlB2/liLZ2wPqUTKncmSdmHaqeUfT1KPckfX2h3qRPiTgKFjR7aM+tjT6O7XUWYfbcG2WkoLMaY3DWVZUGgjg2lvCykttqqpQEZJ+jooKTyEdTtAQBBsvclMT5Cf+rrfWxrK3qGrL8y/2zo9xUD1NyzPCMABROHcjSICS7qfTMhqo2qWgp2qTKiLjTHYyk4uDLEtDBjBK0GjgHIytWxsTEvRnHak+s9esqp6egeTS1Abc3mDPzcdB/aXrxyixMYZHbyn6brGppDg8Kc5AjpsXhRDapo3j6k5HX50RXvJj8HP/g0HdHIH+HLjEiXe1DSUSkfUr0QCMAPIDhdtfejMjIsTywkNuP5/q597M3bMv5ZF7MSRUSCmBQOipxtV7etZxLU4Fya+IiCYJpiLT8xJLaPBaX+/wVtuEcM49x+TcBSB5FI70e4Zv2FiltFnOm0a3F9MWLzdt1PwsEeDOfe++X7IZ1Dptbxc4y1d1+/gM5NS5XEYERevSpKISOutry84c913/p+w+aJy+wJCUIqW1Uqm3IIrg7HxUcMaK2JtdQVdRHE+9NV7U/imt85cQGVDOFVX7MrJHuCNXVU71ki6Nj8FJX4UBbxbO4xnaqEajSj0CQfdfgcmEpx84XLqNlfr4tBo7OpEiWsxUopE9uka0b2swW7QmgU3thCAYjcaQ0PCSErcTIDokmBuNbs9FJcSbIuGEkZuMRAFu6tIuuk/H7P/MDOrbhdfW7Jn9Xbu7JvimtERKxfMsEAgAOEPI3HVw9+68Ab3TolrYflOEafMqKGk5E1XgTBu8HR/ieqPU9bhWLZcz59ow+IzA06ot7y9c92Nxz1id3rn37ffzF2nvEXAUrez6QXv/hEDJ9/zIKf6bZ8cJcKWuYf/adTnfr+h4w+CQ+24tX7lm5z/fKJk/r33E7SwiWLSzkxG+u9+4Ps6S0mMbfqg4cIi7VAXR4FSLduwp3L6L19kJ93qGye9WP3hqZXnZ2TOJuG1+aoCPapBlDsRscoUGun1NCnLG1aZHmgI4KypLtv0cMKgdyH32rl5Xf/iwxDltjMTnTQUZ9BLKWuJ4bjUmXz3E54p2R559P+ee1yM6t/IfNYSF+XFREkEg+MujZdLkNTU1i75fM/WJt5Yt3WCvd/6GWdbIPnjoXy+8t3njTu5i3lznzTL3cQ6MQX5e6VNP/GvRgjXeRE3nQ9UQgOMVaFBbT4/09r1vvV/wveZaUzU59X7foLRg2f8P8E41nhtXQZHr7H6F5clXDggZP9oRE27s1z1pyrgQpxvyi1TR1ISiOoshhbmwbOt/38waOpGu3WACBjPn5mWMPDZ/qVNVFWRaRUtgv1soNRZ5apqGv2xblRnBCmgCjkQ1APPjkolTSignWkZPBCdFV4OzYPk655GSmMfurF38ZN6RvPqZ35FjlSqAA71OLM60mVfOmVbDT0J0A/DWSYbrrvE9XBYOmUmjr3bFxdYRAxcNViAQVlubHHA0OMrKio8ePbg360C93f4bIowxAFi8cPGLz7z9xeeL62rtjcPkZrpK22zxgk3//s8bM977vqzcqb2lNM7ana2i4kBUoNrwUptEI3fufRtXj/mwcKVnCOkqX5Lxr5oh6/oEZZxnLYUn/fulDUcDEBIaGHH3zfFTH4b01iZwWVpERt93T/jzj0NGG5lxMYQ9GUlcgt8gtXX3WydlPfjP4s++NlZW7Zo9r337jkHXj2F+foyf+TQy/yup0WbPrnfBjOZH0haIaOahvt7kaEi8eTxt3yrZz9zyzrLKo0V19VVGbqOIRE8/dTyck+tJQQklhoM5VYtW2MBSBy0Ofv1d2y7pNDEeJdGYBYLLHz3s6XS5nbiWO8pms/Xv1xd40IQJw4KDAn7PoUYMH8Fcod16p5n8rCcHpCCiJJERI4c8X/Zc504dgoONjLOzrl7hPVHv0idUwTNWBMDbdr/5UdH3oBd+cVUt7fLWFbZ0huT8BjSw09rq5nH43ggNpLJKOEdOPCoLUSaNbwlBJRTVWUDR76qBSfuyC1+fG/npmpCUSOtrT7qTo90yMx7XB0JO/arHCrVcB1ocPzY6t2UACAyIGn+tQqlTRpWjcdK1oaoKkqSn/2ROl8IUWZZVA/VYHYeLMZWajMYGfvSb5aHT14Z+OrWgsND0yCu88xK/yRMg1AZi4k8g+GujjcLAKBuGXdlj8LDuBorNq8L/cuCnl39AVFU1PrHFXQ/GENRWsnN60pacczU0Un7oiZsIoRwZNpXtO4cxJ0dQEWTEm/e+PT1/ERAZUAZ0fOEePardCLRFKagtzDkvY9zGDkg5lbvqF7ErjCNwSghXgbs8IoxKQCgw4rHk9BRaTCAU1e/BCZwQQ4u+vWu+W1NXuKFtz5GYklhrkLXgQa2miucBdLsBnUCMnOqVUpq3ttOJefyLuKiaDJ23NGGzTBqUgIlob3AJOKUUJKo/8AShfO++vPkLW7Vr53PlYKioLJ3xmTMxKuLasbU/blm9Ymm3+662D+ocDcZ9ew8sWrSsb4d028AeKIngdIHgEnU9NTcerNFwNvlT9MTAHJFo6aJU7unzaaPa0QyLnjJKd2tzJhGUgHoGZ79jCZRe/VcmenT4qTMheIbXCB4z1VjP+PeO4LyJFhr/0BZrcUAVgSGXOb81653p+d8AMQNXgTWsDn2gb3wfp9VIoHE9HZ7LZeWNfRkzOAEdikFVVavJaaIG5iIOJ3GoYJDBYuV6TWjFCU6FuoFbLZpAYEY7Q6cLLDI3GgApoHBQCUV1DuIAOeRs3VK5KzcJpE0L16feMlKKjnRq684oA+Seh1FF7gLV4Hl8CTk5MRX7S8mpk78invY7a2aQc8BmpduZ9oJ/aGhxdV3e028lJyfv//EHdd6K5P88QIEFGOQxt91kbdO2LjCg1mBIfuT+hG07DQaLaKkCweWlsPAX/iQ9L4Jeb1hfHMeRnHrR+JnXjEXEX9Uu2NytdXYm3JuOgeteeI/2+7r4h/E7nwZq9sgppMDsq5Ke7RfZ3WHgDIikKarzOLZVSsoWfTgNC0tHPngfSYlzFRYsfeddU6172AN/hzirHrxaU1Gd9eXshgN57e+8Nbhtq7qi4qzP5tUVlna++6aAxATRLoWiOieMHGpWbM5/9vPkET0dVz0KL3wiTXrR8t2Llrgoe1mZixosvr4OHyOrqDWXlhnCgsHH4pYMqFVD0Qv3cK3+zK95qwQnogWZczUmvOXN45fm5kV1vTtEraj+f/a+Az6qKvv/3Htfmz6TTJJJL4QkEAKEXgRBREERxYYNdZG1d13bf11d6+66rmV1F3VXRVCwICpWVhBEUKT33kkhpLdp797z/8x7MyEoKmBw8bdz5SOCk5k37917zve07/exicH+vcKqZBnURwPaDFwFlJDwwiy5KAdREBIfs4iv+Pr1JqhMak2DbidynA3S43ZGUwjBkSOH5qbWurpWq92SnOwGgZRirKpnvtJU0DO7pMLQngThR+FUh7zmsAmiWGcIRgtuKBtMDOLDii8vXvcQMJs5Wrcg5dqhnUa1WljQsGyEdEATA0blJcCQsqCYkpjTtQt55D6oDmtP3df6/Az3k+9mvfEIZGUIEJQTQYnmdhanFS3/w9t1DX7vPbfWfPklfXT6iLsup7lZEA6DLMd3axxRHXuQpG/bN3/m+5buSc5JF6T072Xbd+Cbu59P+mxOwfljv/nok+b/LDj9mmvk7sVrps0Ir1jb7ZG7rI4I0qeHpHm/Yzi+98f/eZh1WNMhAC2FBfl9Snd/+FkW5Of37hmyO8LG5B+AUAhlsf5JwXUGBGPRHIl3U8VXfP06lxC4b2/lyqU7Snp2ystPNek6DfFzgUQEg/qa1XtffnHmgv98e8Elpz365+tAwK7dletWb8vOSu/WM48atUFTHE1wEda5KkuGktd/WdI3ynBtyGJwFDoJzan4dtzaB0ByAjBA/fNO9w5NH9qqGL1VCO1S9j+PtjE6qojRSqpEe4w6Fa/43adTPjxJJTvXbe5x+2UJF5wb1nWmSKY1RVXThvROv+uCA3+ZktoYDNXWOi4dRi8Zy2mbyY2vH1zxsP4nlk5E8eDBxQ/dRQf2arTb1YvOSZ32iDU/V9a0HoMGeHc11D35SsPk1/3vLyjpO0T1eVFCZrQ2miwjxKiC05h0bzxLdVS2wL9t2/6Nm5PyezYrfO/KVXpjEwHKgMqCqty0TUQWlFEJ203DxOoC8RVf8fVrCarMAJQGA8HZs+fcNvHPn81eHA7zaKJKIAoRDPBvl2/+w/3PzH7t2+p94cbGiFVtCQQWLFh0wxUPTnv5vdYmv0lngCDCur7465X//McbW7ftQ6D43/tabR3fxveIfJt3axbZ5pwybsPjIDmAiDuxJxa8PDj3pHol8hoJQYqxNtCfzWFoXoBk/GIAyJC7VbzvavmkzuG3/u5wWp1XjvdLcliRSFTMghAg3JeYdt5peV1zN33w79R1/qKxp4ZyUoOAOou7r3iO6ud5dTUvKyMvy5DLEYoQ/oz09EvOVQH8QrcmJQ26a+K8R54pfGh674m3SReMEFanACEdAU5tx+gWX99DsSbNQmX19mlvZ24q9019dNVXC6UXZ6aVdGWDhggXFQSpLhttqyIMlAqInPRYWBeHU/EVX7+65JQZ4cuK0qtXt9PO31FYnCVJDIUgEUghWpsDn3y47P67p1WXlUmyxrgsGA0CSJpS2DnnrPGDuvfJs9jUKBAh2NzYMO/zhc//9QOPOzE7K81i+S/x1eHB38PA/bp/fs3Ki1feA4o3AnWQ3eUd/udO17XaCOPECRhigMRU6YrckXCH+QgDKxl8PyECEkfe4q8FEA3NUlMTAxCc6AwlQ9nDQHWoBkRDXTMCtPCgo7FJ0sMhiXJAKe6y4ojqWE9BZOuEKYQAFBGWgBCklBFmijFRQ2SmezeS7BXrQ2pWKmhSJKDCXyGMP8HUgJBEbvLelasrtu/od+3FUNKlp9tRPn912VffpvXuw4idB4LQ2CxkRuxWzoD4Q+gPcLvGNDVOoPC/c0jbaubxR/5/ZjHGBg7qM3BQHzAV+YAQiv7W4Afvzb3v7r+KGl9BjyJGpXXLt1CINqUPHNR34KC+ZqMVCkCKukC3x3PqiFEadDpp0KD/Fpw6aFYJ6Kh/VLXk/GW3gJIQgVNEPAB9Hky8AkoyG6mQgDECFJFiR6tqHPpuggCta97yt8l791ScdvYNa+csr/rnq8m9ulNZEbHOeQRsrK5eO/tjy+aK/ufduHfphq8/+qTHwFKWkc7iR+1EQ1RIIg81yhpyojlzU2hA52ECYUaAEIkCDYetGPkvJMRPOUOQDUFNmUCwtnrz45OTqqH1tIkrZ88p7FWgjDwlrMkQrfWZFXFyWDdw2O1+tIsb7yaZJXKzizMa6VEUSKKqg8T4t9FlFCNqNykfIj9kELcRHdH4vsToUQKGbSnnQ7XRo9f8fYI40qGOUjYeRVrfUm+fnprH6ZcILcz3Tn1G+EOS0xYCpq/bsvmOR102Z96j/w+L0lr/Pa3m1mfp64+kn3tGSKMSMRPdbW2q8fVrREo/tsKAOqAfJApoNWWLDp1LwB8g8MB2c/nxdSJlqET0d2L26nDTjhnSqCSs89ZW7ktN6Xt26TkXjpk7d+Gq5auYQMWAYAefLzWMGhKZSAA4ZGjxkKHFbbJ9v0SGLVqtQ1PSNUwpA9CRV4Tqvq5Zd8mqe0FLhQjoE3e4Rz3Y6bqAmxFAJ0g6IKGIQA1/HOXsYz+H7aq9xzWBEoEmKuSmQMWsz5v+NePC26/1//HWlCdf2/DgFK3PNOekS8M2lSJE/Fxrs5izAF982/H7i+GGq5o+mQV/eJHkvCXdfR3V1HDEKx6F8FocUf0PL0I48tC+vequ/XKPLtzrwZAf1u9glY3Qt0h4HREnTQyiXJCkQHDDrM/Wbd923u0TSXHOl/94affUdwtLesjZviAhMqD0c+QJjsz10JieDTF1LaMNiAa7OEVErgt/WIRCGApBiAMPga6DjgQUNInkFAU0FRVCGSWKirboUAoe0hUpYk6O/AIZgXbpQTnRzQhB5IqgSIC5XeCMAj1rSRfH1Rcuv/lP6VPeCA7utvj1d0ouGZ4+ariuMNnAjhRI/MT/H8NZ7eE9RSChsBoOS5QxjUbCe4gPe/6qFz00RotOR1MgAoXdablw/OgePbqmZvhUK8z+uFXEdOgPY8RJNDpu66c0uaZ+kV1KYgU202ASHfisqkUXL7sd1ARQUyIOV7Ldl3DSo52u0W0RBEagjfP4uPfOM0DS2Ly7an/SPdc4rrsqZHN4x4+yBmrXVO8/qbpGsaUhCEEg5A/sCzQnXzm264QLIdmbNexU9YbmXa2BzMoDztwc0XaRGEdVcUT1k6EGwoHtO8vv/Xvnu69MHDu6duuWpc/8uyDkzC3IBK+DCSFIxLtHHLY/nEwsI665Qh05VE+z9Jt4kfyf5TwUproQctRCHG8tyTa58jY/E2JhneuhYLAp1FzTVFPZuKeu6UB9S11DsKkl5G/RW3XgnKCKxMokl+Z2qu4EuzcxMSnR5U3VMjXZJsuyCjKNREfRlkgenWqOVtDx+B8jU5kr8suILiUESUScaTS7gMg1LW3cGNv8b3c8+wF78f2C0szUSRNanCqlqJkXG5+g/L+bvCJckD0Ve79ZqlcccGWkJgzopaWlIKNxG/9/BVFF/mimyykxMRLa3GrfAUUIuKeiClEI4PiDxuN78OqX26IkCvtNoS3B36tafPHyO8CSHrGjhNyrDXks5WroZOOGNWOG6obpUI7ThWI7KsDIJXndfSdexFRJ2G2cAOmc0+Xem0kgJBwOCQQnEQxqczoKzzlHYlS4HASJkp3nu+EaHgxYLDYUSGmc3zOOqI54+1FZ8nXvUp6RsO8PTydyJAtWuJZtd/zp/4UyU3TBVXOizCTl9dh9E88zDT1F4RwyFIYMNeqG6ADxC6VFiZEsJ5TTkJ831/urN4e2rt+/ef2eVRvLtla1NGFrWOHMK7vsmkPTVFVSGZEASCNGYFdjaGNjsLlZD4CMTKbeFE/3tC4FOV362Lv5VJ9VTragQyYKQQLR3jCzzHjcAz4OwAkJoZARVI6tEKaMMWJqLCMTIkgptVlTLzl79fyFfbZ/6x1+GZQWCSKMBCLV28lDxLMW/1eOZsQ1hCJgmelby/Y88JeGtxY3dXVs2VDZ5/qL0++5jqQlY6zYHqfP+PUuAlG4JBmSVRglTFYMainz+TIiFAIsFjmdUBcPOiAH0orBfa2VexvKLlx5G2jpIBiQxHt8Ax8ruCYgg3ZoyHdcAQoHCAFoxvGJWHFVUZMTiTEPaUHQKbU4XcxpVsMN1gZAoTKmanrEhAYj0JZIwmEnDjtGfsoQoIlP/sQR1ZEvOSm504Tz1t/7+OZLHgyD1PnhqxJ7dAlJVKKEGeUnjMkeGAEAGnUxAOQEdCKU4wqkDpEIjXy2CKK/IVRf3VSzrXrb4jWLtpRv9fOQ1aYWeQuG5vqyUjKSE5IcmsNht9uJTQO1TVM9AMGmUGOTv6mupaFyf2V1TfXOip0bv922/qtNC6zzCjsVdc3tVZBcmGBPTGAehooU2SpmTfCHuLY62DYxwqC+vnFnueJyscwUIfTW7XtcQYSiLGZVA35/5adzrX4hoHj34mW+racovYqMaDZaBI3HUb/yhNShKYcYUbUiYN2KVdWNjcPfekQZ0q/q1deDr3zMLx/H0nwnoIuNr3ZW6zA5pPbLrOIh59VV9Tt27s/NSUnxudGYe6ORXwQP5uMRo9Ed/JBw8n8FVQtABiSM+sdV30xYegsoiRE4Ren98sCHLBOgODWIQhYUDIkIGsNS5HgbUoQYFwMxukNIrGctdvtih4vEigBAYrktQ8uCxro+SLyZIo6ojnL7EZ1ROnJQ0Yyu9dv+ZVMGuvt1C6bZKAWZCwwGI2daVTiTJJ1jIEgsGlDGolJURlqEtmVxsEM9DB58S4NVuBVbahoPbNy/ZlHZgrVl6+v89QXeoqEDBnf25XfyFPrs6R7Jc0iOBg/38J0ALoC0yJ+qW8vLGvbsqtm+9MC61fs2f1b5udeW2iWnYGTiKbkpnVOs6Rq14MFp4PbVP9KRIap50YgSoWxP7bcPv2RRSJ87rz3QWrfuiReGlAwgd18Asqj+5PONT7wz/LqxLaUlW/78L+vf3kh8/h7isYeNtnQaP/i/ciQVJcc56JXNOQrQuZ6en5dw9/W8tJvutDenJ1scGkWzShy397+GB3twJqnNtBloKeLoeTisf/DRvIdumPLAU1dPvHYsM7IsIvZaRgQlQhjK6wSxw83sUX2d9kGbufNaUN/esm+3v2zCstvBkmVkrMjdCac91PX6sIxB4FaMqsqYrX8dOyXBhcC6BsYocdjBbB2rbyCEqDY7MjBEEGkbhhMkcmMZEipijiv2VSgQxfxuqCAREugqQEw2J17xiyOqIz/maCJ6EVq1+sDeMgW6ihBvXrvRXtrVn5Qk/K3h+V/rDU2uwQMgM6l57Xrr4jXknNMh3QfIDYE62sFEU2ZQZuSiDI/BZZQoEj/49wfKv9w/b+mmVdv270kEa6+0viU5PYuzuiVpyTawMJBNZIcoYqHJdy6HG5k1ZjASR3nkvFaf15pUnNq9Pww/UL9/d+W2FXvWr9+wbQ15rmtafp+ifoO9Q1wWj5WYOWJOmJkTEACso46ZIZgQbTBGFLRLTsJlo3fe90Tz5Cn+2mqn1w0XnUrcrsCGLTvfnK2c31u77jLI8iXt3bHtqY/Jpae6ThsaUKgFKYk1KBjSX2gyMsSNwQl7Ck3xEUFIOLKfqBSJpDnFaHiCADqJISaJJfct4QbyDq3ZUDN3cXrPIpLs5axNjCS+TqAlouNvoo3eONaFbZxKIQxoQYCYuRMKjGXnJp85oXdaZkIERzMSpUc2WjoJBBCFGc0Z/wOF0WxJzSZP2m7q7vhuWM6NT2oTZOEgcRCfH/jm3CU3gpIAWgYAS1HyJrqLHut0XUAOK0itMcY8kyMhspt/RuR3yEysYcebQ8Hwk5N1QhMnnCN3zq+vqCR/ncy6dNIuOpu7nDF1L8NTGTeQm6RX1NRWPTjBTeEQnEiMJBeJ09LEEdUxbFAkQPfX7PrXNKZj0XP31C5atmXG7M6F+dLpwxiRKiqrVr4w7dTWkGVgj8UvTy0oa8kZNYzAkaS0f5ZRMvwNYUA41auDdevL185ZNWduxdx0d+ZJJQOGFvQvdBQkQCoBiSJtm4ciP3oIiBkZmogrprgOEWcmJwqLz51W5Cj2agWJnvWVYv26jeuWblu5KXvbiEEjiuzFdskuE0LMkjohHVpiI22nmiDhMhSNOz3/q6Ubn/6XB1y933sSMpPCCAJFvyGD5cG9eEEnrtKSy8eHUzJaBNAQEoWZvelmW0AUNpN4IfBEj2u4UX8QBLlROolWlzEqz2ZygTCjtSZEjbLEgZq9U16XKg64br+R+3wIGE9RnYiIKvoY20aRWXvpLQIYDPGmpladC0qIZtE0hzLylKGD+vVWNQsxQHIEfhhq6sKoVjHKJGoq94lowMQFUg6U/oLPPzqgh1HVPqYDf6/q64uX3gJWIzVF6K3eEU8l/RZ8Ko+ECRI3+VzaCNBJB/sLRLBoFpdm/+CByfmS6DpxwjdTpirPTD3llT9zVdWN1l4lhsF4m40lcAhDDoHv+TH6XdMcH/qJI6qfcN8YhS3ByMnA5jWb3NO2eKf9Tr5gDJYUNT7wZPDfs9xFeZif6xk/NmP1+rp/ToW3PsmoqXU+coeemWbkoiltN0/R7mCLnxe2g8neZXZv+UOhnc3bZ22dNXXNe0nEdmnJRad3OaMoqRiiXHjUaCFCPKKNb9KdIBKiC6BCABESieXRGW32B1cs3/jY/TP8deyzpY9uy9788Yp33tn1wacVn4zre8ao/DNTrdlekUQwllDquDMWVe+JNkJgSNclp0eCBIQwJ8gkQoHZirvR4m7CYFe3IEB+vpqfrxldGA4OYYphCgHgEoAVpLBxjVKUSZ3ELcIJmCTmBHWCLMj16mraXAc2h+T1oqJGAgQBwDmvrtWbW6jdTl0OXdOk8srtTz7b+PXqnvfcqA7vrysyRB67FH+0JxacEoIA7tuzv7KirqA4zeG0Glx5RtsCw2AwvGdf1ZoVexcvWldfF9QUqaAo96RhnfLy020uRo3kstn4A4iBYOjA/qpAQK+qbWxobCYgNTcEd+2oCOkBt8ue6LXTiC+Tf4FZFCNgY+bH6CA4wLKGzfXBmouX3gxaBiAZTDsPSOv+16JJBwAsABpIigEAdTA4PCHKENiBOR9TqkcGgPtvclbvIw+9w3fUeKe9Lj9wl7jg3GZNNu+iTiKOhAEJGABXi+I7Ir7DAvqjbiN+wOKI6icMOsb4T1SAsK63WqwZk69zjBgACvWWdO1+8xXahi1hHqLIXQ5n39NPnT/nK+vKT3pecbdSmKfLksDjgdzxIAmUgZRqgjWLyr9cuOyrrQ07zssaWZzbI5N1qdmor9izLT3Dk5Bgl2SJCHo0bx8515yT9Ws3E1nq3DmdKowQSoAGWgLz5i557tnpy5ZsdbiTGluDhb7clDOu6rq38Msli75ctLi2vOmUkuFDkoYrikrNIjzp8CeDkaguxPfO/XrnzI+6jx/i37dvx3sf5Odm0OKCMBKZo2BAKSOAOiInROG6oJKgIDc0tVYeoFZF8qWEFGTN/paySquqyKkpXGE03l55giWGRXSClLQ2N2+d9ZH04hsJIwZ7b7hCy8/XjY6T4IG67X//F/9iRfqtE7xnjgzsK2t8+qW6p2d0u+kKzeYIr1jHCjLB447fz1/02R1BjVUIoYfDb8x4Z8o/Pp782kNDhpQKZqQbEYIBfd7cpS+9/P7qpWsSk+2JiU5/IDD/y9lTpiZceul55553Ukaeh0QTzUgo1NTUPvu3fy9cuIXJlorqJk22L/xiw6Stjyp2/cKLT7/o0jPBYHz5ZU42MRrjDWkyPmf/0rOX3QiSAzQfAN5tO+lP7iuhKBmDIZuqGKIy0fgwsslJLFve0Ysag3iCkGHjz9v2xsJV057MgD6+yy/UZUpDIV5dwwmSpCRghAOK6hquczXBSxQJo11VR56EiBvPOKL60QgZY0lPiqCpcuaQ3jCktxmBUI/NO240GXc6CoFIw5z7G2uYQ0qBwtbaJvA3gRBAI+HU8Ut9cAzvbdz7+eq5/9r27yxn9rknn1ui9F702do33nu7oa7e5lQGn1J60YWjOndKMisjRzbkQs0KZ8AvJk+eTjTl0T/eaFVVLlCi0sa1O5788wsuZ15WZ9HQ2CoTGTgkQcqYzPP6OgZ/uPPdz1bNWV21qrV7a5/i3j45gwrJaFMiHZI0bMsbCkJCuyp3T/nQ3T0v+c5J+yrLtz8z2Tf7M0emj7ndAIxFAjMkiJLJBEgVTjAMhFXVffPy685woO+1VwU6ZQfnLlo6fWaXM0ennXOarlIlbhFOpCTxQSUZBNlmSXd6WtZ+0bS2XOuca0nLCFo1RQjYsq318Wm5UJeccAtKrOw/81rfmN8FbLUr1u3YtIGiKHzkd9bePZGak0mH3/ACo511Is6p8UshKtO6ZmdlnXLayZrqFCiB4IAgOC5YuP7u+/5mVXw33HL1gCGFiYmuQCC0ddPe2TO//ev9L1buqbrj/13u8zFhEHUaU/2EyRan2ytbLYk+n9TDApzwQKtq5ZKsYXTM7hdyGuYs3Od1a4LhprOX3WrwI+AYkVeQ3PlP6ZNCXgUQqapoAuih/QaiQ2jQD3tNxGBDBmhWCUtSnTUJDlBDGFQIB39L+YyZtZX7+0y8Uu6U01xetvvf021ul3bVJZLiNDrYjrz5LN46EUdUPxIfk2jAYQoemduKRYtDSICxSIzEgQhOKRXgX7t+49S3C4vyHePOW/HR3KJ35ydcm4FJ7rYf7Wh/QziENh9YN23F68t2Ljst5+TR/cZkKMVvT1341z9NGT6kz+mjhq5Zt/mFZz8SIeXuu89XVYpIjxDZmC+TJFpf2xySrIxJBDSJIiJabNYzzho6oP/Jzzz1xqa1WyP3iRIkAgUku1Iv7H5ZrqvzJ8s/ffCbx88Ojhzf/cICSwkTHQRUDnKmExmxkeq+sYOyijtD1yJPQV4m5w2BoAZhCYQeeSAEQWgIOoUQIYoxWkOBgC9RzfW1XP94yJMOZwzd+cAz7n0Ntntu0S2yDqjGD/2JdAhpzO9yQFnTUgf02HfSBXu/mp0xbwkdMdRamE9a/eF1WxH2Wq6/iXQr8kvE2SXf+sSk1kCYCeLUBSFAkrw/EjwjAcKYWZ8mMfqQuFv4uY/uCOwMo5RI0tjzzjpl5EiP1x5r3iTllVWP/elVytR7H5s48pS+Vma0igLtXpzfq7SLNw1nT/mqW2nRJRMGMxmNhLrkTU688dYrWlp1QhgKJJRF5/wZeBIsiiJ+qfHeSCDqJzC3avHYpbeBpJnCMnfahz7BzoVu+ZxyagIuBGr2YhDQwdTFOq6xScSkW+pbV7zythQSOVdfPf/FD/o8PSXl3ptEgs3L5OVPTMlAW86ki3e8N6vl4SlFT95FnTajWmj2WRxR4ix+cOKI6nBJqcg/Zk9htCUbCTVlCyJ4xIwqzIiWmPNySAklzY07vpivW1TPpMul4hIr4dVzlzrPGSknuX7ONjvcVLEwWwbDwr9h/6YZ30xbXb7+1IGnX9xnfDqk79rTsHThsiG9Sx546NaCfO+qNXuWffOnxfMX7bt4SF7n1Bhb1GHfvq0HMWIU9u4pr6trbm6hrU2Cy2LVip0uh5bodaWkurp1yywpua6x0S8xaJMGjBhCY/LXAa4heSen+zJDi4Pzv16iN/HLB1oyrdkWYUMC7ZLaP+eeoMkR4czPdnXOifZdKvauZ51pNKOGBAgUwhQeMRLWxoPiQjJctG6znHTpRZUzl6yZ/HbKN8sqVu8b+coDvGcXXdcljPMqnFApqnYI35wlT0u1Xz42+NU8febKwMUbtPy8ugNV+xZ+44QsdtrQUKJbl2jWoAFs0CBsn84EQD1EDne4OEXNHw7u2EsbLdHhCyLid/4oTZShA0raKKAoHEJQgj9y5BlBO1A7pVBTZSR3uA7yt59+sX7e1zfeMvHs/GTYFonZyoVc2VKXlJWTl+e7654bVsx75OOPPhp2akFmltcMbxVFzsz0/fA1hjvkXB8OVYgoq3kMUcyvXXlABC9cdgdoyQBBAHFL6hlPpP2Wu4CTsAQyi8Tn5izfIfucHE2w/x30Ysw3xlSWRMQ7mYi2/XuGwmEx473NH3415JoLnBddaFX4kufeOm1gb8t5o10XX1CyY8fuv87MaPVXf/5Fj2svUC67QJC2dq4jF8CJW884omrnpXk074/h2vqWvRUWm9Welc41wLrm2j1lsqp4crJB04yUleBR1hBKkXLAAOGOviUJI4aRwuKgxtJ+c3Ftz54Bu1XiSNjh86Xkp2TE26acog/DyCjrRCcgBUVgdeXi176asSi08ebhE8/uNi5ZJACFZJd+9VVjLHZLQb4XQYT1Ro2EbapdZopJcRI7jtguR93+aBuj6ESZNevTj95bFggqFTurOcH7750aDvkvunT4VZNGUatfYooQgRDDFoMl3oRhSI3zx0BGtdDa5Y+nPPQmnf6PndOaIHBR/3MH2k6OERTwWOf7MfpYEqO+BkTOOaVRkQbdYMEioDAUgarqul27s7wpel6G1NxSu2WbpFoSc3NBY/WMtjqdCfdcse7cm/M/eTVn4q1w0dnNqKuMaILERT5PQEhFYuVqYbfxUwa6Th/Z8NmM0OIVaYMGtGzcXDd9bs9zhqnFRVRRLEY+KxzZCebId8TPMwAiKcoh/EDRkxVWhLavbtUjL8oNZVI03Age+8jI/+ZTEhJBGVkrQNj4C4UIYiiXtj0B/kNJeiGFQUgg1Mj/jTyxlipHypqFO7NAcm3ZWXnhLVwEdUV6lfkWbNp27kN3XX/t6XaLMmLcgPdmTqssr83OSuOgC2KiCGCHJ3GlQOSfj57wUEXTNqAigDPUjKw+ee/A4nHL7gYqg+oFFJfIfd3ejKeLrwtFh/5AGNiTmnAqpjUvHR0sQcSIC9DDYdFUJysqWGxhwiQhRHOTkJgkq1yV0ZAFa/9O9c1NNV8s7Hn2KY7LzxcZqb67JrnK68o2bsqqGxRKSUi+/w7ns5+u/cdDg2CQ+Op6TLIGjbsmYVTsJ24V44jqqI9PjC8O+f663W984Gpq6nzjFViY3vLZvF0fzUkYNdKTnaMbm8zgColxhBtkaJLDnTXkZGbooQOKxNRkd2qyIszJbgHHqtIaPXfR4y0iVkNIfh5Ys3flS0v/1djcdOdJvx3ZZaQb7CYcsjvtw0cOMLyFaGho+WbR2obGlnMvPi0lLcFMJokohbB51TQWP0b1Q83bgAC9+3Z3exL8AWX6ax9zIV80YaBFhoIueaBQRi2ADNEPaPLAAUbCeiEMMEKBCkN2zw72cwafI+w4a+WH0/QZnv7uTp4CGe0HB/V+viknhDFmphQJiYbFBscvbWhp3Pf8q3ZvivvmK5vXrN039c3Ey8Yn5uboFFXQg4CB/VWaXQ42eVh1PezZqxVkU87bhYDxXpoTzG2jMX1K0Jma2PnM4bs+m6GsXJ+2+Ft96bd+qHIO6wsetx7tuCIsNrtBgTBCCR4+yqYACrB6VW7McJVlkai7i8KC+DriU2iWsSKGz0gMm0GJOQdDTa4pPMhedOjihBOkBqeRSaPAa4l9+4adNGRzFmbvSQ9xIZBRb0UwHZqSm2si9lAS6TnJ4bDe0qibhi7ygPGwpHfkeOblzA9gzLBDAPDZgSXjlt8HiieCLFG/2XPKM4mTIMsTMgSP21Ft/dzPFob4jt7YVD/zU0LBPWqYlJnVvHULfjBP7t5FGtwPVMmMMtu62QghFkXpete1kJSIvmQh9MLMTvThu5FgyGkRELYHWphsbwnbdJ9NawqgR+gSk+PGMI6ojjkaNjcOBeSMaqlJyZ2yK657okZirvNHlr3yjltV04q7cllGs6RvirygQAoUKDPPEAgZUKZEEkQHDBrsBsxkBsV2+dOjgVPtOf4jXkKgDuG1lSunLp5aGai4cuSVozLPtYONmX2XwmD7RJ1S6m8Nz/1k2czp804e2ffc807XNIZGrhkOEqWYkjnt4/aDiGrwoD6DB/Xxh2DevAUI1gkTTnParQgQAkQdqERkVZOJJKGsaEyKXCjnMR1QToQA1ITqldLHF19CZDJz0Qcvh168fOTELpaeREgdrgFB2ooNUbpATMjOTurec+mfpvawqXuWr0h1WLy9e3FZ4gQ0YOFtWzY+/s/Ebnn2y8aseeKd5E5T7Q/fwTWN0+PSGRpfP3/RtlSy1Wbv11PqNlz/Ym2oeapYui1R7cz79CAeu1FOiVJs0zbvhXiQge177xnZzL6EYbdNTEuxYARPRUnY4gH50Ry+GAlrxKQISmXGGNc5R278tWhfDfxujkoIVVaQSFwEOBeEgK5Ln9U+1Pzl5qGXXZKRxQMiYtpKlm6Stmzo5WRAdOTY0tAkS0xVjQJaNAuJ8AumlzFmzwUyicif1CwTQh+z4l6QnYDhi+RSd0LKM3m/bbHZKKAc6yWgHfK5Bl2OQJAUObCjYtOsD/urzDPy1M0zZirT5hT8+S40YCaJIcwogzGiw2oL9+5hBCcRtCsQgl3zjXotWmpqvn7lNQf6u1929erp3zheeLXL726hXgcQLgyGsHiDVBxRHTXwb2OilBExwZk8Znj9uvXLn5898N01NENJvecirVu+TnSFK4Ha+rDu15x2YbdSXW+sqZOpojlcksKoUfsCBAnQLmJCR4bMnzBVJI8eS+hGslkyyHQF8LKWXdOXT1seWn334JtOyRnhEk6OIkooZwAmRmgwrC/6cvlL/3gnIy3r6uvPzit0cp1TEsFUkpFcMzSFJROmGV32BjKMEqmbVNSR/wyHhKzpKuU8HAoDIyCpEIFuZfsqahv9gVbBQvL2Xbs8DmtyiocyGo5YDY6G5EeQIRPg0TwXdr3M4U9+YO0j2reuiQMcOXJhNI49XiEz4YggydpV4/WyPf5Hn7WndPZM/QOkpfgZKABQUbPm2Vfl9Qe63H+7f3CvzhvLv33qlX4n9dbOGOHXmCMekJ3Q55RQImN2pjxueGjd001L39IA0kdNDHTOASpLEJYMFW0EqgOVwciboFl7MlDWoafPKPRjrUL1RBckOYhxyEhbYji+jjhh0zYMxhHWb9pVV9fQrXtnlxGD/cTisLuicve+8q7FnRwOGzdok3x9u1e8s/rrTbsv7F3aasggO5zMpQcc/hYA5g+HVi5YnZyQmJRiB9DJwaai4z5ohu0CXUBkEfNOP6xZdtaKe0AIkFXgwZvdI5/xjocsXzMj9lAUpZsTQdgxzAiEEClMgDidzkvH2LZvaH5tlrZ6V+g/X7gnjpaGlOoOhYnDJ8PQoOgzlJgjboAbO14PB4NTP6z7w4vp99+kXnxha6qT/+VBkeZTb7gMWOT+EoNeKx5qxhHVMR4aihACoKkpaaOHVzw/s67ig5TR91p69whIVEYJBJZv2bz/03lde/awjxzk37Jj7/sf2wcNTB86mGjU5ADWo2KX0UDZ7Buix5qYoe1C5qZw4/sb3tu2b/tFw88+rcsoEgkgDAGVdoqxLa3Brxeve+n5d90ex3U3XdajZ67OkVHCkTPCNm/ZeaCyMS8vNyXNbSTbonQ/m7fsLN9Xm5fXKTXdLTMwGydVhV40fqxEVc1iQaCwbVfV5u2W3E7vTJu1ZF/l3vIDVBKPP/KCz5c0uH+v0j5dMnOSDW8UCf5ZJIqLYEGH6jqz/xmbyaqVy5d/4vh4Qg+fjdoJyB2cofpelwzIUrLDEQCmWlWVqIIQBoIC0ffuqUMx9InrYOTJqseWc+tvKt3WPWX7ugSDRLPGGh7i68Tw1XCwYmT+LhBJojtpUN8GW3Fjy0I7JCb17849Hr9RWzEapFHaW1G7bqOWlmYtyAdVgViit/0bR/OaiBIiFYKZBwFJfGTpGECG6W4Zgaa6uslP/+ujt5e8/v6fBg8uJeTQZtGIVTkUU4RCM6bPmvLSB89NfuiUYX38wCUgp444aUanedOnTS8dlJaWk6IRYhjPyDNqbPDP/mLJovlLL772jNS0FGFK3yE71AAcx8xU26cwQj6tWhoCcfbq+4FagAYvD3WxZeQ9k3GVcMscUEbjRSCidwA7wKwYHAhoKr/oBDxdi/qfOXrzjU+Xz303t8e49DPP4F4vb6tomKXG2MeGw3q4voFICjjtPLLdCa1ppEIP89CmDWtTLzyjcMJ4kZXV85Lzd6xev23LxpymZupJwCixVnzFEdVReuW2gy5AcKDQ2NSwbQcDOQG6HygvV/fspdlJOuiMyZbURMv63bWfrLG0tFQt+ta6bm/ymDOZTdEBkaJiBMZmtkYGwjASNJN2Gk9HO+rGImYfBfAm0fDlui+eX/fqb3pecF7n8+wiIRLjMdFW3SCATc2BeXO/eebJaVXbxOU3nKOTli8XLnfYLJ07Z9mdGiB9Z8bs99/55t7f3zxqbD9NY7EiOX377Q+nTf70vgfuGjd+gGRTzQEWRYExo082e3g5iKrZc7+5/dHsh3+XZrWmpeZ0yimWgDT5m7au3zPr1efuePCSm24418jIRRxb1IcRIXPqJNZJPSZOrvZ/sP6DPE/ekNyhVkg8TjGlWYGQuV43e87eDz7v9dvxFSu38GkfZvTowjxOLiEvyj/5vtssXg/KCgckwwd07d1FDgVBlTVB41olJ6DPJgeL0ggoJFl25+eJMV32vLkQigckDewLsqwYoQXqvG7X3vCr75Q/9veU+25Sbr2GWxQF8VDp7oPIW0bUBGoC1PZAKy4AeEwhTSSKASzKyvUPYi5JkYWgVDJKUBiFU9HyXHuIJbITk4b26p0gWSQBFhIBIb26db7upkuefur5vz/88kVXnlWYnwEB6YBs31xRv276Zw88Mb1v38Kzxp3ucFp1CAIyI3TFmPRLx+27776fWdkEydiOcw4sG73mQRB+YDYQ/pvUwU+7zqddSwI0TJFIyGRTjfKgJk1HnggW2esQpJQ63KovUdkBCRYnMqswA3AzzD50BfRQ1fRZQSD5Y0ZiXnrzgZqaKe+5UpOSTh6Yfvskm90OGVko0Nq9OOfFP/v9IcLsZh0jnp2KI6qjtwkYbUMKEwwRhJbGmtmftNz6ap/rz5JP74P3v9z4+Evu5JvUwq4CIKlTfurDd6558h/lVz7sHlxqOX/k3g2bnIJ7e3ZhVlvF/srqBd8k+3yJvUvQZgkTkFFHQjkwcy4uppp0pGZbGBR2Otff3/jO619MP7vPWeP7T8iQ8tDgzWSxykYkeEG+ZdP2V16cvW1TndWT9s6HX7338QK9JVRY6Lv57vP79CoUiCePGJSWkVnYNZVJKERYxwhGlACGD+vn9SaW9E6XVQmJIKYVQKKjCNMwM0TT5IF9sh//ffLJvXsVF41WVErN/jDYsXX3ksXLepQWCWFkgYg50UdMoXJqUK2na1kTBv0GF9Gn5v+zSW09P+3SaIHfiN06sAqoR8w2qVi3tnz6Bz3PHZt83QW2r1dv/9PLOPOT9PHjwm4LOl2y08WEQIGMcJ1IFrcLAcIYCStJPEF1grnq9sphRk8U4YitzS36rgNOyLJcORZ690ZA2TjEzbv2Vrww071imzWyd8Oc6TwmcX5Yr4ZIdYptnNDR1sI4qj7W5UlIuPbGS0JXC4dboxKD9g/QlNM89KRrqjb+4rPHjB3lcVsJBdk4fZoq/2bSGanp8uv/+vTmq5/ITE+2KXr5fus7r31bl7zliisuvPT8vt26pBvjbDK2cQZ2dELqIJ0OgVh2isgE7tj6cn245eXyj4FIQBnwlrfzbj/fNbg1yaNy1ARrB6CEQSpLOiYTGL2LkXcLEZQJCX67fOOLU3N6d/VcNmrl9A8yJk9L+93VwexkOcp4dYiirKZZkj3ur+79i23bzpyJl8ydNjX5b5/lzHyMpiQmK6kcEDhnRmk8ISsv8pUFGnc4XgCPI6pj37HE7LFu3LB12exPUy8tdd/229YUq+WKqq9fmJ757n/63JAnnDSC2pMSVItaA2sT/V0tvoTG6e+36p8mPXobycgof2Hq7o8+T73tOqlPSVSRN6p/YOioC6T06HJUBFCH8JYDm95f+Z7ms/2239Xpcgbh9KClMr+CIQ+amZl6+91X6iGBsowoMKwLgVaLmp3h042X9e1X2qu0RFEVyigFwkDWAYXAPv37di/toSoSYcxofCQAKAwWPgnUyGkj4OnVzV6QrzlswIhKiRStxoiiLhk5uT5Fpkii84Ok3S2NuisiZ7sLx/a44NtPVry3cHaPsb1zLTmS0EzRie8Hu8f8FCkBgsLhTSq8+zpnboaenGwZNrBTijdslaiMciwRgciBEEEYMWkY0OhJNsqgHdRFGl/H4ZwanIOisbXpm9X+JV/48oZZzhyGDtUARcgRiMedNX50wkk9vtmzw8pAEjTKyPvTQDkOojpm2V2WH7ixh8U9RLPImkWOTukaL+aCqzZ91JghhXmdF6/a+M3iZYlrdyINnDKod/drzsnrXZLkEUgENZL3xzHIjlaBI79ChOggbEDu2vrK33a/AyIIzAqi+QPPVSwj44zE/mHGFG5IrAIh7ZiIO8C44aH3ziCMljhprdy/4d8zaqsqim6dpPYt9mPN8odny6VdveefGXJZ6KGN+gggU6qcc0bKns1VT72fuGOf++MvfM/cq54yKKRIBDkzmlXMi4+cJmGOX8Xjyzii6oAwAOxJ3gFXXWlJ84mczLAUtl98Vq+SIhuzAEcOXEZxYM7ndSs3ZgwaX15T760o696n9+p/v7vnvY/cNlfFg9N6ThrpLe0eIoTU18uKghYrRUB/SygkFIsFFCXGbHIk5gC50OtD9fM2fF7VWj/xgssL7Z2DGGqfSTbfymCaownJiSeleCkXjTt31Tc2pncuog6bAKQCQ8ZYhyxLqszMTvmVKzc1NjYXd+/scbukyKJojjqjydkJlJCysorVK7b07lOa4LNxhUkJzpjaWnTeBREZoXarJkAnwDmabA9IycH+JjRaVjWmFqV1Pav/qFmff/TZ+k8u6nOJF7RDb38HnF9jxh6cqWmYnirMYWOXXRvQ04ohgREABYEQhHWiUl2WAZnEdWj1c0khmiyAxHUUTvBDGoG+ZRU1n8yXoN5z4UAsyAOhE8rM7C9NcNq9iWBTajNUp0HwavIpYHuXdHg3ESciO96L/kQ421YdNAapNU0p6ZWf0y3ntJF9YOXWd/7fX0YN65F3Wm8kwEXQAGBRC3R8EBWJwbVI4KUyogK7c+srT+5+BwgFiUGofnbqHWOyTwan1dTMYAIPkiT88Hjjz9n8sY4slAgJNLdme3xFN06y9+uGXmf3i87hAU3RgYUgeDjOA4GgO1nXcefsn7Fw+8ev9YMheOkF3GExhSIYQjAapBOM28A4ovq5x6fNHyNhTJWyMlOzshkBFMICKqamp/vSJSHCIBjg/uWrN02blVlYkDrpvH3/mV/2+tzcWy5wXzY09NLcssp9PfoUpl1zOe+U3dxQVz95SiJQ7ZqLFJ1snvqmpDpzzztLT0uU8MhlOwlHvqFi7dx9c0d2OXW093QQIBPp+xX+2GQhciCwr6Ls0cnbDlR7brnaMaKf2Q8qAzetD0eZErJly86nH39184a9dz808fTRg1WrYsT5LMachWZ349tvfTL5qbduue22CdeerGqGWodRpmNGl3DbyTXiS6ntotqfZ9L2C8EuW8/KH9e4o+XzTXOKM4oH+4YrppQy1X+oLnNMmQwqCIRAByAWQXSKOkEksulK1VWb182Zl5aX6j7r9FaXXf9oTvmCr5POPdvRtxcqcUNyop9TisibWv0A9t/cAGcPCzOJgi6ZWVCjKBgCUIRAhBDBIEW/kbZUBWD82f5KHjKN9p1GcImiSJmZqXzfLl+o2iq3AIiwQd4ikHAC9DgmFwkhNGTAC5WRO7e+ui9Y/eb+BUaOqOlJHNe1uOco70BhIVToFFnkhUyYCg0MaEfuNgKH8BcgSBFbj670FPnmy8FhCdo1gTyxoAjuSBdIhFuTovI23/ERyIC2VO9nFX4HeFuhnlZUWRx2ZJQY2Si5zVyTjmHOiq//6RxVmxRA5HBQEmULpFQypip4BERQCoQKHtRDqWcOy+7dl/XrluFxSnZnOCM1GbC28tNa2Nqt9FzIzgxITHE4HEz+6pW3T/Z5mlsC+197v+v/u5nYVEGIQGRHOlOG9aJ6wfovwpJ+WrfTvZAqonxY0cisXd7boNIxlJgIo8ztIHoYNdWAQMgJMtHWgC8ISIosWeya3W1VVdkERcbbktjAE5ikPhar4vSqDpfKgEpG4snMjrWRWqFRbkTCqWEEyeHEPqI/QoSEkGXJPr336MWfL1iyblGRtzCVZhvhU4ex8nKTJSYsLBILAYQoUiQqpwJRZyREQfU4dm7fWvHm+yO8SSzDu+bpfzr3N2iTLo8m1+L0wCd2loMgsWZn9rzjOu51BnMyADgF2pYQYNTgd5YVexBdgiqMGUIIyI1mvvhzPdGNsJlyipgLZqIIDqhznTXWM38j6CE0E+hAKeDxnR8w6neKAS3u2zrlyT0zgftBJhBqec914/Dc4c7EpICEERBv0HuKiNcQUaacozQhP/4TGFOZMEk9OIkKKst2K9it3KgqMKQoEUxJMs2z9D3Sf3PYnFbVr371TXeeq/T6uz57elrGc/8q/v2dmO4zL7qNzy+eooojqg5LUrW1sJp5W7OnRm7b95HQl6b06iV16yYrCkgyze+U9NtUaGheO2dhAji80GnvS/MTrxoPXk9YUb2XXejaX1n5l2mBcKDz+NO8IwaAS6EmMzM5onOno1hdvXrVrtW9BpQUJRYyIYcNFso2IfU2CGMMFaIOQkKOXk/azVe4AiFLaqpuXLhOkQiJRs4/J0QI0DMyU2+798pASzAzK1VWFWzXbdJ2VQLE2LNP7dOrJDcnT9WYgbfM/iqk1OgnMzrRI/bNSLod9iiaOmlG6isCJiWmdErJ61PQa/3mtZtL1qWmZAM39WtIhzxEASDruHvR0rING/qfMjzUNTewt2Lz7M8zenZN7tUTLUTk+nrfcsWu3lfu/PsrQZ81vHxTwUuPsPwsQXWDbTveQXWiH1WWlKAkuEKUoMRUc0dGnSCBULi+sjx56WrHkhpL0i5pyRp1QAl3u3RqUJHF169lYVsPjzD72QXInCjR6IzALxH3ELh329S1rWUfVS8xaPqCsyvH2Ut7DkvsGUpyBA062Sijn9Ekq0Pk+o7BfAhzUtvsfjcWHjqsZ5BCmYIwEUQVIEQ1vBIF3TBY1NBUNaEXJbEAo71dJAB+wev++NfQq1/kPn0PjB2dbGV1993RkJ6h3Xo1WhXCpDiciiOq44KsWLtsR2SH1daRVeupxEjPYmHTaKjVsmgFJCSEu3ZGAqhKquqGNz8OT5kT/MulqRL98I/PDXxpWl6SF3MySIav4MxTG55+SwY9edDQgMcFhCmRw2IqM1A43NY34BZGYjOCfhF8d+1MWVFGZ53jIi4iqISiTTKGI9TXt1YcaM7K8LqsEiCTjJQ5qqo1N8tmHleDZI5ClA+6bRhWlWlhQU4suYVwaINJTLwA0nzJab5ko/hozr9wYYCjlubwpq3Vhd1SJRm2bS6f9+k3Q4cO6FmafvjEwsFbSwkhbsUzKv2c5zY/s3jn10NTTtWpYEKjx4xk8LuYOBKueezVL7/btGK7+/c3Vk2dLl7/xP3W3xkhKpJWRfWW9nL+/Y5lN/2lB2zO+utzbOxZLYqqoJDi1uTX4GyBUUKpAsiihe7oU4t4tcbWtbM+a3zvI5oQ2rNsleVFvSThhsTS7pIstYfsh+1iPIwCbXx995gdMZJpfyrxB+87+QHlGNk0gWYNzeBOMvg0D6pykYOsBOTYvkb7vzLa0I0uShI2rkoFAvdvm/qnPTOBNwO1gF49M+nWMQXDIDkJFcLMIZjI5RtkmoRKZoqUHMNdjQIp2k6pzKDfAnPmmnBdq9fBpqHKgKAiuNTcTAHQYgnKMgUiQbseeFMxwDgWBwNjg2G0qcUl9jUAAIAASURBVLp2n2ovePZe54Vn8aTEot9esas6XK5aclr8QlMpI20J+vi8cxxRdbzxMKn7CSE8GNi26OvKRd8UXD/Rd9rwPUuWVz72dNFNV9u7dQ0iV3VRvmFz7RuzsvsWJZ55quJx5ZfvLXvzP2l9elomnA/h8NqFiwoVX0so2Dx/kXNwj1CCGqUpIeLH0iFGf7jg+tayLUu2LD+/dFyRt9horBYkJvgAQJpb/bM/mTd1yqxJky6/5ILhEGXXPMRykbYw6jtEc6Q9cPquoSTfuxwklMQOLSL59NMvn332lUuv/M1lE4Yu+nrZU3950d/a0rP0cvLD+b828ycxJS8xvyC7aPWOjduLtua6c4lo0+n5uTbfYMEgvuKCtPPPWvvMmznA61duKLh8rJafyZXoWF8E10oUIUwBdARQLNFSaDxEO/FjHmOXSIcrzgpAarP2HHZysKhQJigQiKo40jLY4R8p/igyj6/vgMyjuz2x3oHvQyrDtB1Msf9gZNuW88YouQ2FDnpA3wdVhvSqgWEIEtB+v33Kl027F9atBqFHUFKg/M3OD5+bOJR7rAbJJmnXpRSV7Dsm7ffo7dXDuGXTjg3rtldV1xACqelJJSXFuTk+iUWMYtOB6s3/mO70JuSdf6bs81Yu+rps1kfJJw/yjTwFZVUc/i1J+3sY+VYIbqej813XWDUrOu1IwOJNzLr3ai501eowBjtiTyR+DOKI6rjYEoyWlmWP2zOg757PF9X84/WU5lDdwq+daVn2wi5UUSDQVPfVMvmjRa5zRyQPHRgItO6fv6rHgH4HehT7szJ40M9fmGJ57m3Hs7fZ99fueHhGWu+ipDNOC7sdElJJ0B8CVGaVDITUCg2L139JBS3tWupiHjS8v5HuNVNcxJAUZKATdnjLJH4YI7W3dEd4hszJOSZIJESjDHg4bJGYQqBnSe6Vk0YPHNT1yG+v3eooyer+7c4VC7d/kdbbZwNbR2EZChCkGFQU11XjGzas5q/8OWfEpbbzTm2yKUC4AkwDUrd9R8vj0/J6ldRbeu9/8d1+xT0so0/iwHWUpHh89mtMLMc2srAoju75tu6duYj4EckgQqQkyi8U76Q6epfPY10PFL7XnfMTPxtxziyGm8TBSTU4liwIHldjT4OC0DASDbQ/bnv90T3vGakpDbDm1ebx+SX9Bqb1EXIkCCOiXdMG/ExShMiWbG31vzdrwVvTP9y6tq6msoUS6s1x9h/a/dIJI/sP6MJkYrGplpbW3dM+zXQmQHH29qkzXasrveeOY6qMUXmbQ8zf9yf1DIJoUDRN92lhFIpAZjZveD0KINVRHEKiG19xRHVcQmEwOM4IaKpzcN8uky5uvPxvu+c95StMSHzqNpqbBQBM0aC5aeNXXxennsnCbN/0WS2hltTrJyblZIBE68oqd5SVFd46wTb2dCkU5v7G7du3Jjb0A5fV6CrCaC/59w5ZlK4TyK7AjsU7v+yb0qdbQomBvwz/EM3mRI6A1SKPHDGwpGthWqbPJDv4TpYtlhcympiAx9JA9NDhXmwbFoydRRH7dzT0Mv6WQ9Se6JzB0KF987Iz07LSgZEe3Qs652bYbDbj5JKfNpcINknr4u2abcmZt+vL/r0HFRMvkg5T+5MERypB9QFRUVkPSay8QquqUjvlIWOEEXlP5fI//x2qakf/7Y7KRFvd+Xes/OPTPQozRVYGZyjHne6v0O1DrB4kRXMjSNkhLk/gMVRk/tfvKgHCBa5fu3ntql2Dh5Zm5yZzxCPUJEEikEuLFqzauXvf6NHDvD4roDBnylCQJUs3bdyyZfSY01IStP/uYzGS48CQMqIyAg9um/bHPTNBhIBRCJS/lXHPOYlD5eQkjGwsQQyVPnKY0PTYbrAIBkNz5yx5/P7XDlRXdSntNHr80Lrahs//s2jWjI+5Ltwed3G3dLTZvJecUb1ta9k/pya67faG6pRrL2c9uoSYJBkU6Wa6LPKw0EjmGYR81BCt4JxTanRmGUlDyRAXayOXVgwlWEGj3KucQvvR7Pg6Hov+zwa9RlGcUEOWiVtt6QP6pQ8rqgkvTElwSyWF3KLoAJRKCQMHOoeUrpz58aqHnsEPVxQOP1lKTZUsVqpqiSmpJffd4b16okhJ1LNTu955U49JV0oJCYIgEhEFOT+cHuOCb9i1fn9L5UmlQ93gMX6Ctqn8ESPwppQmJbu6de/kTbDj4d7HgIS0qaV1x64KbgpMERplMgCye1dZ+b4DQkTFyc11qJ+idfU1C75Y3NoSprEQU5AwAW61SUQRSV4bI1SVlYQEt6rKh1U/OOxiKKVZU7tndV9ZvX1j2VZDXxA75skBSoRRPbRh8gueypr8v/8lINHQ5GkqgoqUAzTNXWhfsmXYEzfrwwepA/ucfN91wSV7ts6Zz8KCk3hb+q/2xBqjqhIQCYmKqCHXAGVAFq17xEf9juW2VlXVvPDClHvuePLTT75sDYSAEHGknoNWVTVMefXtG6+5d9GXG4IBIYxaX1jw+qbWV15588abH/h8/rpwWAgh/rvfEYFQqj68dWru8nv/uO/9CJzChtmtI1YXPXtOwSiS5m1lXJgzdh23iUxjd2B/4/vv/Kd8p3/w0CHPPH/fvXdf+tijV//1yRucCc4Fc1esXLEWEVtRd3fvPuzS8/nm/dVzXisZ2D/p1EFBhz1gNMYSw25iOBLuSoQBIUEQhFDTvTBCjM5VQg1/oSCJRIzE1LUgCkbOC1BqNiMKcxIrjqfiOarjE6MZdXVqCHQH/LXLl1fMX2+D/L1bdvrWbWMer1AkBJBSklJuuNT18fqWb19zXn2P1K9nq8ehgCGOYFHA5gsBSiLIgbHERAAII2jCaGUi5LCdHMLoyqQEw+GWTXs2gl3tm90PQPbTsMWY44jS+EbBkREykWhW/dC3QkGEBLRyf8U/n399/fKqx5+6tXNBmjmvSAjdvHHLo/dNJsR+36MTC7tkxQL9NsJzHnn6nLz64gf/eG7G7bfcfsV1w1WrTIEIEQkrP/xg7t//9spVk26+bGI/BGTRnkZKYikv+qP+DwlxqO6emT1gA9+4c0NLer1GbMcmcC5IVN/azEWEKFF1vvuzuasWrz77uivppefZFLLoby/2nbPIM2KIkEAeNajfkJ5qUmrQZbMA0a66sHTscGFVJAlsAuMSJL8+t39ol067dkHSLn0l4r7iGLy+0+UaPnIQCqlrSa4lYvE4mGmOn1oc0eWx9T+5O1FDhd1TmWJGZIQRYrWqQ07qxUlLzx6pEvvpCiBBoMIIhkh08K9jvp0RPkrGeX9o++sP7J0JPGCMTNe8mHDzqVmnhRJcuqzISDVD6UsnwDqOQ5wAhLm+v7x2w8bN7qTQmWcPKinOEcAZwe7d8kuK07/+z866A/WEMJnZGCXB2gbe0CAAArsrrU1hKijSaMmAA8j7qpa8Mi1T52mTLqZ52XT9lvVT3klMyfVdPkZ4HfTgwNPBAfYYF8nBcoUE0K7BLb7944iq4+1J5MwpnLeuXLtm+ruesV2LzxmzZs7n+pvv53bKFTnp3LAcwbKqAAlIkCRqakhjI3AvYcw0EwyM9likFKNiLAZFIf2R/WpiESFEVX3lnqqyTp3ysrUsbsyVfC/PfLD9UJj1NjyoShY9GkQQyiRZAYqSIbMlDL2qSGDCmE6BUUEj8QxF4MZ5bmv/jEb9jDFCuaIY0ygxX4VIGCU6CiZRYXyQgFjNDoVuDGEBOagRcRijSYhE5bREX2FCzp7deyp7leVZO5vjLeY3QDiKthfS7vbRyGMTXl/qGQ/eaevRI+SypY8Z5U1K0lKSgVIJiOxLYUDChEloKOi67KrLbnwDjNJ8Yayj4DtK+YcbXPpfXrfeeuvatWsBYNasWU6n8wTLWUVdb7seZ/K/YrdiE1+HTMAeYdqk3YsRwKppZ4waMWzIYIfDTikRMeq4I3gCRNXYRePHjDt7pMvtig2fRX6XZRh37qmjzjjJ7XGZZAE/GNQKo1JgDgnRKFmVOPpU0CHd9eLgt2SUPLz9jT/ULIXWMhBhYK1vlZ1SWjgso3MpuhzCELoxjCMRpMPxOGGEZuVm/uGPd7YGcPBJPY1RbC6Aci7CfqHoTJVlaiSWapasXPv+Z8Vn9vfYh69dtzFr3lfe9GTusgmTYgIJpCZavY7tj71kS0t2jRuz7Z8v13y9Ju2eQdyiiiOpNNE4C18cUf0SK3L4/OUVFdNn2bcdSH/8Vhh2ktsmtY6/70CvUseEc8Bm1bdur/jndE9Osm/UNdVzVrZ8Ps/lcxCvzzDggpnRHJEZIbRtou6n5C5IJBLUdzfvrg00D83vqYFFcE4o/ZH4iJjppUicQRHMOt7/Z+86wOMqru69M++97epdVrcsd9mSewEbF4rBBtNML6GXQEJJSE/4SYGEBEISegsQWgDTW6jGGPeOe7csq/dtb+b+387bXa1suYBljGHn2w9sebX72tw598655yAqJfKUlJQLLz6j8eTm7JyUEAZSRS0JsqAw/6e/uowznpuXJoA4ch76XYvXqMKIqtfMPHvyoCGFAwYMsNk1q9fPqgyPO64ir+inRb37Egs7AEaUPy3PWjpwXYHA40oszx+8YvGKzU3bCpwlWtjc/av5yLPYYGC5DWpa0qD+bGB/0LTQXzPS9BOOIwagK0EbdWoaQlcBrbBOZBdEFY8y+x1Lliz55JNPAGDSpElOp/Ott95yOp1HCD7t8WcLlBNGOIP0vXMok4foqxNRcmFOh8PpcESgCGd4kLMy9EaP2+VxuyKtfwgRlqXL5XC5HF/h9pJQJCCkr3IbKSpmFQOsWZQxj/h/G5751bbnQfoAdZANT8nzZx57Ms/I9NptGoGNIhRS1nN+Dl1OS09K1Y6dUikl2G26GfoiZpq4eXv9lyt3ZvfJzy3M54Cisa7q0ef1bfWJv79Jy++Ff/lH0/UPJ/buZUweTdwOQBqQtPOSUyaumz9/+9Mvy+Xrdz3yRr/fXZw8bpDp0gC7u62wj7QwHu/iiOqwpnuMgCclpV90eu5FM219ykyXO3PqscEP76WkLI1r7W0dn89+y7tmZ78//DBpcP/tKc/OfvPd6SUlKVPSwG5IGYnikU2+g3hqZQgPSS3I/Ftb1huS9cvuq3b3OEBMu0y301OirxWbGgMpmZphA2GanKu9OIY5uZlZWemaHooQjU3+luZgRrrL4dT79C/REJFzDtjaZtZUt+X0SrTbOxN7IsrJyUpNSTEMG7Mc2CNULLfDY2hZiW47USiHUxJzocgVDNDWbe25+S6bsZ8uQiIkBObWnQNyBy+ev3xryyZ/zhgN7GEXhEMIU1bYZoYR8cYJpbmk2aSM9sVg9G17k0ytopTsAqrjqp/7iA5aOD4sXLgQAMaNG2dXT88nn3wS/acjWKnh3+v1AWNw1UFesXAHcWhhpz2LVd1qrBwkyu1abv5aN0WoXT9A8VVqVGjhJ+iUK0PlXmdD+N3G//y65lPw1ylXGwLfzmcKfn5GzrHSkyC5zpVLGAM8fEjDIrprHJmmWzcKJXCmbdiw+747X+to8Q07tfeAQYU+CnpbvTI7rfRXVzvHDzcTE/KvvWhn1ms7a+vyWwMs2aFuMJnAtILe6Vf/wH/Nnzoe+mPvU3+QdOZp7RkJWpgPEs0c44EsjqiOZFBSRgRuj1E+iCEQs0kELSlJHz8KyGCouwQfMXWqMXaiNqiXTLD3/cF5JVOOcyYlA8OvzbJW23fgDwS21WxPdCXl2jKUr0oksO0DbCCgz+t9afa7Tz70yvmXTj/3gunIWOgVyc8ZcIJAQLAH7n/8vTfmXvfDyyYdP9KZYFhCDJLgH/c9/N/n377+2itOPXOCJ8EeNoRQv2p32GJLTkzJac2e/d7ddz5wxeXXXnLFFELUFGXVDIr/vffFHbfffeaZZ99401lCmgjImJJV6XrkFotMBz3HmZXoTthVX91BXhckYs+pzsR8F1ptxrE/2eebLZ4+61Jko+4M9ON8q71LVtYfhg0bpuv6/Pnzj5RUIIXVEiDSyIrfn/zbqswRdXlg9/OsUkSqmyxNTcKosxV+m0g1jL4mHoju96mzIxtjv9j49B1bnwcZANSAml9tOm1IxfFpOQW6Zg9gtHnusANeFnb8YqGgT6hx2LJl25133T/vw2XDJww4e9ZxxfkZJM3E9IyBP75c1zW0GZJj4rChnv5lnHOd60KSxRCUAHbGO/xB0dyWALB9865Ur48hKoMaJBCKshGPV3FEdWThFHKprPIYt8nOmMyBe6TSENcdnA/qLRGJEUNi2RlaVlqQSGMc4euVWpSfAIJPeLd2bElPyMmCzM45yA40RwV6fSYCt/b1lJWBCppWvT4MkqQZDE1jzhlTfjLKmjSUvQV8QSXPYO24UVQddI88DSMQw+cPSpIUy7BX4TgQkFZIDmGp/W7/cdB6aXlZrqzdzdVtgdZkW7pG/PDf2APfFybBz0EAalwigQYYiOT77Ovx57/TNarPPvssPz+/oqKitrYWAJYtWwYAgwYN0jRt6dKl3/yBBYEUj1jVmLsWG74HQ6jMK7xPRWQqG7gDR3IWeuqZUGK7Cl99J4j82KlSIwANhj/f+PTvNz8X+hsDCNTcn3/LSVlTuNsdimKCGUwhy280WyIJEhls2VRz/9/feu3xRWVDcy+9eubwcf1FKCXWhQOl0yZCeS8aAoKa5k1McKiSIjEpAU1gNilh81bbP//TUZwWPPk2+Y8X4enZjh9dFsxKlQiatQDE41YcUR3x6ajUE6zmCFKVC4VbVHbBkASCZKEIpIeF6yzRzS6R6Cum6cSBSxJ+M9DY0TygoNzBHOEk8wCVLdIN44RpE4dUDMnM9AAjrsxEw2eh6jOCGDDz/AvOOOnEE3v1yrA5NVWOYQQkQF540RmTj5tYUJzldOv71i/HcFLLYMqUcb2LSwpLCkl1JobdTXUcPa78gYfuys3NgLDEA3WnUNVJF/bonqyUjEWt21t9bWijLtsUPadf/jWKJRyQRYobpgKXEUpC6L4fvRNj7dq1p512Wo981IYNG6w/5OTk9OrVa+XKlUKIsrKy1tZWAFi1ahUA9OvXz7r4q1ev/sbO0eIvYpjP9/1SLbSMA3w+/8Ivvmyo906bPoZx84CzIxAIrvxy8/rN9WPHDsxM9yD4LWFPOmg9lMN+XghM0sGcfNcYQwpho44wp2HFhFV/BtERSo5YxzO7Jx5XeqKzqD8ZDmkKxlTIVBJNGKvWd5iHVJSJbVt33/vXp19+5qO+wwpu+sVFkyeN5IZmSuKSdKYeY5QMwlY1dkAtdGMEqm3QIICjwzvnuRflx8sq/nSD+4SJ0ut9f/Zrg8uLMk89BV1Oy3aaIK4NE0dURz7DCYECM1yfEKpvmCmKRghdmYp8IMP0onC7hL6Xh/FX+joVAyhgBjtEMDkh5SCTJSU5gsjNhARITHERScZ0Sz6UA7a0dTTWN+XlZRFCZm5yVnYSU92HSqxHdfAgpmempmQkMG6Zp2O3RxY5R4mELqfu8LCkFJuMeTsieJIc/cvzOOeRK4D7O1cAu65nJGW01XW0+9uoG73fwwCkKGxiuH+ICk2tTIBMdnMWCltI5G1u1pDpCR7Z08f5jY3ly5afeNKJVVVVPbwqKEmhjIwQjN68ebMQIi8vLxAIAMCaNWus95SWluq6flhxVXT5p6q6XcvWMhIZfUtZQRZxwO8RrNIkQFXVtr/f+9iaZdV9yor6Dcg+4Bxpbm5+5P7HPpuz7Zd3XDtz+hjltvttumRolVnoKxZ/FDxSDcwfNa6cuOzXIPyhEC6aH7dfdPqYaYHsdDA0E8hADvBNY2/VTI4aQm19w1/+/K8X7v+0d3npzbddNeWEfsgjzc4KQhmWyY3SntLQMvITFr2eFKKCbTs9ze0515ytHzOmIycr/eoLCh3g2Ladd3QEnI4QAItjmTii+iaHGXoRC72kRkFAA4AL9cwHQDhAV7bJzDJQMJjFYPYzyTRmhH4ZTSVZogVV0mAcQnpDQuqMd3S0+AL+lKRMBp4DMNmVBABDtmtn9W233C3anb/+09V9+2dZjXcIWFVdffedTyz/fPt9j/20T99eiAbw8LaeSn1Cv4sggUse7m3Z1/eFFX00DIKwvfjs+3f97sFrr7vtshtGE4JkYV4rIWecK+U50+pQ7hZVRQnfuuZI9qQEhdke7DAhqFEo+7J8Hr526V0hsz1jiAhXL8CvxNlx6+7ljz5RUVjEzzkZDB3++vCmoC/v0otYRooAEj5/4+z3Prv7wdNmTGC//DHze+H3Dyx59PWMR37VZ9qUYAxuPrpGIBjocTgVRVTWSFW6a9XV1RYbx/prtKBVUFAAqv80Srr6GsvQPn7EBCAzoeOTeav/+I/W95a1Q0daRfHQ391kTBhNLqcGnXLf3QJitpd1wNE4GEokyspKG39sZWbKtpLizNDiy8NiCqYw1VZtEMBmca0sROV2u6ZMHsdpYf+SHEtkXoEqxXkAKULzO4RppFTyB1FB+m6URASRiIjAYHTz8Ss/URDW2wt/vABJEkmySHfMnnepUzOi0z0QCYHj+42rpyz7DTANRECRG+qeLr/jjPRxBtc0xizzVqWjJw/nzY+EH+osuUkQOuq7qptvveGhN1+cM3rCsbf88rxjJ/SORbs+gPrNm6tuu7OovLf7gtMgNxs+XrDrD48Gpo/LuvBMmyfRCeAAgD4lg351CyBKm40R8aHlZf3KGGNos9mQxXXY4ojqGw9DkZnEgLXUNax7/hVnq6/43DP0/Hzv5h1rX34t0eXJnzUTExN99Q1bZ7+dWpyTMbIiEKDNH7znaQ9mTz0GMpJRefDioZUvGEMi8AZ8GiO7ZhwoJ++MahzRZtM7vEBkNbVIVYMKrSKcc82hIQ/bm4X36SiqOxAm8lqq5Yw6M9doj0/M91hBFmy6ruka1wk7Y1zMamVZjx4QWaotQV03EMkf9BN0alEdjnJjzJ8JkhNQii/ue2RU/8KOpsaPH32m8pqLdLvDq4I5M+yp40dnvv/pnNufnlBctC3Ts+vJ2YOnjkocP06aUvVQHt39+GeeeeZDDz3UU5/m8Xj2+ElycrL1h+bmZiJKSkqy/rpt2zbrv9nZ2Tk5OYsWLdr/0wFRMYtOpjXhPmB/6Nmpq1/15luJTtuItx8MSN/C+/65+7P5hRVDgk6nsuT/XqwsiOB0OK648hwphG4HU5AWmbpKfK4LxzsULhDtNtu0U6Yef9JxhmETQlg1ZhVfrDeTCKEZ1HA/zEiKkNw1K6khYBHQ9rWLONY0U22I3ReRqPviFIBA0jmb07BiypLbVIhiAL4X5fQTBp+qZWdrKj1mR9IZPRSJ123cdvefH3r7lfmJSanejuArr3zw2rvvSmFSUDCGY8dXTps+Pik9rTEr5cOHnxtbVujs753z/H8LahtLhg0Fl9sK9QgoOCOnIwLVADhHl4tUt3kcS8UR1ZFBVLbIn526PVe6dt72Yq1hyzvvrKbZ77Q/+krf6y4Ejx4EoWm6f/WWNU++7PnRZS0d7dVPv5o28XjgWhCkDqFYoh3qwh+a5r72Nk1Dm2bQ/mvGlnOAKuqmZab88rfXdLSZxaWZUlHOMTSlRHp6xg9vvKi2rq5XfqqkMOdS0dEtpdGw3DqixiOipl2Px9Ke7jTdY2AAwuQTxuSXZPXrOxDDqqAWPCMCwZErOMXpYCAOgqFwmd/v4+GuLHaYHmVrfbATQyl8HqP/WTMXrtxQe+td9jW7s84emzX9pKDLbqgFxs9Qz8/s/6NLdz41f9lvHkpPMexD+ybdfL2Z4GBS6ke/ALeu64mJid/AF1nKn62trUQUqwJarUZqampJScn8+fP3B7kjRQtL80zb69pHRW4R0NRYcmW5a+ZJYtiQQEtboKyM1wbALwC/V7RcRETDUApsGNA0ZklJECOf17dx3Za62pbhY8pdoTXYtDATItN1rhtRjMFVuYtMEVi/acemDdUDB5Xm5KbLPWrYXWYAIYIQYsnCNXW7m4aNLk9N67EHTLHF5V65VkzBsvNIpEDpA+4E/mHDwuMW/9pyXAHZdp77mJkDLiKPC8M1bNaVGPCNsowQ0N8eWPT5utefXQABw9scWDF/+bL5S0MBlEwOFIBAWxONO3a8O8ljXDwzYfPm9j8+Kwo8CVu3e66/ONi/jBg3QKIiIEhSzjN4KBTe+Igjqh7MFzpVO0hLSEiadtyOLdt2P/BGzsqqwKIl6dOP46eeSMyGACzBlX3xyW3r1uz8+X06o/4njU2ZMZZSnKoqzgDokBqLyNo+F37Tr+pdfB/znKJlo9ZWs76uOTsn2WHX8wuypSRkXDXgMauYxDnk5KRlZ6dGyj9kscUZYFMD1tU2Z+Q4Ezx6c4u3amdLXl6qw61hVOscsKXNt3lTfWlppsMek9cCJSa7RowYHO4JDG83BInI22puXFuVX5SVlmozD0YOR+krAIAwAwTycKeFEaEdJhD04vz8E49rvPLGBIDKU38XyEwPcHSrSp0GENS4u6x32d8un3fjj8q2ZuRce7HsV+gHMBB0OphugfjoHG63GwDa29sBwO/3p6SkWD9vaGhobGy0kNaQIUMsvdDOtbGzjT9cKpUIAQ6MZOgRR0aIkdpF6EljEikxsWDGScgFM3S+cLlcvlrMOCWY5Kbv0d3qapeu2maiZaL6usa//eXh1cs3/eUfvxozrsIUJjLGYrQWrM1BVc8LwafGxubHH//36y9+cfNtV8069yRusL0e/dg/s+rq2vvvf/yNZ7949LnfTzlxnKZzoqh2PX796EySocUc3/ebQkGcmYxroC1uWnbMwttAc6qgF7jEHPhI0sVtg0oChk0Dy+vuGwYcUWsviuiMAmneXsWeC6+e6gty1Tarav6hnNYEIhEMlg8pcxmgkUwfNKDXadNXXnoPW7h88BXX2ceM9HlsBEGVtSqWZ3cC0HFEFUdUR3jIMPGH2YpyBp0+re7ZBaseeyTjmOOyTjtFZKZZYuKEkDyw/7hJ49e+9heC5PzfVmKvNBNj+m3xUNMxjKhSHVD1uK3N/+KLbz/64NPXX3/FOeedQCEMZlp2xco8EKMiVhhee6z5HG6NfuCfjzz37Nu3/uKS6aed+ODDjz3z+Fs3/fi66WdMdLp1jEDDJx5/7t57Hr/llhsvOO9Eu8MIL27Y6dMSc4QyYIp33/n8N7/481lnzvr17Rd9Faonqcr+4UVUEZs3tFTljebmnatX9od0BusWLZhfPnyY39Bc6upxAC8IZgbqli3zgY/B5k07tubrGATQ6EhuFRzVw1JUdzqdfr+/tbU1LS3N2iuyegPnzJljs9nGjBnz4Ycf7r2kWmqtQRBIpAOLqPKTWvml2rqSoZvD0O/kdrDtrt5R/8QzJe6kXqOHSY+HoLP8+l1faaKdMdYVYjFLLHg8CaNGHZvgLMzPy1MK6HyvX4zRbwLyeDyVlWNqtjmLivpwQwcIsm6qyNFfhNTk1MH9R5gnphYUFio4Fb3wh37VD9BLEmF5wvtNK6fMvxm4DUQAyDfLPf7R/OtEkkM6bEgsIu57RO6LBLTSBI4AbsM9Ynj54EH91UY2h07maITIwbnDDgTMp2leDHaALxU6jOZ2MEK31iTTAG4lFSwej+KI6tsVhMK6NSQBvci4kGRKbG/h0IQtXvC1AZAATag4o9c2b9mwsQk0FzR3bNjoqqvQclIIhRKHZGGfmUMqmFnhTBCK/RfVgJgv6G9ua/cFzbCLutoVCU1aJS9sHS92CmxaRxZUL/QG2jvaWkzhJ4KOjkBra5Pf9EqUmiJHCZSIvDXQ0d7c0u4PHQwyKWU0UeQWAJIEEWMKG1LQNP1+f7MpfJGvMyMqTl0G63q+EqPC8IcrmLWBJEauUEglPwVdHbzu5XeTnpyb+Mo9Kzdtlrc8rBUNSJ1xQsDG1Z6HTGgJtL707s7HHhhxwZUbk5N9v3lWy+6VdMW5pmn6DEMniqu7fO1hGEZqaqrVDFhXV5eTk2Otu4FAwOv1xj4kUR+30NQKBDWvP/Ss2Q2vjdvVLhBHYBKD7UGSJtccnGtO1PSla2pu+0ODh+X+/Ma2ijIHkl0Q7avVQR4Fq9FXVDEggAB0J8WVmOT8wdWnRNRRJOIeiAoh6ioQyh1It9lPO3XKqadOUqYIRKRHrfa6O0hpcxjX3XQmWFK5FISwfcuhbqih5T/R/datxVWQiPoHrWsmzb8WtATgdgDzXF/h064L20cMbkSDA7OBZGSx7eEQLXoOJjmPjXJWEZBQA0l+r7+hrmH9qvaaGq8rkeWVJOQWuRx2Q6Jfk4wT1xT5IXSuJAUEgmjgnIUrHnu+aHyhkV45/7MFfV96N/GSWWZKsjoHycOnFAdVcUR1pMJTNKXaizPEAAwpvJu2rXrhFb13QsUxv1719sf1L73VJ7+I52cDki0YXPXqa+sXLp141zVUV7fif5+U9u6desJY4dAtDVz62v0tljKBWiS4EYpcJCUL88W7ydeUbZbtrNOnHTN2fGF+Zlgu2dq5RJWZKtsVipnjFukciEkkDdi111xxxswzcgtTXHa84spLTj7plKLCHJfTTsokhpA4yCsvOf+YsVP69SuwO7glbSVIsGisQKtJ2fKOQUPjJ544viD/kaLCgq9SnSIi4qj3GJUhzNiPmh0rrSwEbgJwaYLUNO7bXv3Z6hUjbjhNThgzaGTlmkVLFy9dNHj8CC07NXTFhWhcserNx/4zYNqZKT/9oeHt2Dhn0bx/PjNw/DBH39LwYh8Rm46Hia86TNNsa2uz2gBj7bQ554Zh7AGFLRFrMM3GL9eveOL53K27cqdPcp13quBaaN0hDKzdsPKfj6S1+vJuuoYN6NO8eOmOP/4zYePu8tuvAadb7Gqk9CTSNVX+ZXtVhIlFzSQhlnWNRzRAhfCTzysXzF+sM33g4L6uBO3AG2cUaxXDY6sdsWGPrEINhSn+QN2YrYT7gNWFl2g5iJNlqoexO/17Ri+0+mKUY5U1M3BPL5uvPthe5TeVxllaK1ICmOomLmxcMWn+9SE4RSaAeYFe8WTe9bIwxYFKEwbIUN4R4R4HOgy+Mp0qexTpr+nSexgwadO6nS89+9abb3xSX9vAdVuQ/LqTVw4rP+fc08eN688dXP1qCD+GUS9j0NS49sU3fN5A8q+vc+T32vy3f23696v9KgYbY4dLXVf6hxL3uifxqBRHVEcCUXWHVKipteXtj7Xn52b96iI4Y4ae7Ky+b3ZpQR/9mjOZoQVrdxlzFwyYMcU5a7q3oZHVN7F35kHlQMjPMhmFDQEO4YFmCEEUdo/HHzSF6bXDvpQ2Q8FBgkxL8aSnJgCBKWRra3tTU0NKeorb5Wxtba+vbUpJSU1KcguFWhCIA6utb2hpbktPS3O7HUmZelJmBgIPEqWmJ6alJYQFsdSevKaCckqSe+wIdyxusHY429s7tm7bXtK71NCprdW3Y8eugsIch8NudxrDR5Yi4wfpKMaIZDAgJBmGrafILogsEPDXLFpqEKaW99Ps9ubd9dtXruxb1h/y00JhSqDuclZeeXFyRlZrgtPhcfa6/eb21nb0GExxdUmYtsaWYWPGJs+cHOxX4vP7Mn95Q82cub4dO919Sojz+L7f1xuBQMDn88WS4hWHOoSihg4dOm/evK73Mey0KEiaGqDL4dlV737pIW91oxg32FXSxwQUPn/74qXe+/6aPOUc5nB4q3bteOTf3v++lgY5a/71VK3O8odV5lx3vpmXxqW2N/plFH1KZdh26luwHlnL6aZ1VXf85m4KuO6655eDhmYp6uMBt3eiG3BahLXTWeWyKn3hj1BSA7K7cpMl+csVOyDylTFXhfb/7RhpSGFfB0Kx2P8jhI35FDqJzVNRho4RVZaI7NPmtZM/vwb0xBCcCn2vmJUw9sk+NzUl6Q4AGzD7nofCDk8dUaI3AEKCSw9dOWAggmbA1FBHGxdEGzfv+u2v7lny6dpR40b84IpR7lytrcW3ZN7qD1/6ZNPqqqt+dPGMU8c4ncwEwYgxdSGRwN/UkuznuZddbB85nJJdxeefGfTN9m/abgwdQElJoQwc4voIcUT17UBVImzDEt6XUrkOtrS3fdmwI/OGaZkzT5JpCSlnnrizo2Fx0/bBtXVabq4vNbXXr39kT04Dt9uemV5++y02bwBSnIyCADpXi8ChzFfBgBG6bW4QWpvfG4QADyG0fcQfxpQcVSj++n3+12d/8ui/Xr38mhkzz5r6/luL77n70UsvPvfcS6agTgxChyYle+SBF197+dMf33z5CSePcbo0SVKiCcSY5EqbSiV9RPshgSqCO7792kd3/vGRa6+96ZxLRr7z5ty7/vDgpZeffdV1p4MVSjoRxz4L9ZZgVkBgh9+ro3A63Aj6nq3yX/feomETH38+95EXjv/drdqwQWvvvXfHl7v63v37duAOYa798MPc9xb0OvUE6J9s+CA4bwG9Py9r2rHk9gQtnpnBHJNGlx070nTaScokw8ZPmpB13CjSuFWDPNprU0KIjo6OQ/8cu93O2IGfd6/XS0RCiNh2P0t2oaSkZP/aVFZ/mU7MkZedMXNi07P/4HPXZ74/F7ILyemQNbX+975wQVrw8hmiKNtb3+A8doxekNsmTAN5iol6fgGz2YD2oSCG0g/oZ9gOTFcTl/CQCio9AKes4jJAYp5n4Lh+uuZxZjvbeFjbZf+/GSVAOULXjaLERPVMo4zWr5TPpXVtrfkpEDQCXYDJrHcyU2kZd3M1uts7pR4tjVBkJ5Yx8CvjBRtwCh0gNwGDAA7EIIJQBf0FjWsmz7sGjGSLPjDTNuC/WVcHirPbGTpDgIR1dD0ohtSD8ixW61BYbEpi3UOvLv3w40nnnETTp4L0wwOPLVm1MueqH6QPr2hr8N77p9lL5qw4Y9Sg89t3DtDb6ZRTRXPbCd62Ex+of6+67l8PvpSV5pkydYgZ9s5RxUGQ7pyMxNtvNJ2636EhUsq4YfqgwZIx8LhlHEjFEdW3biBElU+UZ7BMSU+fdNstqktGB8S04uKJv/wpmCZomjSlU3ewgjwCLkF1n2RlQNCMsKdUf15P1Fh0rjt0W3NLCzsQPEMMf6eUsrWttba6trm1VQjqaOvYXbWrsamFiAymGGCAQkJHh6+pvr6jwyekSsqJ80hAVBQDUv7K+2/BJUnQ0tpRV1tfW91AJFvb2hsb6xvq6wFAZzwshXrgAKv6fgPB+pYm3WazGbaectOSqspWeN45Oz+ev/CZF3svWVz17mcz7/yzLMoPINg0m8eT8O5dj+Zu3zzoz791Nwf+8pNfjGRJk04/XqXEwgKNQRsXBtM419XCFNS5YC6dAWffhSD2nBqH/jkLFy4sKytzOp37wlVtbW3dClalpKTk5uYuX7784CBGaI1x2RyugQOaYNwqmJP++TJt6iR/UWH9rl1b3/2isnKMs7R3Gwc9I6101hkYg8WAQEhiSoQNulv4rQOXkSKVPNJVKsvaWZCZnJJw5+2/BIAOEALMg6lDRLsmQvg1NJslizTuSow08QF2JY+RJTJneZ5YxlFhdnoItSDCHloV3SAS1T+MDHpAaF1JX6KMfpnK75QzjCrZRPhkgmS78C1v337c51eBLc2ysTjPM/SpoptFBg+EzoMxoGDo0nW5bIIQe46YHjZWD32sIIT04ZXVf350XuPjY/qXrvI2b73phwUX/CC3IL/DlMs3rnv58devvuHsH58+dcNxZ72/bOXQyiKtqe3De+6rGNvnkvNmvXf3f95/953RY0sdLoNhp2E815k/zaYatxkABXTwJdtsUtORxeFUHFF9KwYTMRlGaL2UxDgi0xBRmhIEaLYAY34Q3OenlZta6qpTB5SJ3Kzghs24eqN7+FAzJzWI0iDOEUljSNbedygQEB6CYLp6GVJPMJJcPKGmqboJGjLAfRC/KO0uOPuc4ydMHJ7bK93h4iefNm7YqD5Z2Zk2OzdFEJkuIaBr+rU/nDXrvONze+W5PTalYgIETIbyoSARcaYdRLRhgPKMWZMHDi2qqKgARmfOmlo5om/v0mLFMQ8IQQbaVLHKahhm+ynb+c3m+uadaXpCui2VgWYRRg+xKM8ATQGQl5nx2x8bI2+oef31aeddHDh+eNAOyRJ9GMgeNWrS33/+2V8fDtx1f+vy9ccu2NRnzjPBirIABAz15SFUxbjaZxBBJOCkEdeRSUZSZaTKjjo+YNiwYQCwfv363r177/FPLS0hNJ+SkhKrqJ6VlWUJqa9cufKg72YI6UjiPiB7Xq/Aw1fVX7bG9cQX4tyNLqer9r9vil0rnT86DwryGWgitNSSiRS6a8wy9wO7oqXEErY611dgyf6Ava7Bjj4hUIbefoQzf4yWdlH41T6dRqgBHrhuhpYCjC4J2hE27qpr9IuRhVmMiMs9a8WxviRKa4W2N7RUtfrKslKT7boWlIRIDLrZ3u4ONeHBbAl+hfkbkVy2YJo0cVeLe5vgbe1G1W5TSj+DJbR9zIobwEgCewbI4AVNOU/SD8whJR3+etrJNWkZsIY+x9grVmJ31bWvX+6NmJUFEaCXY8ZPz6u57uf1v/qrY932DBgxYNaFXtPv27xt5RPvpCTZjx07KLEAB/7fBR/denvw4luD2cmVKcm5f72pKaPXqIWLv1y9o3q7v3dfF5FUzrEh/CjQMMLyFiwMMXlYfZ3Ha1RxRPXtGQLB9AVqly/LWrtFGzEU+vWW7R3+FWtw/Vbn6ArWu0BZobCdu3as+9cj40+YmjBpwrbHn2qraSivGKS0yCWHcDIlACQDLaz3dKiPORIYup7kSa5prJdkHmQURtCJpAYeM6gRQWKSJyXZQ4rEqaiZAhVyyshIT89Il4RSSZ0rIVBkiA2NHbVVzTn5ae5EGwstOuwAhTHSHUZKwBc0nJrDaR88uFSoIp+3VezY2pCZlZKabpewr54ajBA2ZWugsbapOjE10WFz4p79Al/zOkoAk4MuoMBkVcXu4KbkgM1w+ARyI6CDDpokmXjWjMJlK2rv+WcTOMb+5kY5otI0TY1HQjnu6XYiUDIWKwR/VIp86rqen5/fU59WVVVlmqa1+xz9YVNTkwWhsrOzrW4+a+Tn5xuGsX79+q+TZ1i8dSLhdutjhudMmLj9oxfccxelBmXbo29oqSVmxUBwu5SFFGC4DVM9wVbfPkX65XHP50ToTNa0fHbHI5VitykYhZYx7xFXw1clNRGZIwhfZS8cQ0kitQj90TVbF7fjn8eWujXu8bfviVpkhDJNUhI2Odhbq7a93aBfMbhXRZI9tbnZp3GTs25DDTtsIiesq74wl9BuA4kyZ0FVeqC2/a9PNnwytyaRalICp0/fDbb0UHRrC8yqwgev3rbt5Pt8T8kAA8G43SRry1J0kY+wTnzPnk86JJcGVfGSIJmUTGgEmjdoA1b/ylMSWDL02XHv/W12uQNS1n+0JAOTG/7z8tZnaoINDVngaFv2bnBZYdHffmIfMkDUNvQvSntr5Zba3W29+6ZKKVj4gUWLVm9x4njUwSJSZKRDcOuKjzii6qmAZWmNhxBA6/ad2y/+v7Qfn1r8ixs6tux49/d39fbpQ8r7KWInks1WOKTc07+88Zl3O5as863ZWHrp2UZmpiTiUXlBQMHCupk9xHhEm2HPTsmq3rKrUTZlqfmjqBWdzSR7x6KAz3z/3U8ff/C1iy+fcdasqZKZwXCFXFdRWVh5ryQh0fqoCNsJgQN75ukX/vvs+9ffcNkJp4x2uxxKf8FSxuq2ow0/+N+8O/9437XXXHX2+VOlRaFEMk2YP3/VH353zxlnnnn19dNjeBrQ7T6B5GadqKlrqi0uKXXoTrWfEL2seCgbB6Ffrmn84NEni3qnF47pu/7xD4vPmO4+dlhA11RhUkq3090rB6ABoBBy8wIaFyh0U3BkShxGWkdghs+cKXnJSNd5+D4fffT08vLyrVu39tSnHX/88e+++24UUTU0NJim2adPn+bm5ti3FRcXM8a+DpbqCn/U0gKeXjnFM6bs+ui/Ha/N8azeatavSj/pdLNPsdB1DaRBFFn1WRdM3B36DQIEkRktpq2hLamuhZQsN5P+b2I7RW3DA8du+mQEEJqkB4G0ztJP2EeFdZc+MLSMV8LFJ1MiszNbeW6eZiQmNta7CBNbWvYADdxKdyicW3IXH5iSWZedmS1b3VX1ybWtAUMPGkwRw2nP5E0cNkQlu95xApeDJAq+vTEFqh3bHVsGBiZcnQ4+AtMBjM+q9/zn7O2NA20NI9G2fVeCTzPtXOjM5qMQItVB8NCry/ELhnsgwkO43dYWLbM2Q1F6dWJN3iCYTvBxoBZoTF2/2+Eymtwsudm0OwO22vrEtt0NvjYOHYkArRDkviCYgmmaJiQKsOq5iF3hnvp0gZ3paXQ79NvQSBEf32tERRC28A2ls05730kTdv3w5M/++2ZessdcvzXx7dXpr9wlB5f5yXRIHmTgy8mwnzl916erch//y9ArfmqecXyrTbNLqRNFAgzqXytN4DGFDhbhM1jVXBd3VnjKn2tbtT6wtp+jQpIwQ/m3rvbXu99HkwLbWzpqa3e2tzYTESMebuMFq2lYj7REc+VoHpq6QkrGAJkpQW9qbKneVdtY3ypMTtLSnokkRF234SQJIK2xqaWxqam+0a+wlFQlegaC2lvaamqrmpvqDwZetoNvuXdtXaBlcmJvN7hRohI1P9QAwSmEmRoffdz/7mfG/b9L7933Ex1rfvq7qY/dawztE0BExrTPlqx5+uWiY09xflz15TV39ztmhMjP9NqZLtX6FLnCvMc2B76DwypQWZYyNptt6NChu3fvjv5rWVmZhbRWr17dE1lG+GHkLrcxptJfOVVb9FrHYkiAwpQxw1l2FifJhWo7R4BQ1kB+JiRDnTQu1UTY68kyAGymrO6bXvnYb9Nzk/Cbu8kCTJMIQdMQg2oXR4tdolXpW3QXjbueAErgikwOCCaFmTYYmq4ZCNdFWVN04BPLBCgFOJMii3k0uB2pEfnqhBDyDQaff+X5R/5WfMGM4/t9Aq3hfz3DOeQ/x94EppFMRnJsYTsqZvxNHL8ifZGmlhVM8QW8s9/YdN5P0i+4Zk11Vcp765Oe+D2M6W9rDrzyl4c3/XtOwm9uTRrdy/b8c4suuigVwA47W3/6VMr4sS05Rauq2myp9rQcqw1Ww7CEVbi4ymMKVNGkLo6k4ojq2zHQUltBIpBJSWlXXpK7ZOWKX/7KgPzRv7jYPWliIBhgOgvXVc2gaGnWbExCbnNji6OuXk9O6tJM3EVa4FDDiIXNDNCyE7MJYe3G9TDQMnPZT4EqFADtNvvpM08ZO2Zibp6HIQppkkTOOYtKm8TonFtoSWNckhQkDZTXXn/FjGlnlZRmuhJ1IYUVipGUXZoAqVm5nNrzQs4YnHHmiWV9Bg8fWUIs9HNuHZiBk6aOzst7pLh3L9ivALqluOP3ejduXW83jLzEXEORqBB74DoiQnObr8njmPG7H8O4MWBzT7/uii0vzYbWJhSScZSNLdv/9oA9Nan017ewRV8+e8sf5BP/HnDz9ZrdrUJYZ9LaQ0L43/ExevTo2L/269fPMIzFixcfTBvgQS6uGHnOJYKWm+06bqRY9I4PyEgsSqoYLDROpgi9x+cL7q6Xu+uQiGUk86x0dLigCwmpy2RlYUK1RQVmYTDDDmtGJ5EwQLCjqt7nDZaUZhuGbi2fMcpNGNE37Tzm7uiF6A+KDWu3mAHZZ0CxXWd7VFxQInwlgXCMmUJHZLC9sadEBl9mBK++IxECH4NXU3oOSWcm9nm+5OeUJEFxWKELS+GbK9yEADBjCMzKLYI7d7/06FPDxlZk3HKda926Re9d1fCfFz1DbzHcieOOGfPkv+Z89OEnA5LGVD/0jMYGOGRHG1TVQf2CR55ynjRjwWfLJ04ckJ1nC6ouAhY2tgj3COwzIsUjUxxRHWE0ZbH6LOCvGB/UKyvn+OPkp69JSHdXjvDbDAnkkMLP1C7Uui01T/83KcPN77h13cvv5j/+UuZPrhEelwmo9bxrCgtzUkErSCxISUhau3ldcKBpIthJVzVxgu7FugkZJaTpSelJREJKs63FX1NTn5qakpKSEK4dY2xiRYygrqapsbEpOyddS9DSUp1pqQ4CISHQ3Ni+Y/vuvILcpER3W0vr9q278grzExId0W0GIJIUTE4TgWBA5waGdXxMFWKCzgQhwE97UUL3uA2E1NzRsmLrsrzk/OLEItZFk/CQ4gQRJLmcST+8KtzASEKv6F9a0d9azBymXPnxx2Z17fAfXirHjWMVFbaWOtsHc2HCUvvk8fEQdShj0KBBNptt7ty5uq4frsIYgJmRxieMNu+qaIFFeOmIXpUDBADjIMxgw+LFdfe/ZJ+3Xqtt9Y3Iyrn+YvfkCeB0KI7vPh8tjHa7UjSVOFxLsATBUauuqfnT7x/esLbu/n//rHdBltrswRhKjGULLCJNbwjEeTeFcKyqrr7hhj+vW1z/1ud39ynLVvUpTe6FHrWjSeuDwhmfAOAsAOZC37pj8H7wJVu35RSj72z35VjeO8BIt6qPEard4Z27FIl+kdxWOUKwsA0ogCmk/uanOSm5iT+Y5etfGuzbq/jn163bsa1s4ZdJ48eNGVU+7dQJbzz+Cs1fW+nMGnPXWc3vvt1oysTy8pVPfVz9zpbk4t5Tp0ywO20STA00Yt0h3fg4ygf7jp6XhQCkQGBCimVrq976kMFIAFn72rt6XYtugj+UXzPe7qtdurLK255y/qmpl5ydcNrkbZs2+qt3KVNOENjD0rsxKSIme1KLc4q3btu5pmMtgT+sO7XPqgwyxBB2IJNQCgkLPl/5i5v/8v6b80VQWKoIkbNGIuTAOGMvvvD+zT+8+9NPlvoCfhPMIAlBnIPx+kvzbrjyzk8/mm8G8Y3X/3f91Xf8741lAb8pQ0AKAE0knPPJ0h9e86e3X1+FGBYvBmDChMXzNv74ujtff2EexoShbsuEfunbVLt5e31tSV5JuiNb9uSllISmBFOEbhGw0CmbQgoiVWZjmNKv3+B/3u6aPpVxlImuU665vPBPP4OyYkAWn/MHP4QI70yVl5ePVuOLL75YsGDB4YNT4U68oHAJYiDtMCJt8nEiPT0IFEQMdPi//Gx+PQRy/3R11it3+Ima3/oIahqCQAEW1QTY70oeaU81D88rdPChjAidDvvg8qLho4vcdtVhzFDFExJAYT1eIlQym+qFTEqSkvYaDodj5OiSyaeWOR3IgDElgHD0B3EUwARna9p2rmjZdMwnlwFPBWRGu+d0T+WrRT9rG1riA8GIAgyDDIFFeKzfzMqxZ34aeiptRHaGjukTJv7xJ1nHDOdIHm7vdeOVo352s6dffxNMp9N29TUzCwbnvfLFsg/cuW/o2c91OF+l9NntSa9Kx7I01wWXThxzTDkD1CHKIpFwuM3j4yNeo+qheUFWVhjYUVV954PtHd7Cp25uWrhq7t+eHzC0X8GlsyS3MUROUFBYlH3tZfaBZcGUpJILZsHqNcxhUzZS/DAlfpIRk6Bze2lxv9cXvffFmo+KKs5GcIaPHLvf+FM9JwxQU1Lq1NzStqNqV3NzuyCpnAow8i5r8QgF3ub65p07dre1tIV72CRnyAGhsb5pd3V1U0OTFFBbU797+6762lZQ3ssW8ZcAmhra6+tqa6ubWSiwS7JkeyW2tXXU19TV1zeHZZrV7uoex2u5Irf4m77cutylO/qVDdDAJcDswVQsYt+F0V5vqXS2eCi1ZDl9+8SCPS0rHbLSaQ/f5/g4iIqU1bjw6quvxsqgH9YyAUcQjU3Vny/0w8ah519mGzNGdWCEHjRNYv9Bg12jx+qVg9Btz3n6FbPJS8GgUDiMDrSVRTHL12F7ClTjA0FqWsplV8wyhemw263WD4rJlyjcHc/UmUnLP4f2OnwiSk9Nu+1n1wBJp9Mdq77Jjj4BWop1XGYAC1s2jPz0POA2cKSDNKdtM17fOAV+dWnQCATBNBjnhEF1T+kb2aUMZ40xOhEiJjvnQFwyUZwd0XxQQDYtGdKSFfU1wEAOHtTrt3f87Kkn35n9/nuvzV2Q1tJhMhvftKtg8tjzzp124rS+OuMExMIUjzh3M46ojprKm3KDAia9HRs++Kju9TlD/3ojnHcGDBncuGmd7x//hor+xpgRJlHA4+TjhznVXLJJkHlZlJcFYDKyPALY4cB6VmcfICvNKitMzP9g5esTK0aWYJrSkmNSqc7spfxpWSMzqwFZM2DKicMHVxRnpmfa7LolxRPOq5TijnLiY1dec8b0meMKivNcDoeUwhQm10K58cVXnjzq2LJBg8scTrro0pkjR1cMHTrUYWfCMrIgDkjTZ44tKcusqBwaglHM4nwQN2jClME5hb8tKS6VIKWl77OXgII6DLGjY8uSqkV9cgaUpvUNd32DxAhHnw5BnEAiCtC0EJQkQClDt0mzNnVMIK58xzqtTFXgCqAVFuOOo19h/P3vf//ma+ZIAtdu8PzhOQdk2Y4bSUluLqQu1P1LTEyfNqUFIAAU/HxJ9YbtuZNHYWqCjSIKlPu9tyx2ST/MizMS2XRms3GiMPCP/dpQxoEyEKANa7dyznoVZNtdnKO2F5UqlOI47RpjSiVNsdaOUsayABnh1cOqtq3BYMvIz68AewYQjexIzvaxP126perprBwdAqCnhDVl0EFhgXUr0GiH85YRQjuATb2UkTy2AzgIjJgMl3eiIKn6q8NEDV0aCCS5v395zh1/uWTGinHLPvp0xz9e4nnJ06+/uPe08R5umDIgpeSW9Fj0QyBeNY8jqqNkcAASwp6XO/aJ3+iTJwBAUnHhrJ/dIhYvBYcjWuAFEEIiU7klEAgkLSyxHrYJji7NUa/SgwxosrMoFQOmIMzPRsBce6/xfY59bOk/VlStL8gpZxEXrsgbu139w30uCQmJiYlJlpY6RhI5QKjZ3dDU3JaZmZLgcaVmJKdmJKuCkaytbW2sa83KTnYl2JKSPaNHV4SSMCmJeEpyRsDnM2wOi6hAJE1JwmQpSem+Np/h0jgDxsKCnqYJHmeyCJiSbBjrZRNhqkhVNPcHfZt3bGzxN5/W57gMSI2YqlEPrbuxPM7w57K9yg/Y3WoaH9/y2rLf59u9fccuMFIvOh5GD4+1DRAkTSFCs3blmvn/fNhdmOY6aZJMSIjpHulOsPKQyhbh1vbYz45IrXXaBHY9B4KoKgnxbo+KiBhjVduabrrxNwDaX++5vc/AHOy+Mo2qLE1wdApoSyseAFAo++ISYFHLuuFzLw3NSFsakDyZSl+rPRHaWt7y3FkZ9JFUzcp7PRU9Pn8polygOA3ECP2tLeDzQ5JH2HROLNjRBs3tLCUZbLbwUYSdDCOUciJL7VmV5ImFwrouQyeAIweVjsxK++x/i5rzU4dMGOPnRjuYDmQM+V4gPz6+Y9Wc7+h5MWAcwObx9J46Sb/wLMrJkADSYfCRQ4yrL5ZDBykGoupZtRrmFMxhCEYo1dUjxXvrFd7tlnv51x8gLVOplYxuN6DlwACKlIpIkCDTppROC3i0z1fOrw3UWgRaJIn7vFnWJ1kyVEgkVSrFIrqZkgheeunNX9x217w5y7w+0yQZFKYIJXzspRffvuVHd3zy0RJf0JSShFQUWsbefP2Dq3/ws/femi/8ZrgVj6TG+OdzFt943W/ff2chZxZJU/1PyhXL1t76o9tfe/ljDRmXDLvEujAXzCRR31azePuipJTESUUTneAUYRzJeiREWtUmZtm8gsWzANV+jDyyAdr5+Sr6aRGLrjiu+rYPU7K0rF733Zpx1SWyqBAs/p168E0kXVLHkpXr7rqvT7Nv4A2Xw9ABAZ1LjPoE7z03yZL+OMRYR12xmYx8X3dPJwFKCm8NaZ0NvjEvVCx6XdeHDK0cMnSI3aF3+2kY5rJrEIpI4Q+xptwer28xohIUekkNcGnL2rmta4d/fhnoyaC7gcQMR/lrGTcGL5kU9IiWdOToDfCwHkzMtQq387CeRlQWmlL9zhI4rpu3cMu9D5kLl5rSD96O9a+/ufXRf4vaOrUDEAFRoXWBRdgDzIoqGiDnqO5pKMAEpWwBgo724qr1Wc114G0Phg6eM9xDHQO/9XcvPuI1qoOuG+0HTspOJWOQyAQwPZR5SD8wPZR19kC3GkQI1RnZaVP7TVq3fMOyAQum5J7EBFNiwHsTB6L7FZHAa9mzd54HIRIJaG1pqanZ3d7hlyQZhj5PRWRoaW2prt3e1t6iVA4thWZGAM1NrTW7dzU3t8mIBAMqNeKW1qaG+l2tTW2ozlgJNEgpRUebv66urrGhOXI0kbTNgp4oOekBEVxeu3jV7nWjK8ZmOgvJ6sHrUluKj/jovqTBXPbcSWNCCF7nQSYlkq72yAUCmiKwdLX83YPpW7fn/OTioNstqmqM5CTTqUsWBR09XjWLlKU7603ELFuB7ldqYfGiYH/NraHZm5Pv+dEtFzPOkpJc31WorxFT5Wk+r3H56Pk3AgVBTwIyJ2OhIznzldyb/Zk2DASRCIWkb5BZFDVNCGXOhCRlgttV//iHNVt35JX8zPx85eY7/ll2zFjQDRPDBve823sUoV9Z2TJThs/WnqXgXIaCKR5p7a/4iCOqIzQoFlERoTdAwSDYDDI0kia2eUPJiNNx6BV4VTAOwTRDs508ZPo9y+79ZP2nI7LGJbIkbrXVInYf3K1QTtLa6YikyhEPU07nnn/m1Kkn5hdmOV0GgQi9RyBwuOjicyYce2yffvkulwMiyuUINOucmQP7V1ZU9nEoPlaYNsvECSdO7JVdXDGsPwtvh4a+XdP4mHEV9/z9roLCHKA9/R/CpTJGbd7W/2382KW7R/UZpZq9ZTyexMdBzkCBIOxMAulh1wOKajmZTS2fvzxbe/2Tgn5525+fvX32m84hg/rMOkMvyCKOPeVjvifIkxTwB7duqUKORcV5nKO3Pbhlxy4GrHdxnqbtaTlgJSaBYHBX1e6ATxQUZRmGvue2n9rME2CmZyUyteLK7ypNGTkDWNC4ZvSCm0FzKe8d8wTPsLf0s2FQGfAQmLERDxIh+0ZVsjBmM5YxJkyzaFhl0rUzvnjoqYz/vLb+0Zfz0lP7XniWTEtRHQMsslnBuiwVGOsjGO17Qezq0hinoMcR1fdl7OG+QiGoomI6gE3IwOotVQuXZBb1MsYMadq9q+OdD1P7DeQjKsFtO8QvJQqnuSh5pTZ8bO8RL26cfWLJ0sq8YQ6ZqDYxujOHCXOoQnCqudHb0NiQmJSQnOxUrG/LzVnm5qbn5qbLUIgWDTWtTY0t6Vmp7gRnVpY7K6uskwViZVEA6enuiZMHyvA+hmWXRkRmYpJ77IQBofdIXyThDj0t7gQYOqKkS/7emXczIOaDji93fPlW1Zwr+1041DZc1dAYQ4pnafFxwMEQHcBjlC9Vi2qYIgia159SWuT93axqP5kByQOkOxKkJJ2YoutQDzZzRrcRJQWrdjTceOWf7YnsX4/9PiXNsWljzY9v/ofDjg889IfsTBY1irb24gVwDXB3Td2f/vTIxi/rHnzs5wWFmXvUqawdJMa0yN4hMST8Lm4Avde82iAxYeEtwG0AwWmteTwrZ3afW/zJ7iAE3CYJJkwMb8jjN/60RfULvbomdWy7YmbB8uXNN13vBW30w4+bI/oigbelxRUw0eMUNs4kI69PtvqYywlOPdyajTJOKIiPOKLqHutEfNGJM2w0cOPcufiOv5Bh1aL5tZ98bi/tY3Bih+yAwFShCRXbket85IAxn+/6/J3lbxbm5uRhInWH9sJxXr2kgGVL1zz9xOxpJ0+dNmMM04FCWb0CSZbYTSg3ZK+9+vEH78695IrTRo8dQg5doSWMDdyhvD8S1GM4k4ptSaYiiTKGhiRikbZHIs2q4u0JRsNKBmJr4/q3Pp9d6smv7F9paA5BYagFnRIP8REf+6lSdQEfFmfQYjJqvbKGnne2JedkYRKrOZA6GyR6DLgjopTEGCJx3c4GDMu2O3VNKTjYbDikPFPXEMlUVjeqjoadgugSgXOWX5DmsOmahvs4S6UhZzUpokrl8LvWh7qgac3URbdCsBkMN0j/ND7wdXYqlI0IugEgYA/dPKnkMpCO0GMWHVzdtSTByW4LQL4NGsBmgF8wXd+wenX+mx8nTxoPoyvJ377l/Q/cG3ZmzDyJivK6HHc8tsXH9xxRkbKUooZGNAUmJYHLjpKoqRW9HUZqimkz3AP6jJlx0s47Htzxy3sdQV/F+dMShg4y7ToQHYweDO7jh9HdOwqjK6N3ZtkJZSc8ueSpjA1pV/QpNKSBpKpOe3yMlYcjkqSmpuYv16wfMXqYlKhYsBGnLgwjNgSsqa5Z++X6utpGU5hG572mGNJ2CBgJkhjuerHEpboUlFSXEXVNsKnrZVRZNiGhrPfVzV754qJdS86dfkG/pP46aTKUf4c7pr5e1NlziVU8UVLHjOHTpogJT3deJPFxVE3JWA4hRTbRwoq9jEnDEBDWGle9CKQB9fiCTETt7d41qzfqun1Qee/s7PTbfn4tEKWkOAGoqCj95lsuJKKsTANisVQkWZIAGRkZl19xXsAfyMhIpX0v6NGZhnj0xlCKddeRRBzxi6YvvSIwcekvQj8zXJNbsp3ZvWYnXCL7FQoQAsAWlhhj2EW7syevgtUSxMJHp0SKEVn0iKMeY2AV5sEwqfbV/61dvHr0D8/xPf3h6mdeKKkcxMp6u5yO3be/uGP12j7pqfYt2z797Z/HlFdknD1dYtTdIl6gio/vH6Lau6naBMCOjqZ33mv8bEnp9ONx2sRAVe3u59+0czP9nNMoI9XLefLoioZj+3n+9vsBCSfCuFH+tGSBzHZwFMooIxFj1weLoRWzYSYQ3Hry+N5T39zx/vMfv1WZOq4ytdImnIJEKFHuIrMTdtBAHYaNGfCHv96Yn5+n2SxSJItBHqRo5nj2+SeMGjegrKzU6bSxsM9qmCUWC4bUlpzV58yiQlGInFu7HoCcdWHh7rGEBEPZHeiSt4F3wfYFD66dPaF82JlFZ9vJiSQ1jHZaUQ8EbQwjKkAhpcbDQjJWP3MoagYjnVBIXdEjxtHWUTFJsds5G9UiIksVJXIvWeyjgT2JqDZv3vbL2+5N9GQ/8cJvpTB3VdcwZJ6EBE1D3eCZGSnqy6151kW9M3yoDFOTE2MzGNwzGoV7aLue39EGp2RULUKRjJQs8heNq0ct/QX460BPAAqcESx7DE93l4xsSXN6CDRiWrgZV1oz1wSBFGnsO2Qd3sitkAKZTwlKWXurJkcTwKb+PQigW8QtCZKFFgIDoXH5Krrq8ZzTSh0/via3f/nb/3dv8sPPZfzk2uJBg5v+df28u+7P/seTDV8sH+hl2ddfFczNDiC6yDz0NtL4iCOqox5ORVdncNh9GembPl/MmtpKCns1LVy1/sFnyn59FTndISgjTf/mbdq2GjeMqbUHHes22fr11lyOrzqBUO5VoIr5r4kmA5aTmnPmiNMeevGR5+f8J+P4lGJbHwAuQwEnVhALo3Io2dnpudmZoLbtsAtkCP+BiIoK84sK8y15vaaG1qaG9vT0JGeCHcPGraHo0tTcXr+7MSMrzeWxKUYlSpKc6W2t3urqxqycZIfTLpVsZnirZS9mF5ehtUyA2NC45vWlr5W5884af6rL6RZCRAycD0lYMVqBUAoWUvmV1mgNTZiXBYkJ0Njqq65xJCbJ3BSw1BNUdBYRo9w4fvpugKpY1LRHD/pXusV4cMjLMPS83qlum8c0zd3Vu2/90R3uBNu/HvhLaqpHSZbIyIfhHp+JBxV8jurCVGc2hgiW04JE4MDmNK7yCt/UlX8E4QPDDaJjVOKoF8Q5MGyQTwMjamEfFpHDSDwL5UdRr+hDtEGWyu8Cg6bZ3gGE0uMRyk0+2NqK/gAmekDTGXZWQ1HtO4KEZQsWpp+Y2/+K80RmuuesGXkb11Zv2JReWytTkz1nzCj6aG7VP3/fAp7xf/ozDC0LSqEx/nWev/iII6rvaOAmHQQZRs6osfyqi3Y99Fz9z+9pa2wqqCjLnTjO73ZwAraj9ssXXkur92Y+ecOaz+bZn5xdWJyvDxkANqOnJpGKS4IBcmY7IfcE/zD/vevuyVuScXbledlGbwmCKwLJHgQRlRaD2V3VJzZdFkSh6M8kB+OtNz56+425F1xw+thJ5Q67Fbk4Q/bB/+Y+/ejrl11+3uSTKpmuWQUuAlg0f8VDD7143oWzjj9hiLCCzj6gKieUSDs6ts5e+OIq77IbR/9ogmcCScIeWjDC4A+txnRCYB3LV9f8+5X0049JOW5S81sfb/14QdnMGTwjAQ2DR73bVDGPYVgJjO1RsoqP+NjPI8dYUVH+r359A0fNbged2UtLBjvdltSnVeTV445slnaxys6QA3zeuGr8iv+DjirQPICBc1qLRVbu472vESmpAQC7tCyqY02rInu5BERCVbh6QMbUZCQAwevb9clc2Li91ylTqLS4o6Z263sfJHX4M0+bpqWlGpZYIEUQlUo6+x53jHH8MYHs7IBNdxs44NarO3bvDmSkOYn8GtizUhMAApABWSmhLJgzI4wOEeMhJT7iiAosyxcASnA5J4+yzZvf/u9/Iox0PnO6Nz0NgTQhgxs3degy/wcz7SdPzsnNqvv3yx07dtj79QG7rQczcoMMtccvHTxh0rDjvzTXfLTqC1dS8iV9ruRcZ1JTRvXYhTseyY6VjbtFJaI9ciUKv4epejxU7dq1+ss1NXUNwlSyKZGdx+rqmi/Xrtld1yAEGZpFowrhvN21dWvXrqnaWb9/CpSUEgha/C0vrH1q0ZZF08qnjCs9FqQR7insoWBDkXVMAxZAcPYurE/Qg0++5GwKVr3whj64jJdmWQ2FlqqqCWCToTP0R9x8mFSbg3SUFwbi4xtKt8DQ9F452arXVWZlpv74lgsJRXKKM/rgf+8vkspxIoTSuY2rxq64AwLNoDtBtE+wj3jCOU3vM5ISdZBSRzyw5yL0jC09EnIk09CpuWXn357ibc15F59b//Hcbf940jNtimTMVO3MSo6z08YBGWWVFlue887Qz6UzLd2elo4Uenvw7U+2ffzFoHOvSvxg+aYH/51fOUj27xNEcEikuDhCfMQRVTRDstADmVIGVd0ZBHa0qwYUIJDJeblDLziH8nrJBHfq8GGe5FTdYSMdsUdrHRzCfXr/z953gFlVXd/vc84tr7/pvc/AwNB7EQQREbEgiKIgKtHYYomaptHERBOTf4otiRq7xt6wF7BiAQQE6SAwzAwzTGHq6/ees//fO/e9YUBUiJBfAnfHLx8z8+a+e++8s+/a+6y9FgUl25E7e9Ccrs5/vrzk1TK1YlzFMW5I4YR/05RcooGeYKWT/XrWYBxU4ekzpg3sN6T/gAqnUyfJPhYiTjv5+IL80mEjqhy6Es9G8VAAcPyxIzye1MHD+35HE55AC235aN17T33+wrRek2cOPCuDZFljTIcsc/foLknGParlJX0vOqflBzfVXPT/lBGF5TNOEkXZwBhFJIEoUAaaakrimMo5DRtICLp0ScCy8ZQdB5we4h8YZABMI8VlmXuGJIgNp6S3g+wBf9S2rsPoPG3TPRBrBxqbGK7Iyi16OOVcWpQXVagGFJCy/5TbsfVIQ0TmdFQcd2zn6au3P7zA3xUKLl3Xr7SscPrJmJLKe8jXJ9NgogkvICEfwykRgCaACrR5a/WO392XWpyX8rPL049Z+cg1vx/68JP9fn4Vz0zvdjKzs4odNqKS7lqIkfqGXQ88YVTXZ9x+f9ey1Z1/eiZ9xGgxoCymUKgo4QAxAAWRulxiSD+57x+T09tkD2P6e68ni0xtgiCU9E8bePmESx/75OHfLvr13PCcuZUXujU3ERb7ulswnewLqr4p78XzA+XAy3sVlPcqsJ4SlhILInIQxSU5RSU5srmTkJymchY9Ny8zNy+Dg5mcoCN7FIaBEpQ6w4jNweaHVt3/xvK3pw888YKxFxY5KgWXPoNJtvhBYZj9DiNb4ExJ8u0ZAUJpKDNVcbkAGk1Huel0hBTiBiAx0fj+0vULF48bMYrPOY61dm5+4aWmLbXHzpuHA8qF3Juwk58dB4GqUCpMAZFFgkjonSTGLI6a3gR+7St5HyiB23e8dO22xyHWBswNGHjQOP2syhmewmKhx7OZ9DiOJwKe9JwnB/humJTN20MS3Ysp2tMKbJ9qUzbNSAQQCvNyr78se8XW3X/+TUre8fk3XxPrW0QIsbT1rURmzfFQSaqPBEN6NAZel6nFcwwEQywcUTTnjk8+LxgzKPMHs9mAftC7coxTTV/6Baup0zLTLN+LZGa0M4sdRzGiQklgpMFw8+LPG5auGXjqCd7zzsS+FXU773AtfD+7IB3SMoyOjq7aer/i4GV5BlMi1bsiwa7UvCzwp3By6EZmk6CMyaEhQkhpSq+5o+bHlhpvLH6LG+bp/U7L10sB9WSOl4o8idxxQNdKeli80h4YhyZGDwWLv/m+R+Ng1W5UTuBY/v4gwKTIWBzhYU3HtufWPb147YcTBo+8cMSPchw5kuhEvk8r6OugqudkIlrnvKul9f7nDL9WdesN1Y++1fzKOxlpfl6QzzUmynL1tWt33vt+dp/U2Nbqrlse8VxwEmSncbs5b8dBr8oeFpQJLHV0z4vKq7ckpO7c8dLngeonmj8FHgHVAbHWe7J+8IOc0yAvC6QzqdLtjiUNN7/zlhFZp/bwNEWrzOtxtxP+qLiPTvnXXKgtdT0CnDTvNruCDAC7OiOtTVrUMBTdlE58PUmVnMavqO7Dz3wvveGZcYI+eSILmasf/1fmrp15F11YecKx3onjIDszjsScWuWs6TBpPKb6SGLo+Cj+PNhhI6oeyzW+7imix+epmH9m+jFjoml+Zdigomsv1mIRabBCYpFQzZvvZNd15v54PiXQ9MhTLCvFP/1kSKHi0I/Mkm6Woy4cfTL6nDdm/qvwyusrXjMi4ZOHnlLpGBYFQxVKQh9BvpQexMHJ1+amkk2pfR3Rk3grURFaDhmWtgJQafsHDL/oXPHmp29+WP/RlAGTpw2bmq8VC6ke/b0YEbhva6oHnAJhzVUJ3LF8Zdtna/rMmeY46cQMASuWLhk5uL8rN5crSnqfityLznxz9a3+W/7e0dqW3ju/+OxZRqq7m1RsS8fYcZBBv6EdQo46OCUxDqNw944FP97+BERbgbkAAw93TMmpGHRC4XhISQGrattzd8QB3Snx9a0zy2wr8dvUcija457co/zaVxdHYjhK6c7GXY8/H8RY/5/8ZudnywIvvlHetx9UeTiAKrqrzASWiyFmZKTXfra6tqlxSFkZfLJq2/1PpZw2Abxub2ammYBosjfmdcf/i+dDe7vPDhtRdT+v5YJAt54yfrgXiHC5FESW5k+bMpEZEXR7DOBaqr9PZn71n95RstNDsWD47Y/Kfnqx4naZSQuxw7WeCDLCqtIGOsa4+drYgjVvNASaLhvoL80pI4SCEFJs+bALDSdHjC3dnTj+JEiIUAgTa7es/tPavzbsapwyctKsfnPyHQXA468U5FD0Bb7WT9pn28FXWNj3qkvSRvUSWSn+eaf3GdLXnZ3LCBUIXKFw6ol69UZ2440OqHI88WujV7GpUg8gJ4Tb0jF22PFvB4sDi7tqXr562+PAw6DqEGv+S/4VFyjjoTjfcKr7K1cOdMERurellXw/ThIJyOqvm4Sx5EOLfMPGq7S9wFAo2PDy68afnyv503X+Wad2Fuav/tU9Rb7HXb+9OpKVjpZ9Md1zijGC3sFVaVefv+UvD+380z2hl1cMGVOcfe5sSPELIeSp9VRxsfvddtiI6msNIQZcUFR8KUwqNhFETgk6XcTpIAAqAtcc/pMnh+rqvL982gsB360XKGNHBn1eXboWkMN7dqAQVp5ecf7gH2aS3DeWv3Fzyy/PnDBzXP6xKSwNhKKgJLR/k6vy3r2of6uJhwIIEspQTvTE4VQ8Ve2itQu/eve1j15p7+i44IQ50ypPzdCyCVBO4zeQAZjfY9ePE4hJ22dm0ekBokTK2CT0a4jl9+Gp6s37VoIqJTAK8/Nzc2IgKIv/mCJAxHTtaKmPZ75Afm2bJlA1BChUkiOQgN2it8OOg2tOWYjnrppX32lf93r76jicouG7G0dWDpk0unh8THMBBeX7mUxJvZWebypQmGqXAYyiUzcZQSB6xCQxA5gCDgUpSXSJ9lHIk3MDsWC0kSiFt16WN+tkKMnzz5iahdGa2l1lkaAu/ESK6Fk0BiqH/hBIRNdSZ02rWrkqfN8DLcCPueQXRq9enCmMUEQbQtlhI6pv7wJZz1UBRrCLBsPM4UKfW0GEWIy2toEvBdyOGHDI8Lsqiyk069Cl5+Zxl1MyMpM7YoevPRQPkyEr9pScMWxmmi/1gTX3PrLo0Ya+jRP7TirwFrvQgySpgXB4SJFCJhom7f8pgRDtqttd9+q6l97Z+qGepl9z/I9HFgxLo7nCsvQj3fT17zsKKVn/UhSL0u72fnIWQOZBlfHuvyIF1BUzjoDjP1ZM3vbia80PfjDkRzc0btqx/ZHXBp0whg7oY3Fj7QaVHXb8W/Ud/L3mlau3PQaxNlBUgM57xRnz+0/TisuiTt0EcOL3q1UQ9yJ4SgTHg4Ftz7+2afPm0SdNSzt2NN9VX/2v53ch9D9jhreiULaoSA/rqZ4MLOHxefvNONWpMuL3ohCugtx+F8yNdXbRND+JYzcqksaq2KOTFgyEOjq6fKCZ0MmbmtE0QbGtb+2wEdWBIgYKQnRtrd397KuZpcWuuacxAs2frHC9s8w3/wzat8QBTKzdGF2w0JjYt7M1pL7zWdbowayPgxLl8PY5yJ7UAJRluHNOGnByXkbO21+889zaBSsaVx5XNWli7okZrgxFNqRBHBawQC0bVyRIoaGzYWH960tWf7Y+tP64suMnDZwyMm2EJjRIOrzSJIdU+T56x12hYE0DS/V4M1NRYYGGRt7SmVJSQDxOjnsoUBTB2eOKVQEMIEqJE6Bx5eqN9z3Sb2yJ/uurcz77ou7cX2+4+4Gqm6+PFufqgMxe8XbYcZBxb83rT7eu/LBjA5hBUPGm6vLJvSaM7j1OS8tEylRE9ZDUdHSvxMERiO7wZWVFbr83WNuRlu6rX/Z55y/+XvTrH2qZPjlqvH9jKUQigDGVeLIzOEHBDQqCgeL0+zW/n6KJgKaU6WM98CID0LjY/eQrjUs2Fv3650X3vbLlkZeLBw/UBg8AZhdidtiI6gAaIQSJYMzp9cS6Ahvuf2pATpqnIH/3/Y+FKyo0n04Aos3t655/VdtQXXDzFV2Brg13P9712psVmXMwMy2+CMU3wio8ILz0naiKQWIDn/mU1JEFx+R7ivvUDvhozXvPvfXcmuI1owaNGFI4JBcKABhFxZrjS46w4N4nshfpC6GnKS3pMassWZooJVkQkMYUULbAplWbVizfsGJdzZqivILrjrmuf9HgHGe+zp2SzoU9pnH+3f2+BPUd1K7gtpdeI81Ngy+9AB3q+seezhNO/2VzudchDcSsGWwRvyNIuwcYLe6rvnx1w1fbnHVNpSeMKZpwTPTdT3S3q+TPl+7cshUbdqnF2YjxTMpsic8jM/BrBnq2atR3JKWe1uJ7BIKtod4kHfyemlcv3/YoxNqAOgEDfzSmXjTk5LTiCkx1iaRO5vfhFXXnKUwSozBZNQlV944fNfTyC5p+/oAr0hH6qiZ82rj8uTNjKV7EeIUlbRkEFdYRkMuWNiGEoSV2AcyCXcT6NKCI11Sk21adJD4laCKqhG5+76Ot/3y2/JSx2g/OLq3q99DNv4/+/dGBt/yc5OQA3acPRuAQZHg7bER1ZIXcPge9MK9o+tTVazZsuOXu3NxsVlOfd/n8WEYKQTBbOwrc/uwrL1LGj1WEOSQYCrZ2QiDKM+IrlfXsF+83TZBuvLHPgjvAHER7esDq4CpL7ZXlzR6YX/Vh9btPrn7q3VcXjc0fNa3f9BHlI/0kHQRwU14VEYTsAxzwa4iqx8qXLS5JLJffZNZ7k4DRtXrNF09WP75qx2qSRc+ZOnt87ugq1yhGVSobV2Qvdj79nomEA5D0lF4VFR8//FJId7c5gb+3LOOSy4nPy/c6/x7upAl3NTAJaIq+8r7H+5WUlvzqqs8+XBi+5t5J9/8m5+zT/V0R4nKoKEyQHT970R/hsMF+nB0QqCLf8NPufbB7a167p2XJl13bwQyCokJk1905P/pB3lQtIyOoqE6IJ4Dvrx2QmHxJvrtIEgfiuYgQI9WfecpUsW5r6z1/KIfx5tPXxioKI2C4ACmhHFRFyB45jSfjWDxJyqNJyBSHU4LKKkwk8jEkrLHo3rhbEEKiIlJdP2LaxLTzzsDsDHLKpKm7W7I+/ZLs7oScnB55G75FbHkfz2w7bER1lLWp4qsNhaYoxwwpnzfdvOjiCPj9117EhlSpuqIi1wuzUufPIrpueB0UiW/2GZ5wFPx+q99sscK7O0KIyHouNnJoU6HghFNkHsXfP31wsa90dOa4xWs/WrZtye21fykpLO3fu9+IkqFlWm8P9RGiMVDIHgGXvU/J8iO1irSEErn0uWEgWPwfO0V1def29TVrVm1fs75mS4rqOnPo7Il9jivL7uUFLwNNKm0eevlxAhDRFXrKxBFrV+26/QUtFBp2wwXO4wdzlw6A3SKBltgnl8oXlBBDYsc4TupTnnvGCY33Lih49Dn2z+f9PzwFxo00fCkuX4JnzzBevBIpyceTnqwsYW9jP4btOBqjezjXGoNlQranKPl7zWtXbH0YjA6gDiCRO9pGjxt0cmXBAF33IhAHHrgY3kEsf5JUpZL2fNZkLqomV+t2twO0QdBV16xU9ZOWXVJ1lZJgMNj0xqKUtz9PP32yNv346Na6mkefzTLMtMvOhaICWdUySwpHsZKdbMrvSdQYL4yZBFm9pp/oPG0KT/VxlXICeXNnwCmTIdUvNfLxQKRq7CRix1Gs8AlS9VvudAnDjIVCpiyPeChGTC7LL6G4dHQ5kiP3aPi8xOcl8tGexCpIgHBEq+gxk1RJcjjgn6VwKZAC87PUgYXDizNKhw8cvrL28811m9769M0VK5dUpvUpyi7LzSnK9GX6da9LdTuZTkGR24fdVKdE0SYkSjNBdEEgysMdHR1NHU11DTs3NK/b2VbXCZ0Z/qxTxp80onBYhbc8S8tjQqNADqugEwFwety+osKGUCeHLlduDmg65YIxyhJvK2RqY93JF+NnFM93pgMGn3xS3Xsr1/zm7irIc150Pk/1c+QcqGI1BaXwNZUvx3i6BmJP/tlxdEd3U8VSa2NxoES+6NgUh1M8BKoKxu679bN+OOg0vbjAVKkUc/pPeDklBvE6g1+9+lZwyYbysy6rXfNV+O5HxhQW8aoyTAjyoeZ0p6em1b6+dOuuusEZ3pqPPq9e8EbuhXPA6zERlYSxBUgeevx4TJ66IT0oaA8YB4w4s9JjMpMQQAbC8LmJz8OSZhF7t/HssMNGVF97eCPhCEyYRnjFytpX3sg77uTUosLGd1Z7532ljx5qUqaDSeOFDYs/hgmlIBL+eXKJ8j19nkRuEvG6Kv6lJmWC+SE9W0VI6ymCQAgHQoiW4cod60gfkjm0uaJhffO6z2s/XtK69NWdi5yKK9OVmuVKy0vNz/Rk+pwZKQ6/y+FwUo0BpUiRxwxudMaCrbHOpkhrfdfO5ram3Z1NrUa7YGaeJ69334r+qQMr0/ul+zJ9qk8FhaDCpWEzBXqYEioCqEA6ttfWLFycNqIPa49sX7wkZ8J4p8ddt3mz3hFIr+yFPicwZXdtnbm9NqN/XzUlhSURVQSE6tIjKFTYpYMnqAiPwhhSmpiGVBI1uWmAoipyqwCJiP8V7Y1AO47WsjK+pq0ME4cYdEnXV2M2/gOMMPAwkMifqwdM6nVSSb/hxJ8Wk9YJjNDDAigsX9MeiSVe84VjwTcWfnn7Q+NOGJv288vCn34auGx+Y0WZ64YrICuNIGiCGIrqGznM98s52//8z7pb7jKrGyrPneo644SQ3yPLJSTxJA8GKEY8Uwuv9DaOyl4VBaLGUVe36SCqe6h4csQ52dbq3umzEZUdNqL6xmTCJbk8srWm+r7nSYSk//E6TXO0Bu9i9z7dJzePlxZCvJIhNEHfxj30azl3hgRYDIls3JgCoxRcQDQpx24CGuTQPqkJSbTGEn41xFruRPPoqZ4MX25K0ZDiUR3hjrZwW31L3faGr+pa65fXLQ9HwqYATkABYmmOWzIE8ToMBSeEMup0ODNS00cUjCnOKMxPzUtzZvncPjd4HaqDJK+YEnG4U0k8jTXv3vbQI+vqq0++6VpTxD68+4HjHn/G+bNLO9evb7/tEfcPZrounM1qm9fddkdWeyjztl9EU70KMFPKiTlB3/Hca+11u0b+5vfPPfvCyNsf9N34Uy0zJRpHuYJ8tiq0vS518DBeVShiprppe+fqL319e+PQAcLGVHYcTZVkN41/j8glk62pzq1jVt8CkQagDETHbdkXXl4xRUvP4m6NdNNG99AIDuleueCJzJo8pAoiEu5oqt+Zd85JWefM4P1Lc9M9nbvv2hToLN/ZpGalxPOY9HGIpXozzz1jZCgavuGqjKnz/NOmivxCBkJBpEhMogCiM8KdGhMooixejXqFAkgwJrhm7edRC1YlNVYSZTIhR5V9ox02ovq+oIoKgwfqd2uKOmjeHGXYYG5Gq+adBXc9A3UNtDhPSGM7mhCbTKaQHiuMmHzVW4vcJhYeM0rNTtm9fM3WjRv7jhqtlOaiohzq/THSkxZJE5xKqw5jTubLd/ryXAYnRjR3YLBPV7vZuls0t5ltLZGO1kB7MBIKGYYAgYCqoqhM9Ttdae7UDEdaBkt1Kd4MluNgTsYUj+kBSoBSIMIEkyQa8EAPi5wT9rijxOjoKNacZVddkjp2OFfZlPaAd9kGaG/tPWRoU9abS+9/6piJoxpffCf23vLCq3+I6WmCUJBq7gIU8u7HS59+adzkY+HCOZWZ7q2X3104dCidN5NTJAjBSOyTOx8a0+fzzAd/C827l992Z0uw84Rbf2X7m9px1OS77nUmt8CliG4ck1C6tnP7gHV/BjAg2gQKPaXRc0/6pb7y8YorNUqJCqgmMt9h4l0j4QKoQLantKGAus9ddv7ccoa6x2VS4DkZ/ivmD4zFVIeLCy6ZFioAMqABAk1tnU4Asr1R5dwkVMF4xRjHSkCjgc7Vjz3XXF09Zv5craocdreveOzZhqa2iZdd6izIQILdE0B7M/cJHO0+jnbYiOpg4IkKoDCSOaJ/etUNqssNuoNpWvqUiThiKHrdsh2k0AQfGrHbcz2hDCqLNQczupq7/vK0cmUQRvbfeePvPW5dGztcocAh/ig/9NVljy8T5ZTVYUmwzRUFFEVxupWUTCgoB24C5yCEMLlAizKRsFgmhFLCiMKAKVJLnBKWyJdKkrkOlKHSY4+PHOqCLVkBJr0maGFB5hUXgcMhdE0hJPOMGXDSSUaKR2VK9BcXaNf/v8h51+9esa3f1ad6pk+I+RwIyARQikiwXdMqL78wbfRIMzu99JwzXVpqW1FuetjQ3apJhW9Q1cDTJ2/55aP+0b0jESP21OfD/nkVqygKyi1aO+w4GjKeVRqJOHSSknqSF7kqsH3IF78Eo1VSFQx/tOyuwvm5gwcLt8YQmRAk6aSX4HUf6r0vgkBMwYx9DkkZczrTXVaiUFAgJcSvWV/H0ZI0TdaAkK4APrGg8YlXe006u3VDjXjp9ayCHMjNMQiw+KtQdzlSszOa//4vaAi4br1u98efqdc+OvD357uceowKCnsIVcrXjI/3KSJtZSo7bET1rRCFEM3jAo8r8R1CweGAXIfFi+rx1Lf2vGjCD0pKSgKBIOVVkyc1fbKu9rlXfc++HmppHvqjazEnG6mUGu/Zxf4PXlPiUqQNF+vOfj3/1CJ5ZWKvVLG/fs0+vf1DfzmW0JTciCRC17iuUataFAAuF7hdnAgDIGdIf2//isZ//tWAnLzxY0h6miW+xanVqOeuof0rh/VXHDoS4van5c8+hRIqdIXJDVue4iqccWLLl1/s/tGdHLwF10zLPHlK1KmpmPhT2mHH0ZLzJGlBIfBloHbQql/Hl73RJnf6Oo9jQ14svtJVUBJzUC1htUf2LYK+VYVPJEgFCYmpA4UgHJHDft7I8mNIEp32IBvLGYYQbpgNny7d9ruHssb0Kbnp6vUvv/X+4y8dm5ZeMH8OpvkBBYlXXWre5Il0zcZ19ywY7Lyrfs1Gz3kjs6ZPNvxuhpT2OLSdBuz4nmFj7v2mhp7t7Z4FGenRpQKGEAMqsnMdc6ZHWwOetx4acvZMZczIiFOTpHWrnfx/vEgxcTG4V5DkfzTx3//paUolFxrPvrJ6trposvUWP3ERAxNB7Kyrq9u6LR9SnBDuXL1eRCMqMBUISUpvEZeDuZwxecspQeFxCLdmxnEkMqBRxiIVeeLYfm5Y5YVqZWTfSE56VDao7DVgx9GBphL27gSIRmB9oHbQ8msh0gDhRqDm+M7UxuhPnhtyo7+4lDuo1l1pkINmTO0jLnxYe27RrkCstr7PuCFVF8yFQVXZs6aPnDo5a30dNLdaTFNmae2l+AvnzgyeUNX2wN0lS3fnzZvBK0q6NCS2j4Iddo/qkCYZ8l3flLvpaJhccAUoMApEUOCAHEwvR4UxXltXvauhHaB05ZbsGcKbRgkgJcQEjv+R3HKwF7g/OWncL7Q4zHPS8WrWANCDoTUvvpJSs6vw9ClK/3JYtqn9+YXi+BHe8SOFS3cLYLs7cv7yr6X1bcrKD7R7H1n1yKvj+ww3po9Ct65Iq1MEIielUU0e2olWd5Ga8ip8iGT1dva3t7bBUCe4vHe/6Rg6Si/NiakaS4rT22HHkRxCxEsUyVXa2Lmp34pfAg8BZYBdY9Whbwy5Vs/OUvR4keKQpuRW3jJlz4kdaP9rz0Kih1lv1ZLTdPq9xefMZLOmg9MRY5qnqtL/hxsUIcDpkiQGtBTgFQqKYJ6Q2QIRFRqyAmYkZjg0jfYkn9sdKjvsHtXh7/HItGAiC4YdHSEwTAQhONeDIVdbQAElUF2z6cXXM04YOfTHNy157aPAq2/QzoAA5Ny0794BJWEEcDk9OVmbPvio7vnXwktXLLn3wW0rVrtTUpiqxItIqq1/9/0NL3847IIzld4VJRfOC5dmbH70WdLQ3IP7Twj2tLTo5nyAKTNvpKV93Usv0x2dQ1//c+k9lzV8uqL2xVdEjHNuCnuax46jAVBRAoxtDtaQD8/qu/pW4GGgOK3VE9555RsDb3bmFwqHJsUzBRHYnf0OeqIP9/AkxOEvFylhitMNPp/QJFuAMeFzx1LcQmVW71sQApSKYHjdK6+HVm/tNfeqlsL8bU8u0OuaVIMLFPbyt8PuUf1nMxEACcS2vPiqc9uOnHPPgr69oLl50/MvZ0YiabPO2fD8m1pHpPSiU0ND+vRvbqle8HLZ+MHqwCqhKgoS8V9qi/FfhKRlFseCiaNxzfrGlz9SXluphQJlN12i9S81VTlkZHIzxZfy58tcx47lLsYGV1XeeJWx4SuDokPAPvo4uLcyPCVgSpJG8OPlOz5aOuG6mXzyONbY7Djv423vLCocO0w5dqyJMZXYvX87jvjqmawMVQ9bcqV0Nw8CixaZ5U+UXe6o6st0FQB1npQBTi6hxNhLt+LCAUc0SY7Q9sZah5YFEcdtNL7ATfkk0xAFgSgQE5iTghRGIAYQYorWV99tfGjB0Akj3Dde4Xz3PfOS25v698/64fnhbJdCQUO7P2WHjaj+Y00Ug4PHpab4ty1438sx7WdXdz376raHnnBcdkGaSy2eONZ33BilvMTr9/huui7Y2MTy8xhjkr8uvjslHMXdZovgRQFigEJzZUw6LrJ4tbH4kaGX/BrGjAi73QSIIllRfSeMF4hEV5FQoZL8Ccfw0SNVXUXK9vH92XcgEkG3atne5SNuud5dXmaojGZn9P7ldaH6eigqVLqHJe2w4391He1r2Je0Bk7segOBTcGdA5b+CBSXNLfEIR2+Txpnw6nHO7OzuZKw0xJJIjr5HiciJ/DAETBABSQY1nWKqMeiskVGDAdjhO23niNsj1rygSZnRMpjuhnTBRWaBkxhSNwGh0iE6Dpo8ZJWBTBDodbmJv+MSa6zpkfLigq1aTtuatsUaPOFOlXisjtUdtiI6j9b21ECjJSPGeUYN2rjC4uqGN359KIBg3vljxqOXj19QCVVWPxFhECvUldFSeLftvf9AYNWIckd7Y27grt2Z4O5cfmanPZ2DXISuweEUIduyMEjKxcLTROatm8q7OZ8kT1wyuqBASFq7zJnnzJOpXS6quoVpVp5ifUrKrFXgR1HFMDqqXeiEtgYbhjw2UXx1WN0AREDzbyVmZfgpH6m1HkC7KGI8C28SXIg7xw/QrR19/K7Hgor5oRLL4pmpmuNTYvu/6cB2tQf/Ug4PewbsNG/lTpIKNCx4pUF4U9Wjp59ln/SpN0NDasffiK1rWvApRfq5UU8XrAJ1e0sP/cMIOBwOrsIhfzsgmsvyTVMp8PLkdiIyo5DiRbsW/AdwQVBYaAwcrOM687Pzc8yf38ji/H0y84N9asUupNpqhwmsWboSDecsuMAoBSRRjDoBKTbawKPvJBdmhO48x/1rTvJ3Q+6auqdwnKBAApUQ9AEqihUQAeC+wA6S0ikn5dVsKsUKaE9YTKL42D7r2DHkRcCAJECoZujzWTRSX2XXi1bQAwgWu7qt2L43bGxI6J+nVJjr87W90xcSAFpGATzef05vtCtjyi3/S1ld2vsoaeyfvXk2N79weNm36Coi1zE358ddG2j+tIr88rT/7ms/taHYMW6zseeDt3xZEl+sZ6ZGgMuvVABKcFUD6a4TI04AXQK4HdBqs/wqASFAgl7UDvssHtU/4nHvnw2U4bgCUU6EKMApCvGQhFiGIKpBIAmHKTsm/Vv1NNEAKXh2NL3PzKoGHXOmc4xg51hY8s7HxetWqPV1Tk6A44hA0lGGggRWrOW1jeqo4YraWmC7qlTv7VmTkCrHjpd9t/JjiN4RaFIutHVhpsrP54DVAceBsCqaMq60JzYyLHodMhmrTQLxkP+RCFCVXvPOM21at2S218YoSlrFyzqfeVZvuPGCkxYzu+n34VC2vqRgxIRRkRKafawoeSvly67/TH11js6ancec+GsjNOnGV4PAS49+QgBoqCgCYl4UAgVBJg03iHM3vG341CGXaMfCKKSK7Nld+Ozr4Qbdvuu+41wabuffpnV7ARAE4gsziy5UGI/sP8NUAVIe40c2e+Ga8n40YGMNN8P5hT8vxv1fn2N5Ws3Tbth87+e4Z2Bli3bVvzmr9E7HqddAUFQ7IG73/ano93TmvZfx44jOgSikHtnRDbMt4abyxafDdQhP/uiFylYl/UzfsaJhtdjKOAUPI4vpO4bJYQekqUhGVgaUobEyMkrvPD8htG5sT/+emAd9VxwRiTdF9EZPbSFJyEGkHBqqjZnZu+5p9IFD+SjO2XmtGhxThwtcmYJLFv2GAxAIXEcZaUFpUeTm9rKCXYcsorCjm+NGJAIUx2IjQvfCz/wUv5PzvNeMt+fm7b8rkdGLFiU/cMsTPUBkft9B7wqpRuMbSi3B/SYDjWtX68YIcCF04hFUv3O9FRKWeaMU5avXc9+cn9vodA1q8zaGucdv48U5SEFx34VWL8JEtthx1FSnxBSH20p+mg2KF5gLgDMjWXUdc7FaaMDbpcLuRMoIonRhHL6IV8ewhoHIaAKltLB64G6dciJmlwQpJiUQT/wciv+v29JlUweTqOmg0fbADwdnYrgisAoCMGscT+2J1FgosYidnKw4/CE3aP6rgRBiAKU1NWuX7w4ZVSv3MmTwOfOPH1azvFj8IV3SXOLFEe35IjJvwMohA2qwFJLlwmSUEVVFIVQFgEMFGaNP+/c7KysL3/2q52PPzhy3iy9d5mhWJoUB5ANyR4rMjvsOMLXESEmmtWd9XE4xdyAAgQth/x6/Wcw84ROr5daAbIjBfH/Oyy9GUkljYTDK5941tzQ2mvWFbWtu2peeoN0dZKD1V8XQERPh+f9AUgALRqufv/Dd156pazq1Lat27cv+iDa1SnY3uZSCa142EsHngCxQZUdhzTsHtV3hAOkz3BO7vg7/0oVJmSHXC0vG/rgXaZpmpSyg0kTVgqLSAU9A8AFoFKIQILOwFB24L+zbEu0ZWhPsV+CUt34/0QJIOnnBWgRwWVhSRQkKFAoSIESlNt0ZI+wDe3+XQKCISgIGjHkXVR1JLo04wMCsWMG9T912NYH3/XCAM/AQYbP70VEgdSeALDjKG1DJda8SGYBlDpM1dG2Xh/OiGMp5gZCsgOuncvG8+vPC7m9BkCKBUuk3JS1CwaHB07EgDPD7PjXc83PLjrxp7PD11+m9c8lNz8WGDY85eTJpluVdlPk6w8iUyWCxR9IXIgolcqcDBA4B8KB6QRURGVf8EaIwM7PVrhm3znylAGh267rWvBW559eynbmuC6cjn4X4cykHAkqwIjt3meHjaj+G4JSqhKyD6mZEUKVg757pgRSWhSxrcPhUNDr4ZTobV0QjUCql2u66OEguJ9Uij2rszhIQdiDwBLufOT/rtWUkEAnkglucTqo5ZzafVpf26xDuQdKMH5zGUkoLRNEYhDUTN686IMd739aWHBse12Tc+GHKX36GK50aj0X0E6Odhy9uMpSbzIBgyIUMqO9PpwFis/qe+eL7DpyPv/VcKoxhccYU0TSDP1wQz2FUN4VaKzbmTf/JLx4jurzDDnzzM31Hes2rxs7dRyPF4+Efl1Q1wRqxBOBLjiJhEnEJF43UxTC0YzFHKEo9bpAV79+/pHOzk21tY75IwbOPh36VzETN7a01tdtKWlpZv4SQZEeHNndDjtsRPW/E6Zc3Epb6L0H/lWe5i0+8/SYy7H9kSfakQ+ceybNzvxmj6nETyRjC3uMuCURFZE9q/+7IBY3VgjGBWUUGaMCkfM4OFIU6zSxh6O8xbdgVnNLXi5LcEalk7Ns+cOWrVvvfZR4aP5N1+xcsuSLp14fM3Soeuok06lRW+bYjqMzkgjBygMNxu6i988CqoLikT92qFpWnf/6aP80oJKCTSkVaBIQ5D/hDKAAUq+39yXzVQcDtyPGCO9VmnfLz7J4BBQiE9j+rkkIGs9lxAiHFz79TPrabQPnnaMProq2d3zx0iuO+pZ+55+jlRR+PSm6HM4+J06hUyaB32eA8PevHHzjNRiLipQUglzIWT6b2mKHjaj+y5LYNxgqSwmqb3yy02TPZs/tRkATMMWTleHvuuwe7k5Rw4F1195xwr03atlpSZeGRDv/a+mDm8AMSjQpNSOkkpOQ/R8p/A0C/m9oARZMZABcmMGNm90vva8OGwRTx0HT7vAHn0I45j51cjTDI1tQUqVTIOGCUeSUhShopskEoQKQMcEIpRgjRAAxg11rXnyl4+21g5+/mU07kQ7tvXvrtjU/unXogEqtd1mCvmZ/NO046iKRHwygtbGW8g/OkljKWgqZTezSzHEj2onwCsI4cMoFEE5R+d4zdt+e63qcHBGqqublMGnN7OLCZERkpSoAEQAnjyevr61bBGFaSsqmy1HUp7e46PeBTu7++SV84ac7r/jj4Jvma6mp5tceV0gAdVXPSo8AhABcwJGpIiPdBCnGZTmoE3ufzw4bUf0vI629qknogY7kqxmL46D+yCK41wAAToJJREFUp0ytf/G9tb/9e9CIVl4wzT3zVAORCSkQs38JPMBAjHcFdLcDfC6MmaSti2gq8/lQoRwOy9jOQRTN1hgNpZyxDz/4oPOtd07MTgl9tW3R3+8bdNaMKq878UK5v2cGA+3rNtFINGNAf+5zdX2xyojGUvsNUFL8ltCB1WszDbP30EEjnh4Cxw5HxPyS4lk/vQ4mbzBVJuTOgZ0m7Tg68RQl0BRtjwAv/zAJpwzd4coIkx/B+P4G5xqLwxPLL1wkaATkYPFTzxRnfXlgoEpu+JNuikJiCjpedKEkiu4/vQkLIglCBgwYFvrxD5e89KZw6vULP+01/ZiKuWfHfG4GYt86M0knYMmhP8k4QJogSNgjfXbYiOpICQTESJgQBgkjd4RwmPg8QFhEI5DhC519gnbhjZUQDF/wu1imJwjokxLeVoHF9tSFFg0VQ1u2rX/kqd59Kv1zp3dur2164DnXiEGZM08iXhfKRtF/RlVlH/ISys+QRbQHStPLy8f//Jq3b/hdcN5vwtnOySOHZ150ptCQocYwnuyQoCHM1tVrg7e/7L50ljZpWOvP/qFOHCh6VwIlQuyhW6X4UshJU4SltAPICWFjR7CxIxQ5K0AOrGK2w44jKKVYHWyyM9pa9OFsQB6HU4ggUoJbp7jOnY5+rwkxQsHBOVBFMJLo1iQ4lge4YKS4ixDUMIESVJT47yGSmCmtjxX4puEZsqd+1OOYSoIkypicueFgkm974hiEIwGVA2v2ufQrZ+at/Dz6998q2rBBt/8EKksUMOSl7PuGEktZfsxExE9UaJgkD0iyKdjDvnbYiOp/Mdlhj4xEAGIgYs+8yp26d+wIahITwp0vv+k79SRenK9zE5vb1I+WmgN772gIaAsWpfauwtx0lD6jBEwOFJBSRIEcpboxMErysjHFs+mlNwY5lOCa9TVbto08Yyp16rIcQ2qVb7jXdiGSHsOAe7vHY1JJnByMYbNANAgoIJhVVxIwgShIKBBVAKfE0DQ6avCAOTM6rruExqakXH9hyJlKzZhOhUyI8TSn+lPLJ0/asH7bl088O/TjpaxXVtb0qWpGBnK0zFJVkqRbCYGW5jHK6aT4w0NuedpanXZ8yyP9fyJffOfp497ZRaqMbIu26KYo+mQuMGfCatxRjG1zzIuGG7rGUDBQ4vUHEVI2BJjU8ExCCoRE+8jCRKJH4qIkQXUXJkEDINLU6Fi22un1w9D+4PcarW2wZKXm9cDwfuD2yN9l8lA82TkjVOYBTIod0IQuygH+baSAe+J80MWFz+MOAThdqqQJGMKa7/2uPz/Zuy+193fssOOwh03aO/QZUppqoUpYbOuOd//f31o/XeqMxmLQ0vLVVlAZEmCmWL/ovab3lxdfc0Hxz+dsuuO12Fvva6bgggOi0hEkXREQAgiymKG0d2E4KrjQ0lIGTj/Z53ZvvPDmyP2LR50z0zNmGFUIlXDqP/RIQRTcRMERBQgTTQ6yXdSt4IAowsHwtl3NbvADwXB9IzMRqUbQUr8hBKgBIEqLsmdOxdqu9hfuLj52jNa7LMaohZKsulOxJM4pZVKuwtJKkOOAtr6xHd/8PN3rs0GPrOxC6iJN5YvnFSyeBcwRTzMiDTwVWPUXftLosK7LlzAKlBJKqCLXGpHWlTShlyePI3pUgN11YPLfmLxxLBwOf/rEc4t/+tuOVWtIV2jVq689ed1NjctXgGlizwormfESPaGeaZDEF30P9afvRsPWEVzhcNPb761Zt7nw1EtIh7Hxn48ZDTuRAv+6dt/eh02MG5OkPCCxu1N22IjqCLinhHDpCOG8+ocpQ/ubf3hU/WRtBnSWXPGDSG56/BW725cuXuK/4lznzNPCl5+XffGkj5cuNXc2E6aKYDh2/8s773uM1daISKBj0Xvwx3+S7Ts5pR0aixTlOkYMzIKvSoJpjjGDuEM3k0YrsQSS20sylEhuJk1mPSGdg7t1L6lFWcKDwGJGIMBXrDZ2NhIDwMDO7TvE+s0kagACZ2hSEzra4Z8Lon963vjjjfrkQZsfflldXe0MmhFGeCJlcwWQRsO8pY07gUNhuHknBtsJ8AMccrYbVHYcPR03TIhI0S3hxqKPL4hjJNUHyB0kl/NLcfQdIlUjlHjl1Eu8tvlm7IJAOVAB8ZVoAHCgBCnllAjKAUwCUtqAKYKqKHLKKibOOZu2Bpvvfw7uflS76t7+w4f5pk8X/jQeP44CSDjSGDAer3LiCA4IGPGDIBIRL4oEsIOQL2ZCAaBmqhk2NmzUr7y1aObE6L036H84d+lHX0TveUENmMx+WtlhI6qjMxTGEIUrNWXCice3fLG9GTanQiZ1uYBDDEF0Bc88Z3bvc2Zxl5aiu4fc/ItJl1/EPG4CSBXWnOtd/OqbLc+/Fv5k1Rt3/mN1sBPSUkyCrmhErPwy8tkKpd+M6rzI9udeYS2tBIiJ1qgd7inaLNE/uYcoetaOKJtImAwAjmgmFKEOpD+Foda2z2//x5d3P4B1u6Lrv3rrhlu+eu0tNE2TAkHCBGlp2Llu+aelV00vnn9exuzpHZn62g8XShQFFJFL5Iech9dsrHnyJeeQwswbL65b+Gn487UsFLU/NnbY0TO4JBB8FarfHKzt/enFYEkrRX0uR0k49Xo8YQw3Y1T6We21hHEfFsKe7ydKLESIxMA0BQqDIicIhoGGQYTgBC0qIwdgUyZkXzE7/ORna278i64rQy+e5yzKQ4EUBUHOwSBogBGjXICACBATEGIGxmKEC5MIJAev5kJoJMTf+/CDluknVp0105+Xm33m6b3mTKlraYD6Bmo3nOz473/027fgsHWqmBHuamhpVvMzfDv9EWhuXL7aN2VSMBBoeOZlMxrWqko1CpwCzU0nuZkEBEEUDj1t6qSJm7Z0/vbRWFnuyEx//iXnduZmIJjqzobNLy7I9+ip91we/GBp6B8Lgn2qnKdOiemMAWgInAAmJ3MIoCDUAk4UkhM2GP+XsOSeCAhETiBG0Clkqv2uxg8hJDU7Z9CJJ315+0Mh6mutri0JQ6+pJxoel5Di8iCE7vLlXnFeQUWZyMzAoUrJtRc7OrsgFiSgc0Qai+fxWGeobskqLyhVV5wXHljiveLPnR99offvh8UuE5HZ1Ac77LD6NoRsDu2sXHIFxJpB88sSKW9ncFre8OOCWWkEhYIaA8PaKu9u3H5TlypRbRHgHYHAki9ibkdq/948JUXpCgRWr+2iIqtfX/CnKggMKAdQXQ7fMSMcsKAZPi8+4WRaVhjViMIFBYEkjr14R2fzqg0+3Z3St28sxe1q62z6YrWhKXmDB8U8OgFyEE8X2VwXgIqqjzz9jNSzZ4vszCiAWpzX/5ZfYltHLDNds+VS7LB7VEdnYDzDQezDZV8993rq2ScoJaN2gdb6l385v9gQfGZB3c1/zkeqpaRKyrUwIV7wAXKLaES93pzRw1q6IpHVr5cfM0zt18cEIBzM1mBnUYF24dk4bnTK7Onq/Gk7ugLRYJDLWlYI0+joMqNROelCYjHTaO8iUa4gYUgEgimRViwQNNsDKCRxlWOsq0tvjxggwuSA+lTo1FzTJlWOH9zwxwd3P7N4zNwzYHAVotATUudKalFRwdTjzIpiEwSJCb2pI6WuhXcGTACzY3fHm2/jY685mzv8x47Iu+kyOna405+T8ouLtJPHEF/8GCbZWxjeDjuO1tgSrFvTta1y6VUgYqD5B7Y5s7RydF2ZMeOUriyPLrgurDFb1tOQKglO9reK4j/AGKARiwYXLVn/0z/hm5/o0Vjg0xWNV/4x+NFnwghxMDnhCYJUINz6wefN+SaFfvULPw1s3MRihknRIIygCuBgEax5+90vf3iDePdjZywaWvhJ/Tm3dq1ajwIt3vrB9acEEIFdTsVTWuzIzTYpKsAFgis13VVWBl6vQYT9qbDD7lEd6eDJUmoh1jROvIyyVFtinG9/6TV3Zkb2OTOrl68h1VnG4mXBX9+5c+2m0pMmp10+H1wuDoJKPEQs5RgEIXikI9i1ZqNGNa8Y3bBsdcrmamdOhqmp3t6VU/r1EcIMd3Y58/P63nAtcJPrSlS+qRmMbF7wttPnLTl2NNG17YuXYF1TyUnHO/KzksM3RFDSsHJNbPnawoljnAP6RDZvX/vhR736VPnGDuZMO6CLFag6lfSMtHYwFHBAaqopkAoUFJmke1hbjVIhhsWArF+3ruHGvx73+58XXXJ+/Xsfv/Kr24aOmjBy2oT8kl4EQAhTEOYYPNAVDnZsq4bGFld+nvB6aFcg0tgsFMWRnQkO/Rv4pXa5ascRUXyRbl0lIXvH8Sp3Y6Cm7/KfQLgO1DQgwmtmr6oZR0bNwjyfQTmVA7ZAiNSuI/vahn/zypCvF0pGWtqZp7gXfdLw2PPpTrr8kaezkQ2aONFIz4ghp9Z8iGHEXnu3/l9vFM6aWFGW/+k/Hm156IkhBflaZQUhRMq1oJqTXXnKtGWPvVt/230exVz62FNV+ZmF008RmsoPcn0SIX0/KbWUrAQIZqkeMMVyLUwMNtqL3g4bUR3ZcCqBqARHykxi2aqggtAVDCgzpvQtK4XS0pDb5KCXppXWL3p0GAC5+R4szDKBMyRUAKeWcp2cYgtHzSUrt7/43shfzIuO7rXoxj+ceMmt5onDXeMGh8ePFp2B4GfLxeatOWNHRoYNMIEyoC4TgQpQmNjVVvPL+3J/fiFmpex68LHKAf0cJx/P4xmaW5PUghC3U2l47hW6ak3F1Ze13vOIsXEd/W0ZZ5QeWEddhMO7P/x43cL3el94Ol/z1fr7HyuvKCIlRTFKnPEkKghwDdGyfnZnpE86f179x6tr71uQHeb84xWTS/oV3HilWZJrAGoIlFACPAqKc1f78rsfcby9bOQtV7PTT4i+8e6X1/3JN+v4sisvwtK8bgGcvQnpdnK14389hPUpthADQYMQtjKwHbk5fNXNYAZATwURc7OyTuMcfs0EUzaf3BYhknVr+lpDfAmXTwuk0SR+sgRzraUi4okA9PirCPYryrnurOZf/Mkz483ekEmf+p0YMcwk4DYNmYpItHZn/YNvldPC1PNmk8oiVReB3/yLvPSeenmWmeI3iFDRREI9x4we+tMLPr/p3lGnzypwVKa89LdwbrpQiAsJiacdOFDrdoGExROCS94UKYHFpImOAIKKVJOxe9d22IjqyA9KadQwwttrlM5OpW8v5nIhisj2HZ7W9vRJE0DXhGHq8dyiKpketbUkCNxXu5NUVXKPTuJ5glCZUaWIlQnEaNlWzSePYudNd2anDPzBOeueXYS/eyxn8vKK7GyjruGrv/6N56flTBqtycKOobQlRoIuZ9nsaWLTpl0PPas7oLSqJG3uDMzJEPG3oHI/UXAgmYMGdV15btvfnwrdcnfLztoBl8/xDB0MiorwHTY2FnA0ugK7Xl6kDq4quOwi2LDl+fvv9y9cmD9/XkxxJFlcjCZkFEi8is1OS//pRV/99Pc7bvkTqawquvUqWl4kTFNRaNKghxKCWJrfZ96M2vVbG154I8uMrP/X82q+v3zWKUphnkEYgN3tt+OIDEteHKjc6iZEXxfYMWzlryG4DdRUoGJYMHN3esa21Mtivcopyo00mphA2Udld/9FRo+eDk++AGUvHDU9s3efQElx587VudkjXEMqwwxEHNdYlpoYEKZrzsTighKoLEW3Y8Cp0wK+NOLzS1EoEk97ROESLuWOO8bX/5XOJStL+lW4i/MCVFBggChkgXWgDxgUVvrZH6WegO11bIeNqI6WMlMIg/P6jz/Z9cyC/tddnjVhfPuOmi//dm9hlBf97heqmmpScAALwK66Ta5el1/wxbIv2m65c0pJCQzrB5LQpAhiTR8LQKGy3BMm5ad7aVYqClF6wdz80aNg4Wdbb3u+8Td3uAjJbOvK/9klZq8SANREHI1AHJFhDLijpGDIuJFrHl5kQHXf2f8PinNjlAjp+kdkCWgixDTVf9w45zNv73z5HykTz/KNGGL4vRRNKjvs396Ni+dlwyip6qeMH459K7CiaJgIp0XDEI1SXRdxjESZNeITh0mARBiqIipLfRWFbOU7NG2kWloYBlAYYXL/wRIhVBA4MTLHDtfOP73ujkej82/WmK/84Z+rQweamqIKBNs93o4jLSzkQC0tTrn6YE2geuAXv4JYCzjSgEdA7/Ne1xRfrwmRTJ8AcHHLxJMk9VL2why4x+xFxJe79S0J0xCAk4QxucXUREKNcLh93cbI7mAeDKlurHUs/by4uDDqcMR/l4AJkF9eRioqJBQzAbmeV+g8p8iywAEERgjHeNohsdiuxZ/y5mA6HLN1RX3FqrW0IodSigicHgyRXMh2ffLm9Pg9m+lrx/9Uh8W+Bd+3zCTE7XBU9K1iu7pqbr4Tln3Z8fDT4qkPCkaNAbc/Shkaggo0IWZedrzy4wucv7jItXpj7PbHWEsHIhgEsNVs3rLDqGmhXAHN6S7LMyKh2I4ahqD5/WzUMHHRmfzicfjkXW1PvOc+c5o6emxEc1omWVZ5K+EOMQKdDZu3OojPBWVtW7aL3a0mJDrvCUwUfzmGN1a3t7er/gnBhnbzqxo9bCBBE8S3U8ItFShnbo7/sjnuIQPlWKJSOmuGc/aZptdFQKhCKHE4ZSkFCiRCIEAwFHr9/aaPV4uKk0JftYZf+8ARiWhcNtYkEURIVYUoiCghdGSVUp7hhi3Zx/cmxwwJuHQjfpwecn122HHkICoTUFg7dEu7tr3fumbgqt9ApAkoTN7tPlYbGCn8qW/aybFMn4LgQCkaRUwGUYD9+C8l9THRQG4Aj8UPLqVSAKMEwrLtBJIdIACYacLqNS3/eCKvXyl56VdNJ5aRG59ly9bpAk1CAZieNDWXpAYGwOLYCSCK1OJkEgQTOBGi69NlW258rKqwQnn2+uBxJaFrHlJ31KuGiEg1F0X8G127hEbnfvOP/bmxw0ZURzicsha6NmJo75/8sPWzLW2//FPgry+PnHeK46TjTUUhJmLMiJqGAp4Bc2eJgqz+004cfM3F66Er0FAHFBhAtLNz2e33Nt1xL9vZBELsfv/jj2/5Q+NHnyAB04wRAJUp2emZZjxn6qrXLShVkEjFTukcQYEQqptQu+iTZR9/nnfjGYU3zl2/at2uT5axQFC1MqskzjMgpKa++ukXMDW15JHroSSr+oVXeXUNMUWyxP2OK6WKEnaoJsGO+l3tL78dXbc+xogQPLijJvDOx2LrDiQogHOCMRDENNuXf7HtJ3/PGTWw1x0/1U4ds/SJV8JvLyIGT7Bq45U1EfEkThXTNFZuiO1oFlC0beGG8OerHeEQQ0y4g9lhxxGVOKxmU3z9f9m1bfSXv5u09BKI7QLGQeS/Ejjlw9KbtKJigxGUs7oULQl0C4Dh1/fBZR0jBCAxBY/GCBeCSDkVAGEaaMaowCQBnoi29rqFH9R4lLR5Z6RMPWnMxfO7ItGtH33Md7dbHTBLScryvunGN6SbniW36BSiKG0dq19/K9rfl/PTeb6TJ/efe9rmxtrti97FSERqCf87ilR22PE/Hfau36GpN0GhjtmnD7nzierFz+VBpfe0KSLNqzCFEUCmcI4aZEDfEkNTDKa6f3dVUWen0+MmxESgNNvfryg7cP1dzYW5mccf2/bzO/ILfbkD+sUYcCCeQKR94Wc7nnyz7+jZARdpfvH1lMGD2bAhERU1q+yUFqikM6it2Fwx6VjlB2d2aYriBLZigz5+LFQ4OeWSyBpPz02bNxUEI74Lz+SnTMk2Y1tfeDW4cbOrOI+oetJI5luBFQoqu0/hto7o6b/ddXx56V9+6fa7F9/594w7vhz46o28Vz6XGC5KCGndvevDJf787KoL5oiTJ2Toet2uhs5XFnn69YOK0u78zgm4TKhduarpwVcyy3prV83T//JU6y//6crJ1UYORl2R25F2eWrHv7Mu/ztPTG6eaZ93be2MdkzefB+EasHhH9bkzk3L/YfnbH32iKBTVdFULOumhHYvQVBEvC7az3XxZJ+KdwWaN2zKYE59cN+Yysy2zo7N272aQx1UJSeKKQEwELCsqO+xw83RI2IOnRw/wX0viyAXkZhG9pVR6Sa5qyLh1cyTbnmRaDRn6ADH9EnG8AHx48yY5EoRZkyBsEG9SNEu1+2wEZUdB5Wt4+ABTCKJBVu2d9R3+KAqAti5eYd76JCYBgohmqISXUdQwEBVshBQd6Vke4WU9KRADKez5IyZa7fVNv3tSd9na7owNPjSHykD+0cBVZN3bNy86+GnszJ8mbddq1XXrLztduWJF3pnZZGyPMmRAgZEAEQdesbpUzzpPpKbbipK5ZzZzsZmSHMDcGmvZdG0UCsvTfvJZay0gINInTSmV3EOTU8DTROJFj8RBNgeVCUSbqeY/BJBiadKktmnt3jgx6/84R+++54g2emdz71X+udLybgRAhQFOcTzPhi6njr5mLTjjoGBAygQ/8hBQ266BoJd4HZD0qc5oeuwq3XnC++EdFYxb4Zn0hgK2rq7H4GPl5SUlUB+DoLd7rfjQFYk7j1agf9FuaKbJE4StjKrOreOXPdHaF8Pqh8o9gllPBWa2Kv3RKgqESrRpMymBWiQds/0WVTH/awGmkxGZiTS+voiunQb/OFKdVBVw6JFO557c8TUqTi0ygSuyok5PSO9z9yzBKOm3NljXl/J6SdJLpPAvfpoFp8JrU6V1Q4XKMlf8vvOnJyqs84UDDgKDZGkZQ6aOZtw5IQyaz53L9M9+k3dum/+tjgQR0A77LAR1RGSwhPlIyG0cfemux4MmdFJd1y77cV3Vj3yzPghg+jQSkIVnshMVkPdyonxzMQpVWT3PkqJUVyQMWNa5/3P1mz7IOPiq5RxI5EpDDiPRlp31IVS3YNPnyWOGekszs5pOCPwxUbYslUrK5KynQQRwUSH5nQMq0IQsTjAo+6SIqWkSIAJuMeAnSGml5UCgBzDFizNl5Y2PH4dHNA0kUgxdVmkJh9N+3SsUOZ0ZhA0deaYecqwbdu6fv9AF+hjz5iQOf9Mw6/HQR5SisAoKikpBWPHyBsl4tnY504ZPRQS7NbkuJKVaLlZMXigNvFYx8ihAZ/Pd9q0AalplHNCKRfSKtn+tNlxwIvyv7ldRgBWdW5qiLZP++pR6NoODj+YoXJH/8Xi5IxZEwyPg0kMo3SDrz1X8+2rAK0Os+73Vg4fvvq2N9seeHzAvLOb7n3Ck5PlPWao+f/Z+w74uIrj/5nd967qdOqyJEuyZcm9N4wLPZAADgZCMORHB1N+EBKHXyCEEAIB/oTQE3roGEw34IApBowxYBs3cJV7t2VZstq1tzv/z+17J8kNbHC5k/Ybxch38um9fbuz35md+Q4molgExNBihj1SLor/y4hKXVA5CM31dkyCnXlpVySSVEnuqrLYyXmXDGPORTKXipNFkaMRf8ncjSvFFzruL6PS0NCMqt2Y7mZlPhmNNf73g6zHJ2XdO55fMJaKC0K/v73p3id9D/8Ng4Eo2F6pSkUglRnq8BvnkywAMxKq37hJgCcHemxYuwG2bMXMTAacGe68AX2C/XpAYRGCZEX5pZedF91YFQn43SBVgxkUSPUbNoYWVgb7dObFRSAxMm9+XXVtZq8evDBPIpoUJzRKpUFur1wSXrs+q1uFt2ORJFG1fHls+Zqs/gM8OdkxN0OVTKravAMj4ohAkloSRVU+VtzLFQykSEvLGjIwCuss4Pm9LoaszChFGRhKzMH5N6qVX3NGKdn8r/VGoWr9iEqKcktOJ9Ut2S8JsjIy4k5zfLCYXa2kDaxGKgOVI8ER5tetGLDoX1AzF8wgGOyMqjRXh37/6nh+dnEXwThX4sC036aIBJCh+I7lT2PHDYM7Tuc3PhR6eWlWvigef5bs0ZVAIHFIHO27m8NQyr3xUutAn7T1O9GuC5FKvoQJZqelMxWqsut5gVyO6ibaGhBumdB2YPt7BzrlSqMtQB91/3gT6XhniOFQaDmI3L9c2uPsM6TPU3LU8O43jNue64uEwrvXOcsEObBFaCSAJxyTM2Zvf+RF79iTcu8dX/fRd1tenQTbauNvu1zusuJgeWfp5gIEouEJZmf06OnqWCyUvYuzF2Th7dXzHvrPuhffMKtqQksql9/57zXPvxbeUSMRhTJXyuKhZfBtq1bP//PdK/79NG3ZFlq+bu59j1b+6/lwXZ10cQI0QrHaBUsaFyw1GyMSyVq7KTJ9DtXUkPpd5MT+hToL5Hz95kVvf4gwNK1gxLo3PoHFy1xxq74T99m9QKelZgftIkU7CVaCFFIxP5UzRYKEaCn009NNI5VthSr84Ahz6lb0X3Q/1C0GTxAwBNjpKWPMS12uzyjpHuHK67HrP9j+mWW7/3Eic5zJQFrPUcMDYK6tez/Yt7OvV08nO6G14WrlFu7yUQLQQtawvabx829w1hJoapKMmmprG7+Yg/OXYySqcgjQUdxlOx2zki1U3Lpr+75E7yjRcxT1fqShY1TtNERl/0dKQJ/fW37umaZhxjgnACMno+CK8yORMHJDQkLG2P5xbHVWqEI9RMTXr/n8hQm9Cotyb/tDuLigS6hm5n8/PqKoKO/CswUwYTeZ4MCJq2Qo290FwrgNVkXRmN+tx6BLf7Ph7w/HttZXLVrqBex+1YVmeUlMRZSYk/YggWG3kSPdF2yp/PujpWDWrlibs3lz7xuuNToVC1vKQMolX39d9cLkk669jPcp/eaeRzuEoOgf/8dI2kZbdcqQCNi0cevyP95ZvWRJnzdv5l7363++teLymwY+8FdjQM/9aM2XcMftZC1bDksy5Oo3iVbqzxoaKe23Pr/+4/d2LHhp+1yIbAWT/3VVweCSI4aXHx8sKIkYBhK4hUGsRRZhf5UCHOlOBENE+aZtyyd9IDGv++iTl8xdFPx8hrdwDHnYTkeie5N4UwW4AsyQkFUT3gp/ubjL36/KGNBn1WtvrJ4wZdRVFwW7dbQUVWqpFsGW5Qw7vZLQ3Pqh8BQk9O60PoKGZlTtN0jVnHAqDYMZpgAwSaoMIZKI6PFYijvxHwhok+Hmnc85IzOnQJSWRAzMOWdsnz79PNkZJCJomCbxnc2VsJt/cftUTZ0exnzu9KMG1QzqXnX/hCII4wt3w5F9oy4XA2GQKmRmCEhxuuf3ZZ17Wt9FC6vvfiEKovvd480j+1pel1TBffBg2SnHZjw3ZfljE1xd8uXsJQW3/YlnB5VGoEFK3YpUclP96lWZKzfmXvkbz8+OBKChfxjne2QSLl0KPcvAdO/jIZ36QLv5ji1P5QTtGOCeNHc0NFISEzZ+fP7K/0DTBnD7AEN/DY24ruwXaV17Q35QMDBpdxX0/fTuEIVSRYhbhHC0Zur0pn++U3rT2e7TTnH97pZlT7/ar6LCGD5AoIDW9XfY2jVsWZMcSCD4c7P9Y36+6KuF655+jabPq3/po86/HuUdOTDmdYsEUcLdWN0evU4NDc2oNH7YKbRbe4JTcKd8UXSKY4yEsHGzlZG7mRlC4IQEnOcXdi3oCGjEePyjXKUdOxUXgRDEkbXIRDmSyImoja0jbnevkQaC6TXczKiBtQbIAm5IbkRAdetLJJcCMYEgGHjT3cxtVMEyEwyf2wA3FyqEz4lCnHwdi/NuvvKT39/S7aMJA+96wDx6aKOLuYib6liBO10sMLOiPO2p26C4UPrTgWT56FOx90DICEhu0F5d7D3IEtqebmvnlkMikR70eZ9GKmD3LjCJ6Mz8hlW3rHr1rdpFENkGPu/FC4Kj+/zPMT2O8mXlWx6TOVUjjtYU/thsQYwbHBJIRLJu47bPpkztcvrI/AvPCXfM91xz3rx7HjPf+6DnEb0QiLjR2hyxVmut1aehQcAYcx0zLHv8ObEL/7UB3ikZNqrw3DFWWYltThLuD7UyTT+83jU0NKPS+AFStXMymlPmbChepSrxHONFe/r3To6Qy8kTNZs/jiHYne+cf93Cq3Y2gPaJIIGwqr5dsm1RZflpF2z8dun2yR+U9+zq7tVdtm4sQygQ3FKumjpt9WczBp99WdPM5Ysmf9Bp1CDs3QsNrn4ZZ0r4xkLhhWgsFnWpXoOGo1PlFEQjQ19urszLUxVBBGhgWrrsk06q1SA1M8t9GEDc+6hqe6yRQlSKWr4hmyEtaFjdf+H9UDsPeBoY8q9rulxZemp+96Os/EAIwGMneR+IjOxmZ0sCpAXSB4+7OCszlzoVI1l5Jx43srjIKwFEjHFTJq5aqhN3x+XDXY0SU+Uy4HUHunSM+F1VjZvTi7MxL9Picb8LVQ4o/HACPe7HOEod0NJoC9BpKgfd2u4y0PhjrCXukYjY3whgTeu3rHvmHbMoP/OGK9kNFzW+vaDxhUly41ZAsBI6x8AkR2pYtLTuvgkszef/46Wemy9bvXLrjkcmurbVmBIFoAfNyKYtlfc8VVFUGj3n6iUvvwcffx0gMiFGCJLFv4CBI2cgJUrpVGTHzXn8rz8ir1ZDI3UhHN2ChEaTCt8sbFz1i/l39Fv8b9ixEFx+gLobYiOu63FB/tGjInl+IPJKYkR0QAvceNyzYa68jOKjh7r7diYWNQxpZAZyhg8JDB8C3AdoIkipvDSjOTy8F9sVBYDt1TWfTNtexNJhWO2r39TNXYCxqKViU3wXqakD5aDqoLSGjlFp7NlAILZmVfhTA2F7tOYkVavm2g2bIpFoxflj5ICeBaUFrrWb1lZvL6muCRR1oES3ekABFq1dsdzK9va++FLq2cNV3LmgumrrrAX+DRv9WZkRl+GvqZ/x1AuRtSvH3HFTqLwocv3ts+7/d9d+hYHSTrJZ7gFhj8d6mkhptLs13iwpro7eJCIHXNK4pve398S5FPeAady0vuSk4qN7VByZll0Q83Am49QHW6kF/PSEwVahMpTMlj8gVMK8kixihmAYNxaIwhGW+r4eeVK1VfZGRdPEd2seeTvzsjPLSku/fPzZNU88NyQ/1zOwvzQNRzZmHxLP92EMHZ8MmS7r1dCMSuPwgZS8kwsgp2e34C3X+nMzoi5mFOQV/PaynMZGX0amICFBGCrbi0CaligZNhT69XJnZYPbix5vl4vOgTGneLOzVNkgA2BDh45gRw5h/fuyoL/PzePFqrVpptsO8+96PqDNn0a7B2tOmorTKVjYuL73grugfhm4AgANQyKdb6gY5+9W0ZjpixGY0m7Dqc4F8UAyu+aUTVsgVL1oADCPeitsd9BEpb75Q8fqNktaMf+7mluf75JRmHXayVjRuYiiyy69rab4lQ7FpVCYR07WFx4QVqqYIOkQlYZmVBqHE6opvMo3DaZjRlBCzCDkEkRupic3S8mXE9qC5SofS5oud34+2W1llByfOyuLsjIZMBmz/FJSujf36IExw2xEyRH8Q/uy/r1jpiETClIaGho7ExCHHS0MbTh38SMLRAjqK8HlKtkgnmw4tvjUM13ZFRE3c5Pt1RAymaAOeCDPy5y2xHGeI5XyiAQ0autwymfh3CzX0H61fo+vuhFnzI76XP6hA2MBHyOyG920vgqSxNRH5RcWZk/8e3ZWuqjoEnG78n/180CvCtPllhl+5iQ9Hdj+MI4Wl06n0tCMSuNHB5loT9U2+2VJnfNFCZID2mrsqgs9KoUFhkCWU3XIiNsHd3E3WXUVtFv5WQQGGpwRCCWUHlHiUBzIYoQeIxb/HKdxmGZVGu15uTrdXpx+LokkdIAVTRt7z78N6irBNMFD/eoy3vOeVnDECCooamLSLdCwZcRxj5WB+0vh4otbOoEo4MQUHZGk+sYwVYpLCFGQZEVWzJyzftnSE6+8yDzxmG3vfbjm0ZeLLjrdP+II6bRehj0EnpUqTLBDDhTlkrIecdsSDGYOO0JRQXlwfCv6HpEsDQ3NqDR+GFIJIPzkTARUfUmpuQzbTGSO2q6wqvfjCM2NtVpkBJVKsakqpu1QFkgy/CgwPjEwBjwK0m3PEiKSpD5GQyMJgbvTgwO+XAFBYELjQy235aFNw767r5pi0LAC3J6KDfLF1QNyfnl6QUmfUDDAATySWEtXFkzQhp+gPqWq7Sx1TkYAXnXwSCCjSEKQyU0GYBCE0Yqme7J/flz9J19U//tZJLH2+YlZORlFw4aAyc0Ed9qDogkmWnoq1uVSOrvYUmXckjmm55yGhmZUbXMzaR3owt1qA3evkmbIdtI8tqVKIU6mcOrn86ZNHzB0OB073OP18s++Wvjp9KLhI/xHD44x4UNTD7hGEpOqg8WoSNEpaqUVvjpUVTH3JmhYA8wFnEOj/zXfL/ueNSLSqSDm4iZEkZDHF9qBvDBJgqPhijs3KAGiaDGQJC0X80sOTApClMC8ZAgXM4b27XbF2O9++2C//95a3C/f/+Cl2K0sxsCURJDosPm94nEJ23Jwx1ZDQzMqjTYICcCLizfOmJU+ZU63stLG4rw1f7s/jJD281MinBhyPUQa7XRpJIp3OcCmyLbCebfF/9K4FgwPYGNxtPPXeZfnd+/W5PdLxtNUwV2c89ABroFljCFA7eatW+bPL8/McQ0dGIZIbEd99eyv00xXztEjSHU05wKRm9FAmmtg32iXgGvR9KL8y2Sv7lHDAJIm6Q7kGhoHHrriXcPxOYVq5uoFYGWd+lx43pYlW7a98KZ5873rPpnX84IzjF5lJkeu8xw02iu4KvUwANZGthXOvg7qFkF9JRgm1PD5K8ZMH/KXgj4DY4EME7nPMa1cqfayA0tc7OO4WNRqfOnddefc2Lh4mavB2vLSO6uuvz/n200RRKESJKMMIySM2obwpzMzFtVVlZ22aPGKxo8+9kSiblJq7cQOdHa5hoZmVBoaDqcC1VYZmhgrOuHYnMt+Xn3765vvva/HtWe4Tzwm4je55Jy0/dVojyB16ocMN4erSmeOh6aNYHjBjEIouN07ru/JY4szS6MeDkAMmzOsd0/tOhDETnVHD+Rl9zvt5G8bt62560E2aUrVE68XDe0Gp41iEGOkOpojGuFo9bQZ8175b8llp+Y8+afaPnmbnngFvl0MABFGqgtg0ixneWDlTjU0Dg/0qZ8GtDTUU2hAlhFMj5bnB+G7TGis6lRoZWeEkQUkMWKgz/002uUC2RyrL5g1HtCEyFYwTKMqtmrRiNDFY9ODBTuCvjQig1QBLSBBK3nfA09aEInQbbBjjyy9/iIaf8fa9xYWdissuugs6OA1pVQlv0gEomr75vueDJiu3PPObBzcteKc06rP+3PlxEllXTpHMgMI5E4mB4kAdQRcQzMqjbYDqbScs0HwZcs9D7zJjj559rat6X98ruyI4eYR/WMcmNIN1NBoD6uBVIsnLgEZrIk1dPryCohWq3YvDKKB9dmX5F8zlDICkkEagVIkUXVxjvgtHhTWAQScWTGLTMPKSOt6+ol14/9Uu3VW3q+vMbpWWC6fapuOKElKCfm5nZ64y+33QW6u12V4Th/tXz4sZnJM86WRyjdPGu8IJRgcuduMJVioDoanCChR1+Q0sXUKxTWj0mjn64JUTxuGyOpCnz4/IWtRTdmUPxeFGuaMuXzNi68Vlpawgiypq3w02smCILIQGUCtaMr64krgHohuB2YAhkAU1WVdG+jRHTwu4Iwd2vMqEsR53G4b9Q0fvjSxExh57p6bP/jKe8YC49ijJAInAkTGGXCWUdHFVsxiAOD3+7r4yWmrTMk23LqvX6ruG4k+17ylDKP9PkedR6XR4iaqvssAH81qmLsi867fRIb0CZ98Qu5NV1YuWxH6ehEXOiqv0X48b8kBa0Q4a8YlENkKTRsAGYRdc9b/prbnX739+wuvB5C3atDn5KIf1DUKwASXggmMifDbHwVufI7/31WZb93WROamf03gyzdKxCjGXSNuM6ndmBMm63Br25KKUBWtkiFIICHV92C15+NbHaPSaN4QEG2fo2/5sXf+yVuQE0v3CzRKr7gwd/Rmb04+MmkggU6k0mgH/gWiWRNtyv3yYojVATOBRcDKasq41nVUb/R5JGNcHJ4rCwEzALYvW/HVa293PW5Q16svj6UHXL89+4vHnqOXJnb6y3gh41yQmCJVe4n66KacGgeAB5OqF0Xjk2mLv/hi9s+OG9Cvf7nb3a5JhWZUGju5roxQdC7yQ6FgzLQDV4Ud0grylbKh1OoJGu0BURl1Tz8P0AOxemAIjRT6cmTT5ed48osaPMxDzBSH7doEMCLIz8w97tpr0tKDVkkhSOpyzplFA3r7mInSMnaT89XQODhuR3zHeO2tyXfe8Vy4ifXs1rF3n04ImlFpaCTAEJAzSyXYAoKhOJSSiiYj/qaGRlvysls8CtXdJf6/kBXxTf8NWCHARjAIon5hjoObRqHHiDHmBiTEGI+/gzt9xKG4WALwgyAE2SHgzRvQxGQQuGRAWUFj2GCb5gkW/zGeMmEoO6lZpfWrJldST8vU4VQvvvDu/fc+K2Wm32taltQet3GIbJa9uElJpbSb/uLUqvenbD0eSK0tMSXLNMTm62G464utLliHqQ6tE7j79p9gAGoi2bOMJdJD7XYppLgxa6fkyIHc848kFh+hVCOsRkmAYGSR5f3sXEAXWGFADhGq+6APXHMhdewScZuoMqua2x3LPf+OfRL03Pe0odaPUDr/MP7xFlNdkVV3ZAEgkYhzC4CkkqtCEAc5SVbu//Xv5XNQttLFckYmTm9TaZ+wr18ScPWAbDUyQiYZpsaN0J5viXaes7jbsy3v0unuf96yck396xPfBIoBa+9K/MbB2ZQTSwnVeb5jCuKMSgKjdjPg1Goatp6x0llxTmu9ZGNUu29ObKc3NKM6hL77HrYgteMwm6yTgKj6rzduyOIUIU6nbEbVXiNO32deUKp3mc2qhBozu+8lhkEEPhsLMgIQBmQQM2s2nOa6+fhoZl4IuRnf+Hnr3ULsJUIl941R/WjiosLHxBML05Yb4Cp+jAAxxpp/hTy0W/B+/Rg5u0P8GSj5LucV0erGZerMYWxeb61YB5HLQi7irBdEW/BUmqe2Y15I0qAh3RljOybPsmS9BNvJQ82oNDT2Yr01f0o2A8finMqSUL9DEuNer8frjj8mAYIDl4KF6oBxcLnjXzqf5nu2eCYNe/9r4CLw6Vi1ZUTB7hjO0qOdb6VRBWG/6SdGduyBbBGnZOgZ3BxO3v16UutpkKHkHqQUdryq+QkxSj2fgKn5pEKEzPGdlcZfasprNRt/OyYC9iLAFgJJiDHiMYZ+kCCJEj8ZA3C1W8Oj1RM0NFILiAybdtTfcssdfbofNe6y6zdtiiECR15X2/jgPc/06DbonF9fOHv2PM2lfoCTOI3tIPDJ2SAiIMLx14VJM38p+z1mdu0i/R4CzhOKhUwFlTGhP5kMX8l2Pfv91erAgpjc5fmk4tcuu2sbzXBJ3GjiSJMxjpxDIqEFdIxK45DviqiDPxo/yo4JCeTLCFxwwa+/+HTVxxOW3uOfeOeD58QEfDZtzhP3T/PJ7iecePLAof0FENchqp0GkIgRSmaprbyORxmJrE//R4WmFMFi7u14nXXdoAaT++MbIvMl8tTskIMezp8S69iTR0/SmdqCScGcoI46204dC9kclkCpophkn8kDkmXfEVPhqxRgSLs8OBKRqFW1tSYWs9ICgazsIGPMIiBBDXV122tqA2k+l8fdULd+w4bqaKO5cUPt5g31xR1zXS47goWaUWkcvvmrofGDW5My4AwkY1TRtfTyq8bc/ddn/zvp3bL+3qNHDH/+qfd3VG87+6JTLrhgtNcEi/RU282RIWcLtMjK+excEBHnHWFWf3Fk1q/PtCo6xQzmJ+Jgb/Z2n77mBCw9hj/V4lErr9IZUSfnyw5SqRw3kHbZccquVPvamXQicdCqSClFSHCc08K2bTsee+ylTz+YN2rEiKt+f1bHkmxEWrdp05OPvDp96reXXn1Kl84dX3n1jflztkQj8Mor/62trb7iyrMKC3Kk1IxK4xAadj0GGj92c1JdrUmm+82TfzF40YJVLz7+1n8eeW329FXffL585M/7XT1+bGa21yKBO2dSa0Kq/sCIjBGA9/PfOHRKcDBNuWZs7I8nCZcraoJbSoaqG7FTtoXoNNdAXdn/0x1I57jVSUx3OCoRSYak6BS1mMgUm7yJrHRs3SWbWqoEMLUem0QKBny9e/R6+9k5Ex6cEsz1/uGP59eHGt6b/Nkzj7xWXNC1e0WPLl0LzvufsaefIRh3RWOh7GBGeiC9PSvIHgJGJZvrlSVGCIiQSBK1VA204eMvpLhRdrG4bW4CNIDQIKenFimrrQ2uxvc5is2hFYwpi+xW6Rpkn0AVlBRccvXo6TM/XD+3YcOiaRUDSsZdPaaiazBiCRdnOx1Ytce9u9WuJiOS6pj0NAH5Z1wAsRpAtyqb8y15vWe3P4yDozpwJlGSK+6bt/6ohJnSp/QHFCKR6uwEoliMTAaMTIgpPQgXqhqMVGTthOBSRJEx4mhnaluqb6qZxNct1E7NFZdFu2oPANPS0372i2Gr1qy5+/Yn3nhpWnmXHjn5/hcf/9Kq947+w4hBQ7oTiw4a3EcmKKOKyFG7PfI7JIwKW+g7MgiHoksWb3SZnMjamXpQ2+s4HmNxzsQEsXAUwLt6ztL6rIxGwzBU2TbZgpmkTxI09uqKMIh1LisNZnqJEh1FyJHbUNXmMi87eNSoUY98825OWl5+h/xOnYoAwGTMIVPUfmqZd79NlghMIXGToa+erPQZF4PV6NApM51yboc/50B+WoxiYMUNlC1OIXYObDW7Rzrg91PndIKg2vnMQkoZ38GBJLNkfI4nBGUkilRytiU0Nwlu2csEYEzGzTxTvShaBOOScPEgSHQ8CXLOJ22tBMrOyhg9+hczvvh21kcrHvn389n56ZULK08796Tzzz8TWVQ6ETiSjqfX3hscHYIYVYseVcAXcJHn9j89QczaZXIJLpHaGqOSDFncTMhLTMruWDzhf27f4TJ3GC4uZWv6aOijBI29IC+T3fXgTSOPL0MwmzXelM1jgBQOxaZPW/TGK1PzsvICgcCCLxe/+uL71994PjNVBXe7P1yWABazIpI1NERro+HML8eBVae0pjwgreqhT1QjRAA8obBJ+yQLp+NU+71V0555r+KsZId0rFi0KeZvJF+kCajBktKyJIOUKhyTu2SKcW6EYw1Welh6wvVWkzdmWFImr6I4xleKQ4UkM8j0mpwjB1MCcoCu3TuM+99fL1v8xNwZy1G4Bx3f+4Jxp5aUBCPC4oyrMiuponHa4zhEeVSIYAiA0aN/0bfnEJXxZu0y+MJZbm3qkTglH4AVMuyWoli6wwZGGGO2JVEuMSZSMTU0dofbxSq6F6DqTm2fFiuFaUIUVowWf7f6uSffjmyjE87sNWTIgEcfeOaNVz/u3WvAqWf0cWZeOyJVrUMarHk35xJrt9U99PfnnzjrU/ArU1QvfjftaNMyrp/8mDpYZab98/oI/uCY/p0eUmKMrRYhUjCBjHkb19QYXzz4lsz/HIBMaWepE6bg5IvfNUczFGraGm5qqnr9b89F/G5GYMikvRt0kgTJILIKO/vPOfe0ktI8JGQIksgwjPLy8h69um1atdHLAp06FXUqK1atNRxpVkTQAdxDyKhUMhEQjRjWd8Sw9jvWA/R00/gRq4ekoydt+x7KeEuwaqrDr738/swP5g8aOeD6P12VleNavnLZC//64MH7Hystv7Zf/24CJKf2XAYRd6/Ly0pDtZ4l31bCuR3Ai2DAcX93z4p+q8LmnAEyiTpGfPCwS0pD81ALttMU93n9Mi1t64YqWLc1URaHkDre5m5kiRhDd0G+lLRm8SoClIiSJ+9K5CRdQGhxQaIplBGqiyKgpVINOGLtjoYpH3z0+YfTM/KyUbJPP/xq4OCKSy7+OTNbdyvD1j03UDOqgzfZ7AFXOUVAJKRd4bFTazubINO+NcVKGURZzCDkZAgMAxKTLhE3JWhKoZqyMq2koLF3t1E1wYTmVpCcqZ6Y3IgBiGjYnD1z3usPzOpYnnfZNb/q26dDyGo661dHf/Xpd0vnrvrPI1P+dmdZRhZX7dHaTx5VQtsIWpIyH3notpgEAZYRsaLkIULzo0YnfgembYCEnm0Hb6veOZAjd6NWyJgBgJIBA57Q6Us5Lfjdc76aszrIyUlK8oCxqmNlzU+GCSIkIZXk+5xZlf95+M30YNoJY4YFs8wXH5oy4Yn3yrsUH39Cb4kCd3rI7R2HIkblJNTaSjCMOWWxuMvzbINPxYzzyPjWaIBbHfIZTJmY+Big0zIa21w+vsaBs9Kt6mFbshQQgIUiTTNnzuh7bMFxJx7xyzGDJVguwzNgQP8r/vfsV16eJKiusnLZEcN6SZLtb7haxz5knDcxZgIHL7dXnAHeXQIoekM49DGqXX+Gt6Yi32MQaZ/p9aGm8/h92x/b+/Vjkj0q1rxZI0chZeWydS+/+M7axZtOPfvE3/3+vGikbvXiqg8mffLsM5MGDOyaneWWiDrDsOVxks4eOGiw1H6GBHYNC2teUiQcSokImlFp7B8kAFmW3LBhs8nNjKx0n88TI4nAOLJIJLp58xbGeHq6L5ge1KU3zflnzduXtneHdIPZt+knE5u53GWLd4RmwPHK98lDOMAW9cCtoL1VL7K9TdfD+KRUF3ZRs63umWfeeuCvb3bvU3797ef87PihoabGtyZ9cfOND4UbPPc/fOXJp47wet16njdDK3weVNLPMLG6iRJnEgSInBJl8FrsU2P//WEwDKO0tJhIElhEAoERSEnkcvGS0kICicSxrVV6HJitQg9JsjLfXZ+ORIcBWwCmnamDbN/XSFL5QC3SG3jICNxPB6+ra9y8ZesxY7qffPJJo44aLEB4vd6jjhl4+W9P//SLuZs3b9pR06gZ1U6PT8eoDpJbjIg7doQaGxqQGZmZaS63SSCJMBaO1dbWE1Eg4EsL+IBUQYWGxr5OLdvsCkmkqkltIRKDnH4pEkkCQ04cbEKvoZH0kAllPlv2QyboFRISgFA5pzxVWaKzMqlZOJ1o55XJkvPKLSLLspBMwwSOYJFkgEzV+BFACMCIgMGJcx0H14zqYHIp+0/G2OS35z/9xASMuC+++pcnnDSIjJiw6KOPv3zivvc8fvdlvz3luGOGElkGN/W4afyIPai5h0dC6Ya1dtK1ldNIKepBEsACwdEIQ9whMOLMA1jKSiDbh5TqUCL+fdSJU6EBkoMtbGqvVZa8D0UpVSUqxrh0hNWl8uyEejRMd7uEJGfHbYZa9epb7A/iRx9+8I87nly9qgYZW1656f57nvr4o48DQXfX8pK438L0wavGT+FVYucKKqkzhTRScSYTSYGAAsKhJqith6aQLZwuUrdVmepTqBR5lUJHU0TWNPCGMBIjpbQlkv++COPklpxuDYmYG0Kc63Iipo3NLuC33HKLHoUDCEyApEzP8JYWly5asmb+10siltmjV9HTT7/x4TszBx856PY7b+hSniNI2r1FsFWdvA4uaOzLRNvZdO/ajlbHqDSSJtABP2jWBJBAACFhxZrK96fWfTo7vGFTus+P2RnodImj5O6dTHt5jQiRLBFbvXb9+59VTZsp1m3yZfiNQECiUrFKNN5JYjvDEhZF2Rm0pacQ7UJ2naypGdUho1YxQR0Kcxpj2xfOX7/g6+W14eiH735umt6/3H7JsOFdJURVCpVSTteMSuPH2zuWUNhr+dLTSCMZYMsMJuwa7o2MhBCJUK7atPXPd1Y///YOl2iaNDWwYXPayGFkmFEOjCRLarla2uNLFovTQWv1+sp7Hql//L1wpG7r5I9h7cqsPr0gK0Md1jOWEjK8zhU6O9UemolrKOhTv4M4BQ2DmQaOHXvakUcPFkbk2Udertpac9a5p516ysgIyEQBiJ6PGj+aTjXXD+HOX3pWaSTNHCWlA7b7V4JzgSqyEMJasbJywbr1w+675ZiH/9nvrFNWTZ0RqVwFJpLq+E1JQ512OllvdTu73pwK5xiW3F65fOaSxf3vuHr4k/cOvPD0bY9/CPO/U3lUmAIGBhMhb3Wegq0D4NrQaEZ1iFefRZSZkT5kRL9wbLubZ3iDgYFH9lDJfYRkMrB7/H2PvdHQ0NBIXUbF7C9waFVr6kF2f2oC4iQ5UXZJx9K/3SDGnLQtzUUdMjxBk1sRR0ABUSZNIKc1oyJVF0K7kivnx1S2lJWR12Ho/10jRx8dywtsK87OAR+QqeWd2yR0WvRBXXiWga5Fi5ZO/ehzirk6lHeo3rrplRfeHzSopLgwW2BYEmfAEUiSLWJnE1yh6t71StPQ0EhxnzLxTRRt2iFNYlwpJBBBDElwFCAMMriBed3Lg90rmizLXL56zWdfBbpWGF3LQEo3JlezOJ64FAtIoLSA3ORoOJO6TAIQRFGUHDiZptm/Z2/WS1qy6Zv5W96cknP6AOjVlQAYSXRqATXaCHSM6mAuPOQN9ZHnn3t3+kczy8rLr7j21x3L8qdOmvbUE69aEebIqyAhMoYmoqGFLDQ0NNoWoyJCkkqtk8WpA6dmqhV3IxkCcjC5OlSKAEWBvFu2bH38xerttR3O/7WVnSnjfIsYJUvCDjrK+3ZoSiJwBgZDrm41/n9JtsggR3VfDCDKIEyyaeWq9c+87Ktp6nztxVRWrPS3JBLpMFVbgo5RHUQIgZ9OnT15wjwU/Ld/PP/UM/rX7lj/+NpXnn7ovZHDTj7+xBKuNNPr6yOLFi7LCGRVdO9IKFicWmlupaGhkfKwNZcsEJH1m6NNTR7DcOfkgN9Hqiey2FEXrqpGS2JBrhEIEAj/2vXLn5vQOHla33tuMH42Mqw6ePlo92rWw23bVTTKkLJuy1ba0WB5vYHcPOE1CImThJrGbdVbPcDNnCyWEXQBWqvXb3xqYqxyfb/xV9DRR1gkTOn080Yd1mhLYRRd63fg3TIFRFy0ePXddz+2auGWX1184vjrznZ5jY4FhYuXLl4+b/PaDWuOHNk7EPCtXbdx4sRpf77xbuK+kcP7Awim3Dh96qehoZHyjErFYCRi9eSPv7r38czJ04P56aJzx5CB2BTa+PqbK//5uPXVXOPIAb7M9NDqNTvu+c/X/3hs5K9O8g/oH92yHTwG9/kks+NbSWIUCYBQKj13K7Zqysdrb324acY3+TkZWN4JSVJtXey5V+f8v0etVWsyy0qxIDu6au3ap1+O3Dmx4+gjjZ4Vsc2bOXBMDxAqYQht6tsQdIzqIGJZ5cZAuv/MC0+6/MpTGSNGoqxz7kWXjk5z5xGIZUvXejyeB//19MefbDM9HULSIxC5cw6r15iGhkab4FSKDBX26f3dK2/wd57aHK7LLi+NdCtvnD+37sp7MbKp7MbxseJCGQptnD0v/O/3h0Px5hUrG//xcCwru+jys/OOGRkG4phcGSp2Ua2FsrBTaTgUib7ycFPlJt6vu5mWtm36TDH+j4WwI/2UB9wlBdFQU/VnXyx99PVBgFULv125/DszmFVy9hlZHTvEUCuOa0alsS/rDZGI+g7sUt71ymB6emFBllqABgEce9yIzmU9hBDBoDsqoqbb/N21Y95+dxpYUSXyoTpZxR07vdA0NDRSHYRAQIz3Ku//f1dG31pSNXVWxguT08aNnfX0Sx0jCzIvHu++8qKwyxMV5C/t5HrityZHsmI+wYXHY2ZnopCcJ5PKTEJciwCE4fL37llww8UNY77bOncqPTOxdMTw9c++lgY7Op9yCV14lsjJwsaQr6xzyf+7ijMwhUyT0jS9RsdCINDhqbboQOiUnYO07sgRmFX1tBKdYpUWaTQCtCgaEyJSF7386jvKinveeusFhiGREREyphmVhoZGaiMGAgkYYAwFStj+2pSFF9/RtXFjRnGv79Z9lX/S6LJ/3hjq3dWwE9UZNvdRQiBlASWTwBjDJCqII6ehM6BQXZx5U2PkqQmTr7lrEIggdFoPlXj2L/re9ZdQaQkDC4kbyvAL1SEPEy2fUWlsqRiVNvVtB/pZHjSuikgkJAlKlIcwaBbtF0QCiDiCy5BCSiTLroFhNv3SnouGhkbqQwJJJJVNxSygwAlH9Tj/mAhsiKz7b2fgwfNPi1Z0jhKYBAY4dErEeZi0gCwgCSgZS6osiNaKnlwJj8Z8Pjzj5PxxpwRgdRQ+LYEOnceNpdISCywJyNAO0zm3ZrV030Qknd7R1qBP/Q4mqYKEQsKu73DVjTzuhnH0GIZloGFwbhpxz0UAM/RC09DQSH2YwOPcgYiR6tzHVFJ3nFeABC/EhCByFLkJDIpTDQMBd2tzkkwGEVXlkK2uRYiE8bsyTenmzTQyhEq2SnL7jim+zxpKOkJV90lUTfJ1vmzbg45RHVRGhXsJVjuaJlLS0qXL58xev2NbZOOGqnnz19c3cR731YhAklZO19DQSO0Nhpg6xLOk5SVmTZ666r3pJhSz7qcuAWk9Ncm7sNJDEFEki6kTMfUn2uV0jOJfycU74gRR5YYRWCzOBN2NO1yvT448+elmKDHZsSth++bHXsK5S1xgKgqFlsoBYQScJJLVnCerNdM1o9LYP0qVWC+7uiO2wkI4Grn3gQeuu/qO7+as+vi9GTfeeOeSJRsZMkmWHjwNDY3Uh7StnYubm6u3bLr3GblqZfa4s9Ofvw06F8tpb6x5/V2MUhggJomkRGxpHGElsVG3q/RiiFHANStWLL/j6TyYF7zs7LSJ18tOncQ7z0cefDoWvwkkQgOR2fIPjAEzRKuW+JpPtTFoPapDuRJ3PQBEzgs7dBhx3KAxY4/7xa9GjhzVr6xbccBrEjK7K6VebxoaGqlMqMhmVbwuvOS+hzNeecw/8ISMW8fzAX1khm/HpCmh6RuLehUavbuZlsWkJaZ/vf7hZ0RE+spKBUcDdreayeInoySUZK7bVHPvUzumvVSad2zmC3dQ9/IqHmYfTrbmbff0KvWUl2MobH04bdNjz9W/9j6uWOvJysKcdCYtUl0zUPfK14xK46eRqsRfEDnjHYuKyrsUl3UuLO9cWNapyOdzkfMmag9GQ0MjtaGyuC0pqt5478v7n+6yI7/zbVfisSPCJgZzcxo2bNm8cDat2cpPHO7lfPW0Lzbe+sDGlye5BvTJHj7YYknJqJxezyop3bJWvv3Bppuf9GZ06XT/1WzUcGmSPysT569bvO47K8ayKjqvX7t2/p/uyIiK9DT/hilfRcMNwaF9pWlYyJlmVG0OOjP98C5Ou+DDLsYlWwpPRaZI0ykNDY224UkSibDX7Hn1b8yCbDh+FHebgMDzc3N+fzkNHkgxS+yoqd++feULr3ZiZi74Y5DsKsd2v0JmAWQGc2+5JNirDI47KgZScEwv62Tc9ofMr49J82SHGiOR1auDpYUlN4zHrGDTo0+v/Wx60a9OFn26RwH17qsZlcYBsjGtDvSo1Z/Y/L4eIw0NjZR3GpGQODezjz8qR4zgHm75A4DgBkLDyBjY31VREQUKuJkVCvf430v8DaFPlv2+P4VV2R9LSi4F6hxTaT24Zcdjh8kRQ0yfS3jdXEqODDxu77BBPfv1loK7DVZcViSHHSG6Vhg19W5puF0eCqaD6qBsp6jrIJVmVBoHnmK19sn0CtPQ0GgLYGj7hzwzaFs2oY7LTJuZuEyZnUF2iZ8/PT87O7R0+YZM10BhEe7EYJLIKtrNn9XlSANYMCCBg4gyYEp8CoAkul0+r68eGAiJaR7LZCTE1m/mbP96Qd+fH4tFHVBKxhkgaXuvGZXGgbY5egg0NDTaqKuoVKjQ42Q1NGsGODQiTXEmRhBGiCDjQAKFhUwgRYHcZGcsMUwy3xdtiQdwkTq8Q2a0Sny1Cxbjt6wkE7iboOGrb+oefoaO6IHn/7LBABPArcVxNKPS0NDQ0NDYPxayhwZ22HoHkiBNQkQmuZnZEPMj48g9REgkVUyIJx1RdNxh5xtkre9WkSVkcQ7JzEg0NnXGymcnFJeWZl9+vlnaUYBgJBGZAInAuJ4fbQg6PqKhoaGhcThBACwcjlVWur+Zm7G20Vy2ms1bJOubVKEOpmIwh4gYoohZG7+YteG8W7MmLuyQ7q//9rv10z6HmloDmJ1EpdHGoGNUGhoaGhqHkU6RJaPWpqoPH3qy/r3PDMM1+d1P/KGmkeN/5xncg1R3GkypdCObBUqAxi1bpr39pqxeDuCa9dRLsZBwDSgbdOt1FSNHRoBcUt2TDmu0ISBpoqyhoaGhcfgQhRhriDWt2SRqa0xkEgA8fm9xMeV6UJDZfDKWOqRKAsUAsCnUtH4d21ZHqnM+WABet6usyMzKsgBNUio5TGema0aloaGhoaFxIEAgLQKBLCYFAzQdVXJCQA7AnMykVGJUFGdUFgJaRCHJXQheAAuIEE3FozgBIdnHmnoCtBkYSTwj1Z8UxTiH16eTqQjZ6nuWlFOMdMxdQ+Pwe/aA3CZRjDnaBEQs/iKm7B0BVxV/HMHDGUtU9jHnoI+05mDbnMnJHKNSUdIGE31629OM6qBdnp5aGhrJ5Ug3k5K2dEfY/L3ac3Voqk0iqWM/qvjUJYn0QXNqGhKWjEax7dlsDY024+K36TvC3SyQRhsDS2I6RUqT1mwINUqS+lGlFJ0iIilAEEkp5WG3IZQAAAgQQAJIkvO6LmLW0NA4hBwLUQeoNKM6bNOvtrZJs/pU4VFSSiISJARFGZDKKBWKVEEykCohBKIABgJJgtRBKg0NDQ2Nts+omol89ZY6KTWlShnfS4WnkKTZWGvUb2cInBCIxOG9MGe6I2usMWs2cxllSFwVL4ud8700NDQ0NDR+1F6T/OoJUkrGdPpw6sGeWckW3ibVqFXno2toaGhotDtGpaGhoaGhoaGR5NCuuoaGhoaGhoaGZlQaGhoaGhoaGocb/z8AAP//cSB7KY7WFOQAAAAASUVORK5CYII="
+    }
+   },
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S_ZjoGBU5upj"
+   },
+   "source": [
+    "### Sieci MLP\n",
+    "\n",
+    "Dla przypomnienia, na wejściu mamy punkty ze zbioru treningowego, czyli $d$-wymiarowe wektory. W klasyfikacji chcemy znaleźć granicę decyzyjną, czyli krzywą, która oddzieli od siebie klasy. W wejściowej przestrzeni może być to trudne, bo chmury punktów z poszczególnych klas mogą być ze sobą dość pomieszane. Pamiętajmy też, że regresja logistyczna jest klasyfikatorem liniowym, czyli w danej przestrzeni potrafi oddzielić punkty tylko linią prostą.\n",
+    "\n",
+    "Sieć MLP składa się z warstw. Każda z nich dokonuje nieliniowego przekształcenia przestrzeni (można o tym myśleć jak o składaniu przestrzeni jakąś prostą/łamaną), tak, aby w finalnej przestrzeni nasze punkty były możliwie liniowo separowalne. Wtedy ostatnia warstwa z sigmoidą będzie potrafiła je rozdzielić od siebie.\n",
+    "\n",
+    "![1_x-3NGQv0pRIab8xDT-f_Hg.png](attachment:1_x-3NGQv0pRIab8xDT-f_Hg.png)\n",
+    "\n",
+    "Poszczególne neurony składają się z iloczynu skalarnego wejść z wagami neuronu, oraz nieliniowej funkcji aktywacji. W PyTorchu są to osobne obiekty - `nn.Linear` oraz np. `nn.Sigmoid`. Funkcja aktywacji przyjmuje wynik iloczynu skalarnego i przekształca go, aby sprawdzić, jak mocno reaguje neuron na dane wejście. Musi być nieliniowa z dwóch powodów. Po pierwsze, tylko nieliniowe przekształcenia są na tyle potężne, żeby umożliwić liniową separację danych w ostatniej warstwie. Po drugie, liniowe przekształcenia zwyczajnie nie działają. Aby zrozumieć czemu, trzeba zobaczyć, co matematycznie oznacza sieć MLP.\n",
+    "\n",
+    "![perceptron](https://www.saedsayad.com/images/Perceptron_bkp_1.png)\n",
+    "\n",
+    "Zapisane matematycznie MLP to:\n",
+    "\n",
+    "$\\large\n",
+    "h_1 = f_1(x) \\\\\n",
+    "h_2 = f_2(h_1) \\\\\n",
+    "h_3 = f_3(h_2) \\\\\n",
+    "... \\\\\n",
+    "h_n = f_n(h_{n-1})\n",
+    "$\n",
+    "\n",
+    "gdzie $x$ to wejście $f_i$ to funkcja aktywacji $i$-tej warstwy, a $h_i$ to wyjście $i$-tej warstwy, nazywane **ukrytą reprezentacją (hidden representation)**, lub *latent representation*. Nazwa bierze się z tego, że w środku sieci wyciągamy cechy i wzorce w danych, które nie są widoczne na pierwszy rzut oka na wejściu.\n",
+    "\n",
+    "Załóżmy, że uczymy się na danych $x$ o jednym wymiarze (dla uproszczenia wzorów) oraz nie mamy funkcji aktywacji, czyli wykorzystujemy tak naprawdę aktywację liniową $f(x) = x$. Zobaczmy jak będą wyglądać dane przechodząc przez kolejne warstwy:\n",
+    "\n",
+    "$\\large\n",
+    "h_1 = f_1(xw_1) = xw_1 \\\\\n",
+    "h_2 = f_2(h_1w_2) = xw_1w_2 \\\\\n",
+    "... \\\\\n",
+    "h_n = f_n(h_{n-1}w_n) = xw_1w_2...w_n\n",
+    "$\n",
+    "\n",
+    "gdzie $w_i$ to jest parametr $i$-tej warstwy sieci, $x$ to są dane (w naszym przypadku jedna liczba) wejściowa, a $h_i$ to wyjście $i$-tej warstwy.\n",
+    "\n",
+    "Jak widać, taka sieć o $n$ warstwach jest równoważna sieci o jednej warstwie z parametrem $w = w_1w_2...w_n$. Wynika to z tego, że złożenie funkcji liniowych jest także funkcją liniową - patrz notatki z algebry :)\n",
+    "\n",
+    "Jeżeli natomiast użyjemy nieliniowej funkcji aktywacji, często oznaczanej jako $\\sigma$, to wszystko będzie działać. Co ważne, ostatnia warstwa, dająca wyjście sieci, ma zwykle inną aktywację od warstw wewnątrz sieci, bo też ma inne zadanie - zwrócić wartość dla klasyfikacji lub regresji. Na wyjściu korzysta się z funkcji liniowej (regresja), sigmoidalnej (klasyfikacja binarna) lub softmax (klasyfikacja wieloklasowa).\n",
+    "\n",
+    "Wewnątrz sieci używano kiedyś sigmoidy oraz tangensa hiperbolicznego `tanh`, ale okazało się to nieefektywne przy uczeniu głębokich sieci o wielu warstwach. Nowoczesne sieci korzystają zwykle z funkcji ReLU (*rectified linear unit*), która jest zaskakująco prosta: $ReLU(x) = \\max(0, x)$. Okazało się, że bardzo dobrze nadaje się do treningu nawet bardzo głębokich sieci neuronowych. Nowsze funkcje aktywacji są głównie modyfikacjami ReLU.\n",
+    "\n",
+    "![relu](https://www.nomidl.com/wp-content/uploads/2022/04/image-10.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### MLP w PyTorchu\n",
+    "\n",
+    "Warstwę neuronów w MLP nazywa się warstwą gęstą (*dense layer*) lub warstwą w pełni połączoną (*fully-connected layer*), i taki opis oznacza zwykle same neurony oraz funkcję aktywacji. PyTorch, jak już widzieliśmy, definiuje osobno transformację liniową oraz aktywację, a więc jedna warstwa składa się de facto z 2 obiektów, wywoływanych jeden po drugim. Inne frameworki, szczególnie wysokopoziomowe (np. Keras) łączą to często w jeden obiekt.\n",
+    "\n",
+    "MLP składa się zatem z sekwencji obiektów, które potem wywołuje się jeden po drugim, gdzie wyjście poprzedniego to wejście kolejnego. Ale nie można tutaj używać Pythonowych list! Z perspektywy PyTorcha to wtedy niezależne obiekty i nie zostanie wtedy przekazany między nimi gradient. Trzeba tutaj skorzystać z `nn.Sequential`, aby tworzyć taki pipeline.\n",
+    "\n",
+    "Rozmiary wejścia i wyjścia dla każdej warstwy trzeba w PyTorchu podawać explicite. Jest to po pierwsze edukacyjne, a po drugie często ułatwia wnioskowanie o działaniu sieci oraz jej debugowanie - mamy jasno podane, czego oczekujemy. Niektóre frameworki (np. Keras) obliczają to automatycznie.\n",
+    "\n",
+    "Co ważne, ostatnia warstwa zwykle nie ma funkcji aktywacji. Wynika to z tego, że obliczanie wielu funkcji kosztu (np. entropii krzyżowej) na aktywacjach jest często niestabilne numerycznie. Z tego powodu PyTorch oferuje funkcje kosztu zawierające w środku aktywację dla ostatniej warstwy, a ich implementacje są stabilne numerycznie. Przykładowo, `nn.BCELoss` przyjmuje wejście z zaaplikowanymi już aktywacjami, ale może skutkować under/overflow, natomiast `nn.BCEWithLogitsLoss` przyjmuje wejście bez aktywacji, a w środku ma specjalną implementację łączącą binarną entropię krzyżową z aktywacją sigmoidalną. Oczywiście w związku z tym aby dokonać potem predykcji w praktyce, trzeba pamiętać o użyciu funkcji aktywacji. Często korzysta się przy tym z funkcji z modułu `torch.nn.functional`, które są w tym wypadku nieco wygodniejsze od klas wywoływalnych z `torch.nn`.\n",
+    "\n",
+    "Całe sieci w PyTorchu tworzy się jako klasy dziedziczące po `nn.Module`. Co ważne, obiekty, z których tworzymy sieć, np. `nn.Linear`, także dziedziczą po tej klasie. Pozwala to na bardzo modułową budowę kodu, zgodną z zasadami OOP. W konstruktorze najpierw trzeba zawsze wywołać konstruktor rodzica - `super().__init__()`, a później tworzy się potrzebne obiekty i zapisuje jako atrybuty. Każdy atrybut dziedziczący po `nn.Module` lub `nn.Parameter` jest uważany za taki, który zawiera parametry sieci, a więc przy wywołaniu metody `parameters()` - parametry z tych atrybutów pojawią się w liście wszystkich parametrów. Musimy też zdefiniować metodę `forward()`, która przyjmuje tensor `x` i zwraca wynik. Typowo ta metoda po prostu używa obiektów zdefiniowanych w konstruktorze.\n",
+    "\n",
+    "\n",
+    "**UWAGA: nigdy w normalnych warunkach się nie woła metody `forward` ręcznie**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "J8niDgExAMDO",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 4 (0.5 punktu)\n",
+    "\n",
+    "Uzupełnij implementację 3-warstwowej sieci MLP. Użyj rozmiarów:\n",
+    "* pierwsza warstwa: input_size x 256\n",
+    "* druga warstwa: 256 x 128\n",
+    "* trzecia warstwa: 128 x 1\n",
+    "\n",
+    "Użyj funkcji aktywacji ReLU.\n",
+    "\n",
+    "Przydatne klasy:\n",
+    "- `nn.Sequential`\n",
+    "- `nn.Linear`\n",
+    "- `nn.ReLU`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from torch import sigmoid\n",
+    "\n",
+    "\n",
+    "class MLP(nn.Module):\n",
+    "    def __init__(self, input_size: int):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # implement me!\n",
+    "        # your_code\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        # implement me!\n",
+    "        # your_code\n",
+    "\n",
+    "    def predict_proba(self, x):\n",
+    "        return sigmoid(self(x))\n",
+    "    \n",
+    "    def predict(self, x, threshold: float = 0.5):\n",
+    "        y_pred_score = self.predict_proba(x)\n",
+    "        return (y_pred_score > threshold).to(torch.int32)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# 43s\n",
+    "learning_rate = 1e-3\n",
+    "model = MLP(input_size=X_train.shape[1])\n",
+    "optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)\n",
+    "\n",
+    "# note that we are using loss function with sigmoid built in\n",
+    "loss_fn = torch.nn.BCEWithLogitsLoss()\n",
+    "num_epochs = 2000\n",
+    "evaluation_steps = 200\n",
+    "\n",
+    "for i in range(num_epochs):\n",
+    "    y_pred = model(X_train)\n",
+    "    loss = loss_fn(y_pred, y_train)\n",
+    "    loss.backward()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "    optimizer.zero_grad()\n",
+    "\n",
+    "    if i % evaluation_steps == 0:\n",
+    "        print(f\"Epoch {i} train loss: {loss.item():.4f}\")\n",
+    "\n",
+    "print(f\"final loss: {loss.item():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "LP5GSup24dXU",
+    "outputId": "05f332c4-5d94-41f6-f85b-17793d3c4b49",
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "model.eval()\n",
+    "with torch.no_grad():\n",
+    "    # positive class probabilities\n",
+    "    y_pred_valid_score = model.predict_proba(X_valid)\n",
+    "    y_pred_test_score = model.predict_proba(X_test)\n",
+    "\n",
+    "auroc = roc_auc_score(y_test, y_pred_test_score)\n",
+    "print(f\"AUROC: {auroc:.2%}\")\n",
+    "\n",
+    "plot_precision_recall_curve(y_valid, y_pred_valid_score)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == X_train.shape[1] and module.out_features == 256\n",
+    "    for module in model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == 256 and module.out_features == 128\n",
+    "    for module in model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == 128 and module.out_features == 1\n",
+    "    for module in model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(isinstance(module, nn.ReLU) for module in model.modules())\n",
+    "\n",
+    "assert 0.5 < loss.item() < 0.6\n",
+    "assert 0.6 < auroc < 0.9\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "AUROC jest podobne, a precision i recall spadły - wypadamy wręcz gorzej od regresji liniowej! Skoro dodaliśmy więcej warstw, to może pojemność modelu jest teraz za duża i trzeba by go zregularyzować?\n",
+    "\n",
+    "Sieci neuronowe bardzo łatwo przeuczają, bo są bardzo elastycznymi i pojemnymi modelami. Dlatego mają wiele różnych rodzajów regularyzacji, których używa się razem. Co ciekawe, udowodniono eksperymentalnie, że zbyt duże sieci z mocną regularyzacją działają lepiej niż mniejsze sieci, odpowiedniego rozmiaru, za to ze słabszą regularyzacją.\n",
+    "\n",
+    "Pierwszy rodzaj regularyzacji to znana nam już **regularyzacja L2**, czyli penalizacja zbyt dużych wag. W kontekście sieci neuronowych nazywa się też ją czasem *weight decay*. W PyTorchu dodaje się ją jako argument do optymalizatora.\n",
+    "\n",
+    "Regularyzacja specyficzna dla sieci neuronowych to **dropout**. Polega on na losowym wyłączaniu zadanego procenta neuronów podczas treningu. Pomimo prostoty okazała się niesamowicie skuteczna, szczególnie w treningu bardzo głębokich sieci. Co ważne, jest to mechanizm używany tylko podczas treningu - w trakcie predykcji za pomocą sieci wyłącza się ten mechanizm i dokonuje normalnie predykcji całą siecią. Podejście to można potraktować jak ensemble learning, podobny do lasów losowych - wyłączając losowe części sieci, w każdej iteracji trenujemy nieco inną sieć, co odpowiada uśrednianiu predykcji różnych algorytmów. Typowo stosuje się dość mocny dropout, rzędu 25-50%. W PyTorchu implementuje go warstwa `nn.Dropout`, aplikowana zazwyczaj po funkcji aktywacji.\n",
+    "\n",
+    "Ostatni, a być może najważniejszy rodzaj regularyzacji to **wczesny stop (early stopping)**. W każdym kroku mocniej dostosowujemy terenową sieć do zbioru treningowego, a więc zbyt długi trening będzie skutkował przeuczeniem. W metodzie wczesnego stopu używamy wydzielonego zbioru walidacyjnego (pojedynczego, metoda holdout), sprawdzając co określoną liczbę epok wynik na tym zbiorze. Jeżeli nie uzyskamy wyniku lepszego od najlepszego dotychczas uzyskanego przez określoną liczbę epok, to przerywamy trening. Okres, przez który czekamy na uzyskanie lepszego wyniku, to cierpliwość (*patience*). Im mniejsze, tym mocniejszy jest ten rodzaj regularyzacji, ale trzeba z tym uważać, bo łatwo jest przesadzić i zbyt szybko przerywać trening. Niektóre implementacje uwzględniają tzw. *grace period*, czyli gwarantowaną minimalną liczbę epok, przez którą będziemy trenować sieć, niezależnie od wybranej cierpliwości.\n",
+    "\n",
+    "Dodatkowo ryzyko przeuczenia można zmniejszyć, używając mniejszej stałej uczącej."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 5 (1.5 punktu)\n",
+    "\n",
+    "Zaimplementuj funkcję `evaluate_model()`, obliczającą metryki na zbiorze testowym:\n",
+    "- wartość funkcji kosztu (loss)\n",
+    "- AUROC\n",
+    "- optymalny próg\n",
+    "- F1-score przy optymalnym progu\n",
+    "- precyzję oraz recall dla optymalnego progu\n",
+    "\n",
+    "Jeżeli podana jest wartość argumentu `threshold`, to użyj jej do zamiany prawdopodobieństw na twarde predykcje. W przeciwnym razie użyj funkcji `get_optimal_threshold` i oblicz optymalną wartość progu.\n",
+    "\n",
+    "Pamiętaj o przełączeniu modelu w tryb ewaluacji oraz o wyłączeniu obliczania gradientów."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import precision_score, recall_score, f1_score\n",
+    "from torch import sigmoid\n",
+    "\n",
+    "\n",
+    "def evaluate_model(\n",
+    "    model: nn.Module, \n",
+    "    X: torch.Tensor, \n",
+    "    y: torch.Tensor, \n",
+    "    loss_fn: nn.Module,\n",
+    "    threshold: float | None = None\n",
+    ") -> dict[str, float]:\n",
+    "    # implement me!\n",
+    "    # your_code\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "eval_result = evaluate_model(model, X_train, y_train, loss_fn)\n",
+    "\n",
+    "assert 0.5 < eval_result[\"loss\"] < 0.6\n",
+    "assert 0.6 < eval_result[\"AUROC\"] < 0.9\n",
+    "assert 0.3 < eval_result[\"precision\"] < 0.6\n",
+    "assert 0.6 < eval_result[\"recall\"] < 0.9\n",
+    "assert 0.4 < eval_result[\"F1-score\"] < 0.7\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 6 (0.5 punktu)\n",
+    "\n",
+    "Zaimplementuj 3-warstwową sieć MLP z dropout (50%). Rozmiary warstw ukrytych mają wynosić 256 i 128."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "class RegularizedMLP(nn.Module):\n",
+    "    def __init__(self, input_size: int, dropout_p: float = 0.5):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # implement me!\n",
+    "        # your_code\n",
+    "    \n",
+    "    def forward(self, x):\n",
+    "        # implement me!\n",
+    "        # your_code\n",
+    "\n",
+    "    def predict_proba(self, x):\n",
+    "        return sigmoid(self(x))\n",
+    "    \n",
+    "    def predict(self, x, threshold: float = 0.5):\n",
+    "        y_pred_score = self.predict_proba(x)\n",
+    "        return (y_pred_score > threshold).to(torch.int32)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "verification_input_size = 143\n",
+    "verification_dropout_p = 0.125\n",
+    "verification_model = RegularizedMLP(\n",
+    "    input_size=verification_input_size,\n",
+    "    dropout_p=verification_dropout_p,\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == verification_input_size and module.out_features == 256\n",
+    "    for module in verification_model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == 256 and module.out_features == 128\n",
+    "    for module in verification_model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == 128 and module.out_features == 1\n",
+    "    for module in verification_model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(isinstance(module, nn.Dropout) and module.p == verification_dropout_p for module in verification_model.modules())\n",
+    "assert any(isinstance(module, nn.ReLU) for module in verification_model.modules())\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rEk9azaULAsz"
+   },
+   "source": [
+    "Opisaliśmy wcześniej podstawowy optymalizator w sieciach neuronowych - spadek wzdłuż gradientu. Jednak wymaga on użycia całego zbioru danych, aby obliczyć gradient, co jest często niewykonalne przez rozmiar zbioru. Dlatego wymyślono **stochastyczny spadek wzdłuż gradientu (stochastic gradient descent, SGD)**, w którym używamy 1 przykładu naraz, liczymy gradient tylko po nim i aktualizujemy parametry. Jest to oczywiście dość grube przybliżenie gradientu, ale pozwala robić szybko dużo małych kroków. Kompromisem, którego używa się w praktyce, jest **minibatch gradient descent**, czyli używanie batchy np. 32, 64 czy 128 przykładów.\n",
+    "\n",
+    "Rzadko wspominanym, a ważnym faktem jest także to, że stochastyczność metody optymalizacji jest sama w sobie też [metodą regularyzacji](https://arxiv.org/abs/2101.12176), a więc `batch_size` to także hiperparametr.\n",
+    "\n",
+    "Obecnie najpopularniejszą odmianą SGD jest [Adam](https://arxiv.org/abs/1412.6980), gdyż uczy on szybko sieć oraz daje bardzo dobre wyniki nawet przy niekoniecznie idealnie dobranych hiperparametrach. W PyTorchu najlepiej korzystać z jego implementacji `AdamW`, która jest nieco lepsza niż implementacja `Adam`. Jest to zasadniczo zawsze wybór domyślny przy treningu współczesnych sieci neuronowych.\n",
+    "\n",
+    "Na razie użyjemy jednak minibatch SGD."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Poniżej znajduje się implementacja prostej klasy dziedziczącej po `Dataset` - tak w PyTorchu implementuje się własne zbiory danych. Użycie takich klas umożliwia użycie klas ładujących dane (`DataLoader`), które z kolei pozwalają łatwo ładować batche danych. Trzeba w takiej klasie zaimplementować metody:\n",
+    "- `__len__` - zwraca ilość punktów w zbiorze\n",
+    "- `__getitem__` - zwraca przykład ze zbioru pod danym indeksem oraz jego klasę\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import Dataset\n",
+    "\n",
+    "\n",
+    "class MyDataset(Dataset):\n",
+    "    def __init__(self, data, y):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.data = data\n",
+    "        self.y = y\n",
+    "    \n",
+    "    def __len__(self):\n",
+    "        return self.data.shape[0]\n",
+    "    \n",
+    "    def __getitem__(self, idx):\n",
+    "        return self.data[idx], self.y[idx]\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 7 (1.5 punktu)\n",
+    "\n",
+    "Zaimplementuj pętlę treningowo-walidacyjną dla sieci neuronowej. Wykorzystaj podane wartości hiperparametrów do treningu (stała ucząca, prawdopodobieństwo dropoutu, regularyzacja L2, rozmiar batcha, maksymalna liczba epok). Użyj optymalizatora SGD.\n",
+    "\n",
+    "Dodatkowo zaimplementuj regularyzację przez early stopping. Sprawdzaj co epokę wynik na zbiorze walidacyjnym. Użyj podanej wartości patience, a jako metryki po prostu wartości funkcji kosztu. Może się tutaj przydać zaimplementowana funkcja `evaluate_model()`.\n",
+    "\n",
+    "Pamiętaj o tym, aby przechowywać najlepszy dotychczasowy wynik walidacyjny oraz najlepszy dotychczasowy model. Zapamiętaj też optymalny próg do klasyfikacji dla najlepszego modelu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from copy import deepcopy\n",
+    "\n",
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "\n",
+    "learning_rate = 1e-3\n",
+    "dropout_p = 0.5\n",
+    "l2_reg = 1e-4\n",
+    "batch_size = 128\n",
+    "max_epochs = 300\n",
+    "\n",
+    "early_stopping_patience = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "lines_to_next_cell": 2,
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# 1m\n",
+    "model = RegularizedMLP(\n",
+    "    input_size=X_train.shape[1], \n",
+    "    dropout_p=dropout_p\n",
+    ")\n",
+    "optimizer = torch.optim.SGD(\n",
+    "    model.parameters(), \n",
+    "    lr=learning_rate, \n",
+    "    weight_decay=l2_reg\n",
+    ")\n",
+    "loss_fn = torch.nn.BCEWithLogitsLoss()\n",
+    "\n",
+    "train_dataset = MyDataset(X_train, y_train)\n",
+    "train_dataloader = DataLoader(train_dataset, batch_size=batch_size)\n",
+    "\n",
+    "steps_without_improvement = 0\n",
+    "\n",
+    "best_val_loss = np.inf\n",
+    "best_model = None\n",
+    "best_threshold = None\n",
+    "\n",
+    "for epoch_num in range(max_epochs):\n",
+    "    model.train()\n",
+    "    \n",
+    "    # note that we are using DataLoader to get batches\n",
+    "    for X_batch, y_batch in train_dataloader:\n",
+    "        # model training\n",
+    "        # implement me!\n",
+    "        # your_code\n",
+    "    \n",
+    "    # model evaluation, early stopping\n",
+    "    # implement me!\n",
+    "    # your_code\n",
+    "    \n",
+    "    print(f\"Epoch {epoch_num} train loss: {loss.item():.4f}, eval loss {valid_metrics['loss']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "test_metrics = evaluate_model(best_model, X_test, y_test, loss_fn, best_threshold)\n",
+    "\n",
+    "print(f\"AUROC: {test_metrics['AUROC']:.2%}\")\n",
+    "print(f\"F1: {test_metrics['F1-score']:.2%}\")\n",
+    "print(f\"Precision: {test_metrics['precision']:.2%}\")\n",
+    "print(f\"Recall: {test_metrics['recall']:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert test_metrics[\"AUROC\"] > 0.8\n",
+    "assert test_metrics[\"F1-score\"] > 0.6\n",
+    "assert test_metrics[\"precision\"] > 0.5\n",
+    "assert test_metrics[\"recall\"] > 0.6\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wyniki wyglądają już dużo lepiej.\n",
+    "\n",
+    "Na koniec laboratorium dołożymy do naszego modelu jeszcze 3 powrzechnie używane techniki, które są bardzo proste, a pozwalają często ulepszyć wynik modelu.\n",
+    "\n",
+    "Pierwszą z nich są **warstwy normalizacji (normalization layers)**. Powstały one początkowo z założeniem, że przez przekształcenia przestrzeni dokonywane przez sieć zmienia się rozkład prawdopodobieństw pomiędzy warstwami, czyli tzw. *internal covariate shift*. Później okazało się, że zastosowanie takiej normalizacji wygładza powierzchnię funkcji kosztu, co ułatwia i przyspiesza optymalizację. Najpowszechniej używaną normalizacją jest **batch normalization (batch norm)**.\n",
+    "\n",
+    "Drugim ulepszeniem jest dodanie **wag klas (class weights)**. Mamy do czynienia z problemem klasyfikacji niezbalansowanej, więc klasa mniejszościowa, ważniejsza dla nas, powinna dostać większą wagę. Implementuje się to trywialnie prosto - po prostu mnożymy wartość funkcji kosztu dla danego przykładu przez wagę dla prawdziwej klasy tego przykładu. Praktycznie każdy klasyfikator operujący na jakiejś ważonej funkcji może działać w ten sposób, nie tylko sieci neuronowe.\n",
+    "\n",
+    "Ostatnim ulepszeniem jest zamiana SGD na optymalizator Adam, a konkretnie na optymalizator `AdamW`. Jest to przykład **optymalizatora adaptacyjnego (adaptive optimizer)**, który potrafi zaadaptować stałą uczącą dla każdego parametru z osobna w trakcie treningu. Wykorzystuje do tego gradienty - w uproszczeniu, im większa wariancja gradientu, tym mniejsze kroki w tym kierunku robimy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "### Zadanie 8 (0.5 punktu)\n",
+    "\n",
+    "Zaimplementuj model `NormalizingMLP`, o takiej samej strukturze jak `RegularizedMLP`, ale dodatkowo z warstwami `BatchNorm1d` pomiędzy warstwami `Linear` oraz `ReLU`.\n",
+    "\n",
+    "Za pomocą funkcji `compute_class_weight()` oblicz wagi dla poszczególnych klas. Użyj opcji `\"balanced\"`. Przekaż do funkcji kosztu wagę klasy pozytywnej (pamiętaj, aby zamienić ją na tensor).\n",
+    "\n",
+    "Zamień używany optymalizator na `AdamW`.\n",
+    "\n",
+    "Na koniec skopiuj resztę kodu do treningu z poprzedniego zadania, wytrenuj sieć i oblicz wyniki na zbiorze testowym."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "class NormalizingMLP(nn.Module):\n",
+    "    def __init__(self, input_size: int, dropout_p: float = 0.5):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # implement me!\n",
+    "        # your_code\n",
+    "    \n",
+    "    def forward(self, x):\n",
+    "        return self.mlp(x)\n",
+    "\n",
+    "    def predict_proba(self, x):\n",
+    "        return sigmoid(self(x))\n",
+    "    \n",
+    "    def predict(self, x, threshold: float = 0.5):\n",
+    "        y_pred_score = self.predict_proba(x)\n",
+    "        return (y_pred_score > threshold).to(torch.int32)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# define all the hyperparameters\n",
+    "# your_code\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "lines_to_next_cell": 2,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# training loop\n",
+    "# your_code\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "test_metrics = evaluate_model(best_model, X_test, y_test, loss_fn, best_threshold)\n",
+    "\n",
+    "print(f\"AUROC: {test_metrics['AUROC']:.2%}\")\n",
+    "print(f\"F1: {test_metrics['F1-score']:.2%}\")\n",
+    "print(f\"Precision: {test_metrics['precision']:.2%}\")\n",
+    "print(f\"Recall: {test_metrics['recall']:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "verification_input_size = 143\n",
+    "verification_dropout_p = 0.125\n",
+    "verification_model = NormalizingMLP(\n",
+    "    input_size=verification_input_size,\n",
+    "    dropout_p=verification_dropout_p,\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == verification_input_size and module.out_features == 256\n",
+    "    for module in verification_model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == 256 and module.out_features == 128\n",
+    "    for module in verification_model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(\n",
+    "    isinstance(module, nn.Linear) and module.in_features == 128 and module.out_features == 1\n",
+    "    for module in verification_model.modules()\n",
+    ")\n",
+    "\n",
+    "assert any(isinstance(module, nn.Dropout) and module.p == verification_dropout_p for module in verification_model.modules())\n",
+    "assert any(isinstance(module, nn.ReLU) for module in verification_model.modules())\n",
+    "\n",
+    "assert any(isinstance(module, nn.BatchNorm1d) for module in verification_model.modules())\n",
+    "\n",
+    "assert test_metrics[\"AUROC\"] > 0.8\n",
+    "assert test_metrics[\"F1-score\"] > 0.6\n",
+    "assert test_metrics[\"precision\"] > 0.5\n",
+    "assert test_metrics[\"recall\"] > 0.6\n",
+    "\n",
+    "print(\"Solution is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "id": "XyoRnHT4GFR9",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Akceleracja sprzętowa (dla zainteresowanych)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Jak wcześniej wspominaliśmy, użycie akceleracji sprzętowej, czyli po prostu GPU do obliczeń, jest bardzo efektywne w przypadku sieci neuronowych. Karty graficzne bardzo efektywnie mnożą macierze, a sieci neuronowe to, jak można było się przekonać, dużo mnożenia macierzy.\n",
+    "\n",
+    "W PyTorchu jest to dosyć łatwe, ale trzeba robić to explicite. Służy do tego metoda `.to()`, która przenosi tensory między CPU i GPU. Poniżej przykład, jak to się robi (oczywiście trzeba mieć skonfigurowane GPU, żeby działało):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time \n",
+    "\n",
+    "\n",
+    "class CudaMLP(nn.Module):\n",
+    "    def __init__(self, input_size: int, dropout_p: float = 0.5):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        self.mlp = nn.Sequential(\n",
+    "            nn.Linear(input_size, 512),\n",
+    "            nn.BatchNorm1d(512),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Dropout(dropout_p),\n",
+    "            nn.Linear(512, 256),\n",
+    "            nn.BatchNorm1d(256),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Dropout(dropout_p),\n",
+    "            nn.Linear(256, 256),\n",
+    "            nn.BatchNorm1d(256),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Dropout(dropout_p),\n",
+    "            nn.Linear(256, 128),\n",
+    "            nn.BatchNorm1d(128),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Dropout(dropout_p),\n",
+    "            nn.Linear(128, 1),\n",
+    "        )\n",
+    "    \n",
+    "    def forward(self, x):\n",
+    "        return self.mlp(x)\n",
+    "\n",
+    "    def predict_proba(self, x):\n",
+    "        return sigmoid(self(x))\n",
+    "    \n",
+    "    def predict(self, x, threshold: float = 0.5):\n",
+    "        y_pred_score = self.predict_proba(x)\n",
+    "        return (y_pred_score > threshold).to(torch.int32)\n",
+    "\n",
+    "\n",
+    "model = CudaMLP(X_train.shape[1]).to('cuda')\n",
+    "\n",
+    "optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)\n",
+    "\n",
+    "# note that we are using loss function with sigmoid built in\n",
+    "loss_fn = torch.nn.BCEWithLogitsLoss(pos_weight=torch.from_numpy(weights)[1].to('cuda'))\n",
+    "\n",
+    "step_counter = 0\n",
+    "time_from_eval = time.time()\n",
+    "for epoch_id in range(30):\n",
+    "    for batch_x, batch_y in train_dataloader:\n",
+    "        batch_x = batch_x.to('cuda')\n",
+    "        batch_y = batch_y.to('cuda')\n",
+    "        \n",
+    "        loss = loss_fn(model(batch_x), batch_y)\n",
+    "        loss.backward()\n",
+    "\n",
+    "        optimizer.step()\n",
+    "        optimizer.zero_grad()\n",
+    "        \n",
+    "        if step_counter % evaluation_steps == 0:\n",
+    "            print(f\"Epoch {epoch_id} train loss: {loss.item():.4f}, time: {time.time() - time_from_eval}\")\n",
+    "            time_from_eval = time.time()\n",
+    "\n",
+    "        step_counter += 1\n",
+    "\n",
+    "test_res = evaluate_model(model.to('cpu'), X_test, y_test, loss_fn.to('cpu'), threshold=0.5)\n",
+    "\n",
+    "print(f\"AUROC: {test_res['AUROC']:.2%}\")\n",
+    "print(f\"F1: {test_res['F1-score']:.2%}\")\n",
+    "print(test_res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Co prawda ten model nie będzie tak dobry jak ten z laboratorium, ale zwróć uwagę, o ile jest większy, a przy tym szybszy.\n",
+    "\n",
+    "Dla zainteresowanych polecamy [tę serie artykułów](https://medium.com/@adi.fu7/ai-accelerators-part-i-intro-822c2cdb4ca4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "## Zadanie dla chętnych"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "source": [
+    "Jak widzieliśmy, sieci neuronowe mają bardzo dużo hiperparametrów. Przeszukiwanie ich grid search'em jest więc niewykonalne, a chociaż random search by działał, to potrzebowałby wielu iteracji, co też jest kosztowne obliczeniowo.\n",
+    "\n",
+    "Zaimplementuj inteligentne przeszukiwanie przestrzeni hiperparametrów za pomocą biblioteki [Optuna](https://optuna.org/). Implementuje ona między innymi algorytm Tree Parzen Estimator (TPE), należący do grupy algorytmów typu Bayesian search. Typowo osiągają one bardzo dobre wyniki, a właściwie zawsze lepsze od przeszukiwania losowego. Do tego wystarcza im często niewielka liczba kroków.\n",
+    "\n",
+    "Zaimplementuj 3-warstwową sieć MLP, gdzie pierwsza warstwa ma rozmiar ukryty N, a druga N // 2. Ucz ją optymalizatorem Adam przez maksymalnie 300 epok z cierpliwością 10.\n",
+    "\n",
+    "Przeszukaj wybrane zakresy dla hiperparametrów:\n",
+    "- rozmiar warstw ukrytych (N)\n",
+    "- stała ucząca\n",
+    "- batch size\n",
+    "- siła regularyzacji L2\n",
+    "- prawdopodobieństwo dropoutu\n",
+    "\n",
+    "Wykorzystaj przynajmniej 30 iteracji. Następnie przełącz algorytm na losowy (Optuna także jego implementuje), wykonaj 30 iteracji i porównaj jakość wyników.\n",
+    "\n",
+    "Przydatne materiały:\n",
+    "- [Optuna code examples - PyTorch](https://optuna.org/#code_examples)\n",
+    "- [Auto-Tuning Hyperparameters with Optuna and PyTorch](https://www.youtube.com/watch?v=P6NwZVl8ttc)\n",
+    "- [Hyperparameter Tuning of Neural Networks with Optuna and PyTorch](https://towardsdatascience.com/hyperparameter-tuning-of-neural-networks-with-optuna-and-pytorch-22e179efc837)\n",
+    "- [Using Optuna to Optimize PyTorch Hyperparameters](https://medium.com/pytorch/using-optuna-to-optimize-pytorch-hyperparameters-990607385e36)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex"
+    ]
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "provenance": []
+  },
+  "jupytext": {
+   "formats": "ipynb,py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "a5d7af91182035c53be6efb3f9b18ffc3e259c9c524705249407647c970de949"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }
-


### PR DESCRIPTION
[PIP 585](https://peps.python.org/pep-0585/): Starting from Python 3.9, we don't have to use `Dict` or `Tuple` from `typing`; instead, we have `dict` and `tuple`.

[PIP 604](https://peps.python.org/pep-0604/): Starting from Python 3.10, we don't have to use `Optional`; instead, we have the pipe (`|`) operator.